### PR TITLE
[KAR-38] Add live MyCase incremental sync and webhook registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,7 @@ CLIO_API_BASE_URL=https://app.clio.com/api/v4
 MYCASE_API_BASE_URL=https://api.mycase.com/v1
 FILEVINE_API_BASE_URL=https://api.filevineapp.com
 PRACTICEPANTHER_API_BASE_URL=https://app.practicepanther.com/api/v2
+MYCASE_WEBHOOK_REGISTER_URL=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 WEB_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Live provider pull sync mode (optional, defaults to scaffold mode):
   - `PRACTICEPANTHER_API_BASE_URL`
   - `CLIO_API_BASE_URL`
   - `MYCASE_API_BASE_URL`
+- optional webhook registration endpoints:
+  - `MYCASE_WEBHOOK_REGISTER_URL`
+  - `CLIO_WEBHOOK_REGISTER_URL`
 
 ## Phase-2 Planned End-Goal Features
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -38,5 +38,6 @@ CLIO_API_BASE_URL=https://app.clio.com/api/v4
 MYCASE_API_BASE_URL=https://api.mycase.com/v1
 FILEVINE_API_BASE_URL=https://api.filevineapp.com
 PRACTICEPANTHER_API_BASE_URL=https://app.practicepanther.com/api/v2
+MYCASE_WEBHOOK_REGISTER_URL=
 STRIPE_SECRET_KEY=
 WEB_BASE_URL=http://localhost:3000

--- a/apps/api/src/integrations/connectors/mycase.connector.ts
+++ b/apps/api/src/integrations/connectors/mycase.connector.ts
@@ -9,6 +9,8 @@ import {
   IncrementalSyncConnector,
 } from './connector.interface';
 
+type JsonRecord = Record<string, unknown>;
+
 @Injectable()
 export class MyCaseConnector implements IncrementalSyncConnector {
   provider: 'MYCASE' = 'MYCASE';
@@ -94,20 +96,100 @@ export class MyCaseConnector implements IncrementalSyncConnector {
   }
 
   async sync(params: ConnectorSyncParams): Promise<ConnectorSyncResult> {
-    if (!params.accessToken) {
-      throw new Error('MyCase sync requires an access token');
+    if (!this.isLiveSyncEnabled()) {
+      return {
+        nextCursor: params.cursor ?? new Date().toISOString(),
+        importedCount: 0,
+        warnings: [
+          'MyCase sync is running in scaffold mode. Set INTEGRATION_SYNC_ENABLE_LIVE=true to enable provider pulls.',
+        ],
+      };
     }
 
+    if (!params.accessToken) {
+      throw new Error('MyCase sync requires an access token when INTEGRATION_SYNC_ENABLE_LIVE=true');
+    }
+
+    const config = this.parseConfig(params.config);
+    const baseUrl = this.readConfigString(config, 'baseUrl') || process.env.MYCASE_API_BASE_URL || 'https://api.mycase.com/v1';
+    const contactsPath = this.readConfigString(config, 'contactsPath') || '/contacts';
+    const mattersPath = this.readConfigString(config, 'mattersPath') || '/matters';
+    const cursorParam = this.readConfigString(config, 'cursorParam') || 'updated_since';
+
+    const [contacts, matters] = await Promise.all([
+      this.pullEntityRecords({
+        providerLabel: 'MyCase',
+        baseUrl,
+        path: contactsPath,
+        accessToken: params.accessToken,
+        cursor: params.cursor,
+        cursorParam,
+      }),
+      this.pullEntityRecords({
+        providerLabel: 'MyCase',
+        baseUrl,
+        path: mattersPath,
+        accessToken: params.accessToken,
+        cursor: params.cursor,
+        cursorParam,
+      }),
+    ]);
+
+    const records = [...contacts.records, ...matters.records];
+    const warnings = [
+      ...contacts.warnings,
+      ...matters.warnings,
+      'MyCase sync currently maps contacts and matters only; additional entity pulls remain pending.',
+    ];
+
     return {
-      nextCursor: new Date().toISOString(),
-      importedCount: 0,
-      warnings: ['MyCase connector is running in bootstrap mode with no entity pulls yet.'],
+      nextCursor: this.resolveNextCursor(records, params.cursor),
+      importedCount: records.length,
+      warnings,
     };
   }
 
   async subscribeWebhooks(params: ConnectorWebhookParams): Promise<{ subscriptionId: string }> {
     if (!params.accessToken) {
       throw new Error('MyCase webhook subscription requires an access token');
+    }
+
+    if (!this.isLiveSyncEnabled()) {
+      return {
+        subscriptionId: `mycase-${params.connectionId}-${this.slug(params.event)}-${Date.now()}`,
+      };
+    }
+
+    const config = this.parseConfig(params.config);
+    const registrationUrl =
+      this.readConfigString(config, 'webhookRegistrationUrl') || process.env.MYCASE_WEBHOOK_REGISTER_URL || '';
+    if (!registrationUrl) {
+      return {
+        subscriptionId: `mycase-${params.connectionId}-${this.slug(params.event)}-${Date.now()}`,
+      };
+    }
+
+    const response = await fetch(registrationUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+        Accept: 'application/json',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        event: params.event,
+        target_url: params.targetUrl,
+        connection_id: params.connectionId,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`MyCase webhook registration failed (${response.status}): ${this.clipMessage(text)}`);
+    }
+    const payload = (await response.json()) as unknown;
+    const externalId = this.extractSubscriptionId(payload);
+    if (externalId) {
+      return { subscriptionId: externalId };
     }
 
     return {
@@ -118,6 +200,183 @@ export class MyCaseConnector implements IncrementalSyncConnector {
   private isLiveOauthEnabled(): boolean {
     const value = String(process.env.INTEGRATION_OAUTH_ENABLE_LIVE || '').trim().toLowerCase();
     return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+  }
+
+  private isLiveSyncEnabled(): boolean {
+    const value = String(process.env.INTEGRATION_SYNC_ENABLE_LIVE || '').trim().toLowerCase();
+    return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+  }
+
+  private async pullEntityRecords(input: {
+    providerLabel: string;
+    baseUrl: string;
+    path: string;
+    accessToken: string;
+    cursor?: string | null;
+    cursorParam: string;
+  }): Promise<{ records: JsonRecord[]; warnings: string[] }> {
+    const path = this.normalizePath(input.path);
+    const url = new URL(path, this.ensureTrailingSlash(input.baseUrl));
+    url.searchParams.set('limit', '100');
+    if (input.cursor) {
+      url.searchParams.set(input.cursorParam, input.cursor);
+    }
+
+    try {
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${input.accessToken}`,
+          Accept: 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        return {
+          records: [],
+          warnings: [
+            `${input.providerLabel} ${path} returned status ${response.status}. ${this.clipMessage(body) || 'No response body.'}`,
+          ],
+        };
+      }
+
+      const payload = (await response.json()) as unknown;
+      const records = this.extractRecords(payload);
+      if (records.length === 0) {
+        return {
+          records: [],
+          warnings: [`${input.providerLabel} ${path} returned no parseable records in the response payload.`],
+        };
+      }
+
+      return { records, warnings: [] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        records: [],
+        warnings: [`${input.providerLabel} ${path} request failed: ${this.clipMessage(message)}`],
+      };
+    }
+  }
+
+  private resolveNextCursor(records: JsonRecord[], fallback?: string | null): string {
+    const timestampKeys = [
+      'updated_at',
+      'updatedAt',
+      'modified_at',
+      'modifiedAt',
+      'last_activity_at',
+      'lastActivityAt',
+    ];
+    let maxTimestamp = Number.NaN;
+
+    for (const record of records) {
+      for (const key of timestampKeys) {
+        const raw = record[key];
+        if (raw === null || raw === undefined) continue;
+        const parsed = Date.parse(String(raw));
+        if (Number.isFinite(parsed) && (!Number.isFinite(maxTimestamp) || parsed > maxTimestamp)) {
+          maxTimestamp = parsed;
+        }
+      }
+    }
+
+    if (Number.isFinite(maxTimestamp)) {
+      return new Date(maxTimestamp).toISOString();
+    }
+    if (fallback && fallback.trim().length > 0) {
+      return fallback;
+    }
+    return new Date().toISOString();
+  }
+
+  private extractRecords(payload: unknown): JsonRecord[] {
+    const direct = this.recordsFromCandidate(payload);
+    if (direct.length > 0) return direct;
+
+    const root = this.asRecord(payload);
+    if (!root) return [];
+    for (const key of ['data', 'results', 'items', 'records']) {
+      const nested = this.recordsFromCandidate(root[key]);
+      if (nested.length > 0) return nested;
+    }
+    return [];
+  }
+
+  private recordsFromCandidate(value: unknown): JsonRecord[] {
+    if (Array.isArray(value)) {
+      return value.filter((entry): entry is JsonRecord => Boolean(this.asRecord(entry)));
+    }
+
+    const record = this.asRecord(value);
+    if (!record) return [];
+
+    for (const key of ['data', 'results', 'items', 'records']) {
+      const nested = record[key];
+      if (Array.isArray(nested)) {
+        return nested.filter((entry): entry is JsonRecord => Boolean(this.asRecord(entry)));
+      }
+    }
+
+    return [];
+  }
+
+  private extractSubscriptionId(payload: unknown): string | null {
+    const root = this.asRecord(payload);
+    if (!root) return null;
+
+    const direct = this.asString(root.id) || this.asString(root.subscription_id) || this.asString(root.subscriptionId);
+    if (direct) return direct;
+
+    const data = this.asRecord(root.data);
+    if (!data) return null;
+    return this.asString(data.id) || this.asString(data.subscription_id) || this.asString(data.subscriptionId);
+  }
+
+  private parseConfig(config: unknown): Record<string, unknown> {
+    if (config && typeof config === 'object' && !Array.isArray(config)) {
+      return config as Record<string, unknown>;
+    }
+    return {};
+  }
+
+  private readConfigString(config: Record<string, unknown>, key: string): string | null {
+    const value = config[key];
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  private ensureTrailingSlash(value: string): string {
+    const normalized = String(value || '').trim();
+    if (!normalized) return '/';
+    return normalized.endsWith('/') ? normalized : `${normalized}/`;
+  }
+
+  private normalizePath(value: string): string {
+    const normalized = String(value || '').trim();
+    if (!normalized) return '/';
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+
+  private asRecord(value: unknown): JsonRecord | null {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      return value as JsonRecord;
+    }
+    return null;
+  }
+
+  private asString(value: unknown): string | null {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  private clipMessage(message: string): string {
+    const normalized = String(message || '').replace(/\s+/g, ' ').trim();
+    if (normalized.length <= 240) return normalized;
+    return `${normalized.slice(0, 237)}...`;
   }
 
   private slug(value: string): string {

--- a/apps/api/test/mycase.connector.spec.ts
+++ b/apps/api/test/mycase.connector.spec.ts
@@ -1,0 +1,142 @@
+import { MyCaseConnector } from '../src/integrations/connectors/mycase.connector';
+
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Response;
+}
+
+describe('MyCaseConnector', () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.INTEGRATION_SYNC_ENABLE_LIVE;
+    delete process.env.MYCASE_API_BASE_URL;
+    delete process.env.MYCASE_WEBHOOK_REGISTER_URL;
+    (global as { fetch?: unknown }).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    (global as { fetch?: unknown }).fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('runs in scaffold mode by default and avoids provider pulls', async () => {
+    const connector = new MyCaseConnector();
+
+    const result = await connector.sync({
+      connectionId: 'conn-mycase',
+      cursor: 'cursor-prior',
+      accessToken: null,
+    });
+
+    expect(result.importedCount).toBe(0);
+    expect(result.nextCursor).toBe('cursor-prior');
+    expect(result.warnings?.[0]).toContain('INTEGRATION_SYNC_ENABLE_LIVE=true');
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(0);
+  });
+
+  it('requires access token when live sync mode is enabled', async () => {
+    process.env.INTEGRATION_SYNC_ENABLE_LIVE = 'true';
+    const connector = new MyCaseConnector();
+
+    await expect(
+      connector.sync({
+        connectionId: 'conn-mycase',
+      }),
+    ).rejects.toThrow('MyCase sync requires an access token');
+  });
+
+  it('pulls contacts and matters from MyCase in live sync mode', async () => {
+    process.env.INTEGRATION_SYNC_ENABLE_LIVE = 'true';
+    process.env.MYCASE_API_BASE_URL = 'https://mycase.example/api';
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          data: [{ id: 'contact-1', updated_at: '2026-02-04T10:00:00.000Z' }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        mockResponse(200, {
+          results: [{ id: 'matter-1', updatedAt: '2026-02-05T12:30:00.000Z' }],
+        }),
+      );
+
+    const connector = new MyCaseConnector();
+    const result = await connector.sync({
+      connectionId: 'conn-mycase',
+      cursor: '2026-01-01T00:00:00.000Z',
+      accessToken: 'mycase-token',
+    });
+
+    expect(result.importedCount).toBe(2);
+    expect(result.nextCursor).toBe('2026-02-05T12:30:00.000Z');
+    expect(result.warnings).toContain(
+      'MyCase sync currently maps contacts and matters only; additional entity pulls remain pending.',
+    );
+
+    const contactCall = (global.fetch as jest.Mock).mock.calls[0];
+    expect(String(contactCall[0])).toContain('/contacts');
+    const contactUrl = new URL(String(contactCall[0]));
+    expect(contactUrl.searchParams.get('updated_since')).toBe('2026-01-01T00:00:00.000Z');
+    expect(contactCall[1]).toEqual(
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mycase-token',
+        }),
+      }),
+    );
+  });
+
+  it('uses generated webhook ids in scaffold mode', async () => {
+    const connector = new MyCaseConnector();
+    const result = await connector.subscribeWebhooks({
+      connectionId: 'conn-mycase',
+      event: 'matter.updated',
+      targetUrl: 'https://firm.example/webhooks/mycase',
+      accessToken: 'mycase-token',
+    });
+
+    expect(result.subscriptionId).toMatch(/^mycase-conn-mycase-matter-updated-/);
+    expect((global.fetch as jest.Mock).mock.calls.length).toBe(0);
+  });
+
+  it('registers webhook against provider endpoint in live mode when configured', async () => {
+    process.env.INTEGRATION_SYNC_ENABLE_LIVE = 'true';
+    process.env.MYCASE_WEBHOOK_REGISTER_URL = 'https://mycase.example/api/webhooks/subscriptions';
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      mockResponse(200, {
+        id: 'mycase-sub-42',
+      }),
+    );
+
+    const connector = new MyCaseConnector();
+    const result = await connector.subscribeWebhooks({
+      connectionId: 'conn-mycase',
+      event: 'matter.updated',
+      targetUrl: 'https://firm.example/webhooks/mycase',
+      accessToken: 'mycase-token',
+    });
+
+    expect(result.subscriptionId).toBe('mycase-sub-42');
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    expect(String(call[0])).toBe('https://mycase.example/api/webhooks/subscriptions');
+    expect(call[1]).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mycase-token',
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Linear Issue
- Key: KAR-38
- URL: https://linear.app/<workspace>/issue/KAR-38/implement-mycase-connector-oauth-incremental-sync-webhook-subscription

## Requirement ID
- REQ-INT-002

## Summary
- Implement live incremental pull sync mode for MyCase connector with contacts/matters pulls.
- Keep scaffold behavior as default unless `INTEGRATION_SYNC_ENABLE_LIVE=true`.
- Add configurable MyCase sync/webhook endpoint environment variables.
- Add optional live outbound webhook registration call using provider endpoint when configured.
- Add connector-level tests for scaffold mode, live-mode token enforcement, pull behavior, and webhook registration.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- mycase.connector.spec.ts`
  - `pnpm --filter api test`
  - `pnpm build`
- Output summary:
  - MyCase connector tests passed.
  - API test suite passed.
  - Monorepo build passed.

## Notes
- Live sync mode remains opt-in and backward-compatible with existing scaffold behavior.
- Additional provider-specific entity mappings remain in the parity backlog.
