### PR TITLE
[KAR-27] Add Stripe webhook reconciliation lifecycle

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -44,4 +44,5 @@ FILEVINE_API_BASE_URL=https://api.filevineapp.com
 PRACTICEPANTHER_API_BASE_URL=https://app.practicepanther.com/api/v2
 MYCASE_WEBHOOK_REGISTER_URL=
 STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
 WEB_BASE_URL=http://localhost:3000

--- a/apps/api/src/billing/billing.module.ts
+++ b/apps/api/src/billing/billing.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { BillingController } from './billing.controller';
 import { BillingService } from './billing.service';
 import { AuditModule } from '../audit/audit.module';
+import { StripeWebhooksController } from './stripe-webhooks.controller';
 
 @Module({
   imports: [AuditModule],
-  controllers: [BillingController],
+  controllers: [BillingController, StripeWebhooksController],
   providers: [BillingService],
 })
 export class BillingModule {}

--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -7,6 +7,7 @@ import { AccessService } from '../access/access.service';
 import { AuthenticatedUser } from '../common/types';
 import { AuditService } from '../audit/audit.service';
 import { S3Service } from '../files/s3.service';
+import { toJsonValue } from '../common/utils/json.util';
 
 @Injectable()
 export class BillingService {
@@ -167,13 +168,22 @@ export class BillingService {
 
     if (!invoice) throw new Error('Invoice not found');
     await this.access.assertMatterAccess(user, invoice.matterId, 'read');
+    if (invoice.balanceDue <= 0) {
+      return { url: null, warning: 'Invoice balance is zero. Checkout link not created.' };
+    }
 
     if (!this.stripe) {
       return { url: null, warning: 'Stripe is not configured (STRIPE_SECRET_KEY missing).' };
     }
 
+    const checkoutMetadata = {
+      invoiceId: invoice.id,
+      organizationId: user.organizationId,
+    };
+
     const session = await this.stripe.checkout.sessions.create({
       mode: 'payment',
+      client_reference_id: invoice.id,
       line_items: [
         {
           quantity: 1,
@@ -187,12 +197,12 @@ export class BillingService {
           },
         },
       ],
+      payment_intent_data: {
+        metadata: checkoutMetadata,
+      },
       success_url: `${process.env.WEB_BASE_URL || 'http://localhost:3000'}/billing/success?invoiceId=${invoice.id}`,
       cancel_url: `${process.env.WEB_BASE_URL || 'http://localhost:3000'}/billing/cancel?invoiceId=${invoice.id}`,
-      metadata: {
-        invoiceId: invoice.id,
-        organizationId: user.organizationId,
-      },
+      metadata: checkoutMetadata,
     });
 
     await this.prisma.invoice.update({
@@ -221,18 +231,34 @@ export class BillingService {
     if (!invoice) throw new Error('Invoice not found');
     await this.access.assertMatterAccess(input.user, invoice.matterId, 'write');
 
+    if (input.stripePaymentIntentId) {
+      const existing = await this.prisma.payment.findFirst({
+        where: {
+          organizationId: input.user.organizationId,
+          invoiceId: invoice.id,
+          stripePaymentIntentId: input.stripePaymentIntentId,
+        },
+      });
+      if (existing) return existing;
+    }
+
+    const amount = Number(Math.min(invoice.balanceDue, Math.max(0, input.amount)).toFixed(2));
+    if (amount <= 0) {
+      throw new Error('Payment amount must be greater than zero and invoice must have remaining balance');
+    }
+
     const payment = await this.prisma.payment.create({
       data: {
         organizationId: input.user.organizationId,
         invoiceId: invoice.id,
-        amount: input.amount,
+        amount,
         method: input.method,
         stripePaymentIntentId: input.stripePaymentIntentId,
         reference: input.reference,
       },
     });
 
-    const balanceDue = Number(Math.max(0, invoice.balanceDue - input.amount).toFixed(2));
+    const balanceDue = Number(Math.max(0, invoice.balanceDue - amount).toFixed(2));
     await this.prisma.invoice.update({
       where: { id: invoice.id },
       data: {
@@ -242,6 +268,82 @@ export class BillingService {
     });
 
     return payment;
+  }
+
+  async handleStripeWebhook(input: { payload: unknown; signature?: string; rawBody?: Buffer }) {
+    const event = this.parseStripeWebhookEvent(input);
+
+    if (event.type === 'checkout.session.completed' || event.type === 'checkout.session.async_payment_succeeded') {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const invoiceId = this.readMetadataValue(session.metadata, 'invoiceId');
+      const organizationId = this.readMetadataValue(session.metadata, 'organizationId');
+
+      if (!invoiceId || !organizationId) {
+        return {
+          received: true,
+          eventId: event.id,
+          type: event.type,
+          status: 'ignored',
+          reason: 'missing_required_metadata',
+        };
+      }
+
+      return {
+        received: true,
+        eventId: event.id,
+        type: event.type,
+        ...(await this.reconcileStripePayment({
+          organizationId,
+          invoiceId,
+          stripeEventId: event.id,
+          stripeCheckoutSessionId: session.id,
+          stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : undefined,
+          amount: typeof session.amount_total === 'number' ? Number((session.amount_total / 100).toFixed(2)) : undefined,
+        })),
+      };
+    }
+
+    if (event.type === 'payment_intent.succeeded') {
+      const paymentIntent = event.data.object as Stripe.PaymentIntent;
+      const invoiceId = this.readMetadataValue(paymentIntent.metadata, 'invoiceId');
+      const organizationId = this.readMetadataValue(paymentIntent.metadata, 'organizationId');
+
+      if (!invoiceId || !organizationId) {
+        return {
+          received: true,
+          eventId: event.id,
+          type: event.type,
+          status: 'ignored',
+          reason: 'missing_required_metadata',
+        };
+      }
+
+      const amountInCents =
+        typeof paymentIntent.amount_received === 'number' && paymentIntent.amount_received > 0
+          ? paymentIntent.amount_received
+          : paymentIntent.amount;
+
+      return {
+        received: true,
+        eventId: event.id,
+        type: event.type,
+        ...(await this.reconcileStripePayment({
+          organizationId,
+          invoiceId,
+          stripeEventId: event.id,
+          stripePaymentIntentId: paymentIntent.id,
+          amount: Number((amountInCents / 100).toFixed(2)),
+        })),
+      };
+    }
+
+    return {
+      received: true,
+      eventId: event.id,
+      type: event.type,
+      status: 'ignored',
+      reason: 'event_type_not_handled',
+    };
   }
 
   async listInvoices(user: AuthenticatedUser, matterId?: string) {
@@ -372,5 +474,109 @@ export class BillingService {
     const bytes = await doc.save();
     const uploaded = await this.s3.upload(Buffer.from(bytes), 'application/pdf', `org/${invoice.organizationId}/invoices`);
     return uploaded.key;
+  }
+
+  private parseStripeWebhookEvent(input: { payload: unknown; signature?: string; rawBody?: Buffer }): Stripe.Event {
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (this.stripe && webhookSecret) {
+      if (!input.signature || !input.rawBody) {
+        throw new Error('Stripe webhook signature verification failed: missing stripe-signature header or raw body');
+      }
+      return this.stripe.webhooks.constructEvent(input.rawBody, input.signature, webhookSecret);
+    }
+
+    const payload = input.payload;
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      throw new Error('Invalid Stripe webhook payload');
+    }
+
+    const event = payload as Partial<Stripe.Event>;
+    if (!event.id || !event.type || !event.data) {
+      throw new Error('Malformed Stripe webhook event payload');
+    }
+    return event as Stripe.Event;
+  }
+
+  private readMetadataValue(metadata: Stripe.Metadata | null | undefined, key: string): string | undefined {
+    const rawValue = metadata?.[key];
+    if (typeof rawValue !== 'string') return undefined;
+    const value = rawValue.trim();
+    return value ? value : undefined;
+  }
+
+  private async reconcileStripePayment(input: {
+    organizationId: string;
+    invoiceId: string;
+    stripeEventId: string;
+    amount?: number;
+    stripePaymentIntentId?: string;
+    stripeCheckoutSessionId?: string;
+  }): Promise<{ status: 'recorded' | 'duplicate' | 'ignored'; paymentId?: string; reason?: string }> {
+    const invoice = await this.prisma.invoice.findFirst({
+      where: {
+        id: input.invoiceId,
+        organizationId: input.organizationId,
+      },
+    });
+    if (!invoice) {
+      return { status: 'ignored', reason: 'invoice_not_found' };
+    }
+
+    if (input.stripePaymentIntentId) {
+      const existing = await this.prisma.payment.findFirst({
+        where: {
+          organizationId: input.organizationId,
+          invoiceId: invoice.id,
+          stripePaymentIntentId: input.stripePaymentIntentId,
+        },
+      });
+      if (existing) return { status: 'duplicate', paymentId: existing.id };
+    }
+
+    const amount = Number(
+      Math.min(invoice.balanceDue, Math.max(0, input.amount ?? invoice.balanceDue)).toFixed(2),
+    );
+    if (amount <= 0) {
+      return { status: 'ignored', reason: 'invoice_balance_zero' };
+    }
+
+    const payment = await this.prisma.payment.create({
+      data: {
+        organizationId: input.organizationId,
+        invoiceId: invoice.id,
+        amount,
+        method: PaymentMethod.STRIPE,
+        stripePaymentIntentId: input.stripePaymentIntentId,
+        reference: `stripe_event:${input.stripeEventId}`,
+        rawSourcePayload: toJsonValue({
+          stripeEventId: input.stripeEventId,
+          stripeCheckoutSessionId: input.stripeCheckoutSessionId,
+        }),
+      },
+    });
+
+    const balanceDue = Number(Math.max(0, invoice.balanceDue - amount).toFixed(2));
+    await this.prisma.invoice.update({
+      where: { id: invoice.id },
+      data: {
+        balanceDue,
+        status: balanceDue === 0 ? InvoiceStatus.PAID : InvoiceStatus.PARTIAL,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.organizationId,
+      action: 'invoice.payment.reconciled',
+      entityType: 'invoice',
+      entityId: invoice.id,
+      metadata: {
+        paymentId: payment.id,
+        stripeEventId: input.stripeEventId,
+        amount,
+        balanceDue,
+      },
+    });
+
+    return { status: 'recorded', paymentId: payment.id };
   }
 }

--- a/apps/api/src/billing/stripe-webhooks.controller.ts
+++ b/apps/api/src/billing/stripe-webhooks.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Headers, Post, Req, RawBodyRequest } from '@nestjs/common';
+import { Request } from 'express';
+import { BillingService } from './billing.service';
+
+@Controller('billing/stripe')
+export class StripeWebhooksController {
+  constructor(private readonly billingService: BillingService) {}
+
+  @Post('webhook')
+  handleWebhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers('stripe-signature') signature?: string,
+    @Body() payload?: Record<string, unknown>,
+  ) {
+    return this.billingService.handleStripeWebhook({
+      signature,
+      rawBody: req.rawBody,
+      payload,
+    });
+  }
+}
+

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -8,6 +8,7 @@ import { PrismaService } from './prisma/prisma.service';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
+    rawBody: true,
     cors: {
       origin: [process.env.WEB_BASE_URL || 'http://localhost:3000'],
       credentials: true,

--- a/apps/api/test/billing-stripe-reconciliation.spec.ts
+++ b/apps/api/test/billing-stripe-reconciliation.spec.ts
@@ -1,0 +1,211 @@
+import { BillingService } from '../src/billing/billing.service';
+
+describe('BillingService Stripe lifecycle + reconciliation', () => {
+  beforeEach(() => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+  });
+
+  it('creates checkout session with invoice metadata for payment intent reconciliation', async () => {
+    const prisma = {
+      invoice: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'inv-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          invoiceNumber: 'INV-00001',
+          balanceDue: 150,
+          status: 'DRAFT',
+          stripeCheckoutUrl: null,
+          matter: { id: 'matter-1', name: 'Kitchen Defect Matter' },
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'inv-1' }),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn() } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    const createSession = jest.fn().mockResolvedValue({ id: 'cs_1', url: 'https://checkout.stripe.test/cs_1' });
+    (service as any).stripe = {
+      checkout: {
+        sessions: {
+          create: createSession,
+        },
+      },
+    };
+
+    const result = await service.createCheckoutLink({ id: 'u1', organizationId: 'org-1' } as any, 'inv-1');
+
+    expect(createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_reference_id: 'inv-1',
+        metadata: {
+          invoiceId: 'inv-1',
+          organizationId: 'org-1',
+        },
+        payment_intent_data: {
+          metadata: {
+            invoiceId: 'inv-1',
+            organizationId: 'org-1',
+          },
+        },
+      }),
+    );
+    expect(prisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'inv-1' },
+        data: expect.objectContaining({
+          status: 'SENT',
+          stripeCheckoutUrl: 'https://checkout.stripe.test/cs_1',
+        }),
+      }),
+    );
+    expect(result).toEqual({ url: 'https://checkout.stripe.test/cs_1' });
+  });
+
+  it('records webhook payment once and treats duplicate webhook as idempotent', async () => {
+    const prisma = {
+      invoice: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'inv-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          balanceDue: 200,
+          status: 'SENT',
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'inv-1' }),
+      },
+      payment: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            id: 'pay-existing',
+            organizationId: 'org-1',
+            invoiceId: 'inv-1',
+            stripePaymentIntentId: 'pi_1',
+          }),
+        create: jest.fn().mockResolvedValue({ id: 'pay-1' }),
+      },
+    } as any;
+
+    const audit = {
+      appendEvent: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      audit,
+      { upload: jest.fn() } as any,
+    );
+
+    (service as any).stripe = null;
+
+    const eventPayload = {
+      id: 'evt_1',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_1',
+          payment_intent: 'pi_1',
+          amount_total: 15000,
+          metadata: {
+            invoiceId: 'inv-1',
+            organizationId: 'org-1',
+          },
+        },
+      },
+    };
+
+    const firstResult = await service.handleStripeWebhook({ payload: eventPayload });
+    const secondResult = await service.handleStripeWebhook({ payload: eventPayload });
+
+    expect(firstResult).toEqual(
+      expect.objectContaining({
+        received: true,
+        eventId: 'evt_1',
+        type: 'checkout.session.completed',
+        status: 'recorded',
+        paymentId: 'pay-1',
+      }),
+    );
+    expect(secondResult).toEqual(
+      expect.objectContaining({
+        received: true,
+        eventId: 'evt_1',
+        type: 'checkout.session.completed',
+        status: 'duplicate',
+        paymentId: 'pay-existing',
+      }),
+    );
+
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    expect(prisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'inv-1' },
+        data: expect.objectContaining({
+          balanceDue: 50,
+          status: 'PARTIAL',
+        }),
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'invoice.payment.reconciled',
+        entityType: 'invoice',
+        entityId: 'inv-1',
+      }),
+    );
+  });
+
+  it('ignores payment-intent webhook without required metadata', async () => {
+    const service = new BillingService(
+      {
+        invoice: {
+          findFirst: jest.fn(),
+          update: jest.fn(),
+        },
+        payment: {
+          findFirst: jest.fn(),
+          create: jest.fn(),
+        },
+      } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn() } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    (service as any).stripe = null;
+
+    const result = await service.handleStripeWebhook({
+      payload: {
+        id: 'evt_2',
+        type: 'payment_intent.succeeded',
+        data: {
+          object: {
+            id: 'pi_2',
+            amount: 10000,
+            amount_received: 10000,
+            metadata: {},
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        received: true,
+        eventId: 'evt_2',
+        type: 'payment_intent.succeeded',
+        status: 'ignored',
+        reason: 'missing_required_metadata',
+      }),
+    );
+  });
+});
+

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -87,3 +87,4 @@ For each requirement slice:
 - 2026-02-16: These additions are tracked as `phase-2` planned backlog items so they do not displace active `phase-1` delivery lanes.
 - 2026-02-16: Implemented `REQ-AI-001` deadline-extraction confirmation UX with side-by-side source excerpt evidence and explicit per-row confirmation before task/event creation, plus parser/unit tests for structured deadline candidates.
 - 2026-02-16: Implemented `REQ-AI-002` ingestion hardening with chunk-level prompt-injection filtering, metadata severity flags, blocked-chunk context exclusion, and adversarial test coverage.
+- 2026-02-16: Implemented `REQ-BILL-001` Stripe lifecycle hardening with checkout metadata propagation, public webhook reconciliation endpoint, idempotent payment-intent handling, and webhook reconciliation tests.


### PR DESCRIPTION
## Linear Issue
- Key: KAR-27
- URL: https://linear.app/karenap/issue/KAR-27/finalize-stripe-payment-flow-lifecycle-and-webhook-reconciliation

## Requirement ID
- REQ-BILL-001

## Summary
- Add Stripe checkout metadata propagation (`invoiceId`, `organizationId`) to both Checkout Session and PaymentIntent.
- Add public Stripe webhook endpoint `POST /billing/stripe/webhook` with optional signature verification when `STRIPE_WEBHOOK_SECRET` is configured.
- Implement webhook reconciliation for `checkout.session.completed`, `checkout.session.async_payment_succeeded`, and `payment_intent.succeeded`.
- Enforce idempotency by de-duplicating on `stripePaymentIntentId` and cap applied payment to remaining invoice balance.
- Add focused billing reconciliation tests and update API env example for webhook secret.

## Verification Evidence
- `pnpm --filter api test -- billing-stripe-reconciliation.spec.ts`
- `pnpm --filter api build`
- `pnpm test`
- `pnpm build`
