### PR TITLE
[KAR-39] Add live pull sync adapters for Filevine and PracticePanther

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,12 @@ MYCASE_CLIENT_ID=
 MYCASE_CLIENT_SECRET=
 MYCASE_AUTH_URL=https://auth.mycase.com/oauth/authorize
 MYCASE_TOKEN_URL=https://auth.mycase.com/oauth/token
+# integration sync connector config (live pull optional; defaults to scaffold mode)
+INTEGRATION_SYNC_ENABLE_LIVE=false
+CLIO_API_BASE_URL=https://app.clio.com/api/v4
+MYCASE_API_BASE_URL=https://api.mycase.com/v1
+FILEVINE_API_BASE_URL=https://api.filevineapp.com
+PRACTICEPANTHER_API_BASE_URL=https://app.practicepanther.com/api/v2
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 WEB_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ Included suites cover:
 - `POST /integrations/webhook-subscriptions`
   - registers webhook subscription and persists provider external subscription id
 
+Live provider pull sync mode (optional, defaults to scaffold mode):
+
+- set `INTEGRATION_SYNC_ENABLE_LIVE=true`
+- configure provider API bases as needed:
+  - `FILEVINE_API_BASE_URL`
+  - `PRACTICEPANTHER_API_BASE_URL`
+  - `CLIO_API_BASE_URL`
+  - `MYCASE_API_BASE_URL`
+
 ## Phase-2 Planned End-Goal Features
 
 - Document retention policies (including legal hold and disposition controls)

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -32,5 +32,11 @@ MYCASE_CLIENT_ID=
 MYCASE_CLIENT_SECRET=
 MYCASE_AUTH_URL=https://auth.mycase.com/oauth/authorize
 MYCASE_TOKEN_URL=https://auth.mycase.com/oauth/token
+# integration sync connector config (live pull optional; defaults to scaffold mode)
+INTEGRATION_SYNC_ENABLE_LIVE=false
+CLIO_API_BASE_URL=https://app.clio.com/api/v4
+MYCASE_API_BASE_URL=https://api.mycase.com/v1
+FILEVINE_API_BASE_URL=https://api.filevineapp.com
+PRACTICEPANTHER_API_BASE_URL=https://app.practicepanther.com/api/v2
 STRIPE_SECRET_KEY=
 WEB_BASE_URL=http://localhost:3000

--- a/apps/api/src/integrations/connectors/filevine.connector.ts
+++ b/apps/api/src/integrations/connectors/filevine.connector.ts
@@ -1,5 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { ConnectorSyncParams, ConnectorSyncResult, ConnectorWebhookParams, IncrementalSyncConnector } from './connector.interface';
+import {
+  isLiveSyncEnabled,
+  parseConnectorConfig,
+  pullEntityRecords,
+  readConfigString,
+  resolveNextCursor,
+} from './sync-pull.util';
 
 @Injectable()
 export class FilevineConnector implements IncrementalSyncConnector {
@@ -7,14 +14,74 @@ export class FilevineConnector implements IncrementalSyncConnector {
   supportsOAuth = false;
 
   async sync(params: ConnectorSyncParams): Promise<ConnectorSyncResult> {
+    if (!isLiveSyncEnabled()) {
+      return {
+        nextCursor: params.cursor ?? new Date().toISOString(),
+        importedCount: 0,
+        warnings: [
+          'Filevine sync is running in scaffold mode. Set INTEGRATION_SYNC_ENABLE_LIVE=true to enable provider pulls.',
+        ],
+      };
+    }
+
+    if (!params.accessToken) {
+      throw new Error('Filevine sync requires an access token when INTEGRATION_SYNC_ENABLE_LIVE=true');
+    }
+
+    const config = parseConnectorConfig(params.config);
+    const baseUrl = readConfigString(config, 'baseUrl') || process.env.FILEVINE_API_BASE_URL || 'https://api.filevineapp.com';
+    const contactsPath = readConfigString(config, 'contactsPath') || '/contacts';
+    const mattersPath = readConfigString(config, 'mattersPath') || '/projects';
+    const cursorParam = readConfigString(config, 'cursorParam') || 'updated_since';
+
+    const [contacts, matters] = await Promise.all([
+      pullEntityRecords({
+        providerLabel: 'Filevine',
+        baseUrl,
+        path: contactsPath,
+        accessToken: params.accessToken,
+        cursor: params.cursor,
+        cursorParam,
+      }),
+      pullEntityRecords({
+        providerLabel: 'Filevine',
+        baseUrl,
+        path: mattersPath,
+        accessToken: params.accessToken,
+        cursor: params.cursor,
+        cursorParam,
+      }),
+    ]);
+
+    const records = [...contacts.records, ...matters.records];
+    const warnings = [
+      ...contacts.warnings,
+      ...matters.warnings,
+      'Filevine sync currently maps contacts and projects only; additional entity pulls remain pending.',
+    ];
+
     return {
-      nextCursor: params.cursor ?? new Date().toISOString(),
-      importedCount: 0,
-      warnings: ['Filevine connector adapter is scaffolded; provider-specific pull mapping not yet enabled.'],
+      nextCursor: resolveNextCursor(records, params.cursor),
+      importedCount: records.length,
+      warnings,
     };
   }
 
   async subscribeWebhooks(params: ConnectorWebhookParams): Promise<{ subscriptionId: string }> {
-    return { subscriptionId: `filevine-${params.connectionId}-${Date.now()}` };
+    if (isLiveSyncEnabled() && !params.accessToken) {
+      throw new Error('Filevine webhook subscription requires an access token when INTEGRATION_SYNC_ENABLE_LIVE=true');
+    }
+
+    return {
+      subscriptionId: `filevine-${params.connectionId}-${this.slug(params.event)}-${Date.now()}`,
+    };
+  }
+
+  private slug(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 32);
   }
 }

--- a/apps/api/src/integrations/connectors/practicepanther.connector.ts
+++ b/apps/api/src/integrations/connectors/practicepanther.connector.ts
@@ -1,5 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { ConnectorSyncParams, ConnectorSyncResult, ConnectorWebhookParams, IncrementalSyncConnector } from './connector.interface';
+import {
+  isLiveSyncEnabled,
+  parseConnectorConfig,
+  pullEntityRecords,
+  readConfigString,
+  resolveNextCursor,
+} from './sync-pull.util';
 
 @Injectable()
 export class PracticePantherConnector implements IncrementalSyncConnector {
@@ -7,14 +14,75 @@ export class PracticePantherConnector implements IncrementalSyncConnector {
   supportsOAuth = false;
 
   async sync(params: ConnectorSyncParams): Promise<ConnectorSyncResult> {
+    if (!isLiveSyncEnabled()) {
+      return {
+        nextCursor: params.cursor ?? new Date().toISOString(),
+        importedCount: 0,
+        warnings: [
+          'PracticePanther sync is running in scaffold mode. Set INTEGRATION_SYNC_ENABLE_LIVE=true to enable provider pulls.',
+        ],
+      };
+    }
+
+    if (!params.accessToken) {
+      throw new Error('PracticePanther sync requires an access token when INTEGRATION_SYNC_ENABLE_LIVE=true');
+    }
+
+    const config = parseConnectorConfig(params.config);
+    const baseUrl =
+      readConfigString(config, 'baseUrl') || process.env.PRACTICEPANTHER_API_BASE_URL || 'https://app.practicepanther.com/api/v2';
+    const contactsPath = readConfigString(config, 'contactsPath') || '/contacts';
+    const mattersPath = readConfigString(config, 'mattersPath') || '/matters';
+    const cursorParam = readConfigString(config, 'cursorParam') || 'updated_since';
+
+    const [contacts, matters] = await Promise.all([
+      pullEntityRecords({
+        providerLabel: 'PracticePanther',
+        baseUrl,
+        path: contactsPath,
+        accessToken: params.accessToken,
+        cursor: params.cursor,
+        cursorParam,
+      }),
+      pullEntityRecords({
+        providerLabel: 'PracticePanther',
+        baseUrl,
+        path: mattersPath,
+        accessToken: params.accessToken,
+        cursor: params.cursor,
+        cursorParam,
+      }),
+    ]);
+
+    const records = [...contacts.records, ...matters.records];
+    const warnings = [
+      ...contacts.warnings,
+      ...matters.warnings,
+      'PracticePanther sync currently maps contacts and matters only; additional entity pulls remain pending.',
+    ];
+
     return {
-      nextCursor: params.cursor ?? new Date().toISOString(),
-      importedCount: 0,
-      warnings: ['PracticePanther connector adapter is scaffolded; provider-specific pull mapping not yet enabled.'],
+      nextCursor: resolveNextCursor(records, params.cursor),
+      importedCount: records.length,
+      warnings,
     };
   }
 
   async subscribeWebhooks(params: ConnectorWebhookParams): Promise<{ subscriptionId: string }> {
-    return { subscriptionId: `practicepanther-${params.connectionId}-${Date.now()}` };
+    if (isLiveSyncEnabled() && !params.accessToken) {
+      throw new Error('PracticePanther webhook subscription requires an access token when INTEGRATION_SYNC_ENABLE_LIVE=true');
+    }
+
+    return {
+      subscriptionId: `practicepanther-${params.connectionId}-${this.slug(params.event)}-${Date.now()}`,
+    };
+  }
+
+  private slug(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 32);
   }
 }

--- a/apps/api/src/integrations/connectors/sync-pull.util.ts
+++ b/apps/api/src/integrations/connectors/sync-pull.util.ts
@@ -1,0 +1,197 @@
+type JsonRecord = Record<string, unknown>;
+
+const DEFAULT_CURSOR_PARAM = 'updated_since';
+const DEFAULT_LIMIT = 100;
+const TIMESTAMP_KEYS = [
+  'updated_at',
+  'updatedAt',
+  'modified_at',
+  'modifiedAt',
+  'last_activity_at',
+  'lastActivityAt',
+];
+
+export type PullEntityRecordsInput = {
+  providerLabel: string;
+  baseUrl: string;
+  path: string;
+  accessToken: string;
+  cursor?: string | null;
+  cursorParam?: string;
+  limit?: number;
+  extraQuery?: Record<string, string | number | boolean | null | undefined>;
+};
+
+export type PullEntityRecordsResult = {
+  records: JsonRecord[];
+  warnings: string[];
+  requestUrl: string;
+};
+
+export async function pullEntityRecords(input: PullEntityRecordsInput): Promise<PullEntityRecordsResult> {
+  const path = normalizePath(input.path);
+  const url = new URL(path, ensureTrailingSlash(input.baseUrl));
+  const cursorParam = input.cursorParam || DEFAULT_CURSOR_PARAM;
+  const limit = Number.isFinite(input.limit) && (input.limit || 0) > 0 ? Math.floor(input.limit || 0) : DEFAULT_LIMIT;
+  url.searchParams.set('limit', String(limit));
+  if (input.cursor) {
+    url.searchParams.set(cursorParam, input.cursor);
+  }
+
+  for (const [key, value] of Object.entries(input.extraQuery || {})) {
+    if (value === undefined || value === null) continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${input.accessToken}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        records: [],
+        warnings: [
+          `${input.providerLabel} ${path} returned status ${response.status}. ${clipMessage(body) || 'No response body.'}`,
+        ],
+        requestUrl: url.toString(),
+      };
+    }
+
+    const payload = (await response.json()) as unknown;
+    const records = extractRecords(payload);
+    if (records.length === 0) {
+      return {
+        records,
+        warnings: [`${input.providerLabel} ${path} returned no parseable records in the response payload.`],
+        requestUrl: url.toString(),
+      };
+    }
+
+    return {
+      records,
+      warnings: [],
+      requestUrl: url.toString(),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      records: [],
+      warnings: [`${input.providerLabel} ${path} request failed: ${clipMessage(message)}`],
+      requestUrl: url.toString(),
+    };
+  }
+}
+
+export function resolveNextCursor(records: JsonRecord[], fallback?: string | null): string {
+  let maxTimestamp = Number.NaN;
+
+  for (const record of records) {
+    for (const key of TIMESTAMP_KEYS) {
+      const rawValue = record[key];
+      if (rawValue === null || rawValue === undefined) continue;
+      const parsed = Date.parse(String(rawValue));
+      if (Number.isFinite(parsed) && (!Number.isFinite(maxTimestamp) || parsed > maxTimestamp)) {
+        maxTimestamp = parsed;
+      }
+    }
+  }
+
+  if (Number.isFinite(maxTimestamp)) {
+    return new Date(maxTimestamp).toISOString();
+  }
+
+  if (fallback && fallback.trim().length > 0) {
+    return fallback;
+  }
+
+  return new Date().toISOString();
+}
+
+export function parseConnectorConfig(config: unknown): Record<string, unknown> {
+  if (config && typeof config === 'object' && !Array.isArray(config)) {
+    return config as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function readConfigString(config: Record<string, unknown>, key: string): string | null {
+  const value = config[key];
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function isLiveSyncEnabled(): boolean {
+  return envFlagEnabled('INTEGRATION_SYNC_ENABLE_LIVE');
+}
+
+export function envFlagEnabled(name: string): boolean {
+  const value = String(process.env[name] || '').trim().toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
+function normalizePath(pathValue: string): string {
+  const trimmed = String(pathValue || '').trim();
+  if (!trimmed) return '/';
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function ensureTrailingSlash(baseUrl: string): string {
+  const trimmed = String(baseUrl || '').trim();
+  if (!trimmed) return '/';
+  return trimmed.endsWith('/') ? trimmed : `${trimmed}/`;
+}
+
+function extractRecords(payload: unknown): JsonRecord[] {
+  const fromValue = fromCandidateValue(payload);
+  if (fromValue.length > 0) return fromValue;
+
+  const root = asRecord(payload);
+  if (!root) return [];
+
+  const candidateKeys = ['data', 'results', 'items', 'records'];
+  for (const key of candidateKeys) {
+    const nestedRecords = fromCandidateValue(root[key]);
+    if (nestedRecords.length > 0) return nestedRecords;
+  }
+
+  return [];
+}
+
+function fromCandidateValue(value: unknown): JsonRecord[] {
+  if (Array.isArray(value)) {
+    return value.filter((entry): entry is JsonRecord => Boolean(asRecord(entry)));
+  }
+
+  const record = asRecord(value);
+  if (!record) return [];
+
+  const candidateKeys = ['data', 'results', 'items', 'records'];
+  for (const key of candidateKeys) {
+    const nestedValue = record[key];
+    if (Array.isArray(nestedValue)) {
+      return nestedValue.filter((entry): entry is JsonRecord => Boolean(asRecord(entry)));
+    }
+  }
+
+  return [];
+}
+
+function asRecord(value: unknown): JsonRecord | null {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as JsonRecord;
+  }
+  return null;
+}
+
+function clipMessage(message: string): string {
+  const normalized = String(message || '').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 240) return normalized;
+  return `${normalized.slice(0, 237)}...`;
+}

--- a/apps/api/test/connector-provider-sync.spec.ts
+++ b/apps/api/test/connector-provider-sync.spec.ts
@@ -1,0 +1,126 @@
+import { FilevineConnector } from '../src/integrations/connectors/filevine.connector';
+import { PracticePantherConnector } from '../src/integrations/connectors/practicepanther.connector';
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+describe('Provider connector sync adapters', () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.INTEGRATION_SYNC_ENABLE_LIVE;
+    delete process.env.FILEVINE_API_BASE_URL;
+    delete process.env.PRACTICEPANTHER_API_BASE_URL;
+    (global as { fetch?: unknown }).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    (global as { fetch?: unknown }).fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('keeps Filevine in scaffold mode when live sync is disabled', async () => {
+    const connector = new FilevineConnector();
+
+    const result = await connector.sync({
+      connectionId: 'conn-filevine',
+      cursor: 'cursor-prior',
+      accessToken: null,
+    });
+
+    expect(result.importedCount).toBe(0);
+    expect(result.nextCursor).toBe('cursor-prior');
+    expect(result.warnings?.[0]).toContain('INTEGRATION_SYNC_ENABLE_LIVE=true');
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(0);
+  });
+
+  it('pulls Filevine contacts and projects in live mode with incremental cursor', async () => {
+    process.env.INTEGRATION_SYNC_ENABLE_LIVE = 'true';
+    process.env.FILEVINE_API_BASE_URL = 'https://filevine.example/api';
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          results: [{ id: 'contact-1', updated_at: '2026-02-01T12:00:00.000Z' }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          data: [{ id: 'project-1', updatedAt: '2026-02-03T08:30:00.000Z' }],
+        }),
+      );
+
+    const connector = new FilevineConnector();
+    const result = await connector.sync({
+      connectionId: 'conn-filevine',
+      cursor: '2026-01-15T00:00:00.000Z',
+      accessToken: 'filevine-token',
+    });
+
+    expect(result.importedCount).toBe(2);
+    expect(result.nextCursor).toBe('2026-02-03T08:30:00.000Z');
+    expect(result.warnings).toContain(
+      'Filevine sync currently maps contacts and projects only; additional entity pulls remain pending.',
+    );
+
+    const firstCall = (global.fetch as jest.Mock).mock.calls[0];
+    expect(String(firstCall[0])).toContain('/contacts');
+    const firstUrl = new URL(String(firstCall[0]));
+    expect(firstUrl.searchParams.get('updated_since')).toBe('2026-01-15T00:00:00.000Z');
+    expect(firstCall[1]).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer filevine-token',
+        }),
+      }),
+    );
+  });
+
+  it('requires access token for PracticePanther live sync mode', async () => {
+    process.env.INTEGRATION_SYNC_ENABLE_LIVE = 'true';
+    const connector = new PracticePantherConnector();
+
+    await expect(
+      connector.sync({
+        connectionId: 'conn-practicepanther',
+      }),
+    ).rejects.toThrow('PracticePanther sync requires an access token');
+  });
+
+  it('returns partial PracticePanther results with warnings when one entity pull fails', async () => {
+    process.env.INTEGRATION_SYNC_ENABLE_LIVE = 'true';
+    process.env.PRACTICEPANTHER_API_BASE_URL = 'https://practicepanther.example/api';
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(mockResponse(500, 'upstream error'))
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          items: [{ id: 'matter-1', modified_at: '2026-02-05T10:00:00.000Z' }],
+        }),
+      );
+
+    const connector = new PracticePantherConnector();
+    const result = await connector.sync({
+      connectionId: 'conn-practicepanther',
+      accessToken: 'pp-token',
+      cursor: '2026-01-10T00:00:00.000Z',
+    });
+
+    expect(result.importedCount).toBe(1);
+    expect(result.nextCursor).toBe('2026-02-05T10:00:00.000Z');
+    expect(result.warnings?.some((warning) => warning.includes('status 500'))).toBe(true);
+    expect(result.warnings).toContain(
+      'PracticePanther sync currently maps contacts and matters only; additional entity pulls remain pending.',
+    );
+  });
+});


### PR DESCRIPTION
## Linear Issue
- Key: KAR-39
- URL: https://linear.app/<workspace>/issue/KAR-39/implement-filevine-and-practicepanther-connector-production-adapters

## Requirement ID
- REQ-INT-003

## Summary
- Add live pull sync adapters for Filevine and PracticePanther behind `INTEGRATION_SYNC_ENABLE_LIVE`.
- Keep safe scaffold mode as default when live sync is disabled.
- Add reusable pull utility for normalized response extraction, cursor handling, and warning generation.
- Add connector test coverage for scaffold mode, live mode pull behavior, access-token requirements, and partial failure warnings.
- Document new integration sync env toggles and provider base URL config.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- connector-provider-sync.spec.ts`
  - `pnpm test`
  - `pnpm build`
- Output summary:
  - All tests passed (API suites + web suites).
  - Monorepo build passed.

## Notes
- This slice covers authenticated provider pull scaffolding for Filevine/PracticePanther and preserves idempotent sync/webhook pipeline behavior.
- Additional provider-specific entity mapping remains tracked in parity backlog.
