### PR TITLE
[KAR-19] Complete participant role configurability and side semantics

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -405,10 +405,22 @@ async function main() {
     data: [
       { organizationId: org.id, key: 'client', label: 'Client', sideDefault: MatterParticipantSide.CLIENT_SIDE },
       { organizationId: org.id, key: 'opposing_counsel', label: 'Opposing Counsel', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
+      { organizationId: org.id, key: 'opposing_party', label: 'Opposing Party', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
+      { organizationId: org.id, key: 'co_counsel', label: 'Co-Counsel', sideDefault: MatterParticipantSide.CLIENT_SIDE },
+      { organizationId: org.id, key: 'local_counsel', label: 'Local Counsel', sideDefault: MatterParticipantSide.CLIENT_SIDE },
       { organizationId: org.id, key: 'expert', label: 'Expert', sideDefault: MatterParticipantSide.NEUTRAL },
       { organizationId: org.id, key: 'inspector', label: 'Inspector', sideDefault: MatterParticipantSide.NEUTRAL },
+      { organizationId: org.id, key: 'mediator', label: 'Mediator', sideDefault: MatterParticipantSide.NEUTRAL },
+      { organizationId: org.id, key: 'arbitrator', label: 'Arbitrator', sideDefault: MatterParticipantSide.NEUTRAL },
+      { organizationId: org.id, key: 'witness', label: 'Witness', sideDefault: MatterParticipantSide.NEUTRAL },
+      { organizationId: org.id, key: 'process_server', label: 'Process Server', sideDefault: MatterParticipantSide.NEUTRAL },
       { organizationId: org.id, key: 'adjuster', label: 'Adjuster', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
+      { organizationId: org.id, key: 'insurer', label: 'Insurer', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
+      { organizationId: org.id, key: 'lien_claimant', label: 'Lien Claimant', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
+      { organizationId: org.id, key: 'subcontractor', label: 'Subcontractor', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
+      { organizationId: org.id, key: 'supplier', label: 'Supplier', sideDefault: MatterParticipantSide.OPPOSING_SIDE },
       { organizationId: org.id, key: 'judge', label: 'Judge', sideDefault: MatterParticipantSide.COURT },
+      { organizationId: org.id, key: 'court_staff', label: 'Court Staff', sideDefault: MatterParticipantSide.COURT },
     ],
   });
 

--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -8,6 +8,7 @@ import { AuthenticatedUser } from '../common/types';
 import { UpdateSettingsDto } from './dto/update-settings.dto';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { CreateStageDto } from './dto/create-stage.dto';
+import { CreateParticipantRoleDto } from './dto/create-participant-role.dto';
 
 @Controller('admin')
 @UseGuards(SessionAuthGuard, PermissionGuard)
@@ -65,6 +66,25 @@ export class AdminController {
       name: dto.name,
       practiceArea: dto.practiceArea,
       orderIndex: dto.orderIndex,
+    });
+  }
+
+  @Get('participant-roles')
+  @RequirePermissions('roles:read')
+  participantRoles(@CurrentUser() user: AuthenticatedUser) {
+    return this.adminService.listParticipantRoles(user.organizationId);
+  }
+
+  @Post('participant-roles')
+  @RequirePermissions('roles:write')
+  createParticipantRole(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateParticipantRoleDto) {
+    return this.adminService.createParticipantRole({
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      key: dto.key,
+      label: dto.label,
+      description: dto.description,
+      sideDefault: dto.sideDefault,
     });
   }
 }

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { MatterParticipantSide } from '@prisma/client';
 import { toJsonValue } from '../common/utils/json.util';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -148,5 +149,53 @@ export class AdminService {
       },
       orderBy: [{ practiceArea: 'asc' }, { orderIndex: 'asc' }],
     });
+  }
+
+  async listParticipantRoles(organizationId: string) {
+    return this.prisma.participantRoleDefinition.findMany({
+      where: { organizationId },
+      orderBy: [{ label: 'asc' }, { key: 'asc' }],
+    });
+  }
+
+  async createParticipantRole(input: {
+    organizationId: string;
+    actorUserId: string;
+    key: string;
+    label: string;
+    description?: string;
+    sideDefault?: MatterParticipantSide;
+  }) {
+    const role = await this.prisma.participantRoleDefinition.upsert({
+      where: {
+        organizationId_key: {
+          organizationId: input.organizationId,
+          key: input.key,
+        },
+      },
+      update: {
+        label: input.label,
+        description: input.description,
+        sideDefault: input.sideDefault,
+      },
+      create: {
+        organizationId: input.organizationId,
+        key: input.key,
+        label: input.label,
+        description: input.description,
+        sideDefault: input.sideDefault,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+      action: 'participant_role_definition.upserted',
+      entityType: 'participantRoleDefinition',
+      entityId: role.id,
+      metadata: role,
+    });
+
+    return role;
   }
 }

--- a/apps/api/src/admin/dto/create-participant-role.dto.ts
+++ b/apps/api/src/admin/dto/create-participant-role.dto.ts
@@ -1,0 +1,18 @@
+import { MatterParticipantSide } from '@prisma/client';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class CreateParticipantRoleDto {
+  @IsString()
+  key!: string;
+
+  @IsString()
+  label!: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsEnum(MatterParticipantSide)
+  @IsOptional()
+  sideDefault?: MatterParticipantSide;
+}

--- a/apps/api/src/matters/matters.service.ts
+++ b/apps/api/src/matters/matters.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { MatterStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -92,6 +92,45 @@ export class MattersService {
         key: input.participantRoleKey,
       },
     });
+    if (!roleDef) {
+      throw new NotFoundException(`Participant role definition not found: ${input.participantRoleKey}`);
+    }
+
+    await this.assertContactInOrganization(
+      input.user.organizationId,
+      input.contactId,
+      `Participant contact not found: ${input.contactId}`,
+    );
+
+    if (input.representedByContactId) {
+      if (input.representedByContactId === input.contactId) {
+        throw new BadRequestException('representedByContactId cannot match contactId');
+      }
+      await this.assertContactInOrganization(
+        input.user.organizationId,
+        input.representedByContactId,
+        `Representing contact not found: ${input.representedByContactId}`,
+      );
+    }
+
+    if (input.lawFirmContactId) {
+      if (input.lawFirmContactId === input.contactId) {
+        throw new BadRequestException('lawFirmContactId cannot match contactId');
+      }
+      await this.assertContactInOrganization(
+        input.user.organizationId,
+        input.lawFirmContactId,
+        `Law firm contact not found: ${input.lawFirmContactId}`,
+      );
+    }
+
+    const counselRole = this.isCounselRole(roleDef.key, roleDef.label);
+    if (counselRole && input.representedByContactId) {
+      throw new BadRequestException('Counsel roles cannot use representedByContactId; add represented parties instead');
+    }
+    if (!counselRole && input.lawFirmContactId) {
+      throw new BadRequestException('lawFirmContactId is only valid for counsel roles');
+    }
 
     const participant = await this.prisma.matterParticipant.create({
       data: {
@@ -99,8 +138,8 @@ export class MattersService {
         matterId: input.matterId,
         contactId: input.contactId,
         participantRoleKey: input.participantRoleKey,
-        participantRoleDefinitionId: roleDef?.id,
-        side: input.side,
+        participantRoleDefinitionId: roleDef.id,
+        side: input.side ?? roleDef.sideDefault,
         isPrimary: input.isPrimary ?? false,
         representedByContactId: input.representedByContactId,
         lawFirmContactId: input.lawFirmContactId,
@@ -121,6 +160,28 @@ export class MattersService {
     });
 
     return participant;
+  }
+
+  private isCounselRole(roleKey: string, roleLabel?: string | null) {
+    const fingerprint = `${roleKey} ${roleLabel || ''}`.toLowerCase();
+    return /(counsel|attorney|lawyer)/.test(fingerprint);
+  }
+
+  private async assertContactInOrganization(
+    organizationId: string,
+    contactId: string,
+    errorMessage: string,
+  ) {
+    const contact = await this.prisma.contact.findFirst({
+      where: {
+        organizationId,
+        id: contactId,
+      },
+      select: { id: true },
+    });
+    if (!contact) {
+      throw new NotFoundException(errorMessage);
+    }
   }
 
   async dashboard(user: AuthenticatedUser, matterId: string) {

--- a/apps/api/test/admin.spec.ts
+++ b/apps/api/test/admin.spec.ts
@@ -1,0 +1,49 @@
+import { AdminService } from '../src/admin/admin.service';
+
+describe('AdminService', () => {
+  it('lists participant role definitions for organization', async () => {
+    const prisma = {
+      participantRoleDefinition: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'pr-1', key: 'opposing_counsel', label: 'Opposing Counsel' }]),
+      },
+    } as any;
+    const service = new AdminService(prisma, { appendEvent: jest.fn() } as any);
+
+    const roles = await service.listParticipantRoles('org-1');
+    expect(roles).toHaveLength(1);
+    expect(prisma.participantRoleDefinition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId: 'org-1' },
+      }),
+    );
+  });
+
+  it('upserts participant role definition and writes audit event', async () => {
+    const upserted = { id: 'pr-1', key: 'opposing_counsel', label: 'Opposing Counsel', sideDefault: 'OPPOSING_SIDE' };
+    const prisma = {
+      participantRoleDefinition: {
+        upsert: jest.fn().mockResolvedValue(upserted),
+      },
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new AdminService(prisma, audit);
+
+    const role = await service.createParticipantRole({
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      key: 'opposing_counsel',
+      label: 'Opposing Counsel',
+      sideDefault: 'OPPOSING_SIDE' as any,
+    });
+
+    expect(role).toEqual(upserted);
+    expect(prisma.participantRoleDefinition.upsert).toHaveBeenCalled();
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: 'org-1',
+        actorUserId: 'user-1',
+        action: 'participant_role_definition.upserted',
+      }),
+    );
+  });
+});

--- a/apps/api/test/matters.spec.ts
+++ b/apps/api/test/matters.spec.ts
@@ -1,6 +1,14 @@
 import { MattersService } from '../src/matters/matters.service';
 
 describe('MattersService', () => {
+  const baseUser = {
+    id: 'user1',
+    email: 'u@example.com',
+    organizationId: 'org1',
+    permissions: [],
+    membership: { role: { name: 'Attorney' } },
+  } as any;
+
   it('creates matter and seeds actor into team', async () => {
     const prisma = {
       matter: {
@@ -29,13 +37,21 @@ describe('MattersService', () => {
     expect(prisma.matterTeamMember.create).toHaveBeenCalled();
   });
 
-  it('adds participant with participant role key', async () => {
+  it('adds participant with role-definition default side', async () => {
     const prisma = {
+      contact: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'contact1' }),
+      },
       participantRoleDefinition: {
-        findFirst: jest.fn().mockResolvedValue({ id: 'role1' }),
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'role1',
+          key: 'opposing_party',
+          label: 'Opposing Party',
+          sideDefault: 'OPPOSING_SIDE',
+        }),
       },
       matterParticipant: {
-        create: jest.fn().mockResolvedValue({ id: 'participant1' }),
+        create: jest.fn().mockResolvedValue({ id: 'participant1', side: 'OPPOSING_SIDE' }),
       },
     } as any;
 
@@ -46,23 +62,146 @@ describe('MattersService', () => {
     );
 
     const participant = await service.addParticipant({
-      user: {
-        id: 'user1',
-        email: 'u@example.com',
-        organizationId: 'org1',
-        permissions: [],
-        membership: { role: { name: 'Attorney' } },
-      } as any,
+      user: baseUser,
       matterId: 'matter1',
       contactId: 'contact1',
-      participantRoleKey: 'opposing_counsel',
+      participantRoleKey: 'opposing_party',
     });
 
     expect(participant.id).toBe('participant1');
     expect(prisma.matterParticipant.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ participantRoleKey: 'opposing_counsel' }),
+        data: expect.objectContaining({ participantRoleKey: 'opposing_party', side: 'OPPOSING_SIDE' }),
       }),
     );
+  });
+
+  it('rejects representedByContactId for counsel roles', async () => {
+    const prisma = {
+      contact: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'contact1' }),
+      },
+      participantRoleDefinition: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'role1',
+          key: 'opposing_counsel',
+          label: 'Opposing Counsel',
+          sideDefault: 'OPPOSING_SIDE',
+        }),
+      },
+      matterParticipant: {
+        create: jest.fn(),
+      },
+    } as any;
+
+    const service = new MattersService(
+      prisma,
+      { appendEvent: jest.fn() } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    await expect(
+      service.addParticipant({
+        user: baseUser,
+        matterId: 'matter1',
+        contactId: 'contact1',
+        participantRoleKey: 'opposing_counsel',
+        representedByContactId: 'contact2',
+      }),
+    ).rejects.toThrow('Counsel roles cannot use representedByContactId');
+    expect(prisma.matterParticipant.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects lawFirmContactId for non-counsel roles', async () => {
+    const prisma = {
+      contact: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'contact1' }),
+      },
+      participantRoleDefinition: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'role1',
+          key: 'expert',
+          label: 'Expert',
+          sideDefault: 'NEUTRAL',
+        }),
+      },
+      matterParticipant: {
+        create: jest.fn(),
+      },
+    } as any;
+
+    const service = new MattersService(
+      prisma,
+      { appendEvent: jest.fn() } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    await expect(
+      service.addParticipant({
+        user: baseUser,
+        matterId: 'matter1',
+        contactId: 'contact1',
+        participantRoleKey: 'expert',
+        lawFirmContactId: 'firm1',
+      }),
+    ).rejects.toThrow('lawFirmContactId is only valid for counsel roles');
+    expect(prisma.matterParticipant.create).not.toHaveBeenCalled();
+  });
+
+  it('supports all required participant categories through configurable role keys', async () => {
+    const categories = [
+      { key: 'opposing_counsel', label: 'Opposing Counsel', sideDefault: 'OPPOSING_SIDE', counsel: true },
+      { key: 'opposing_party', label: 'Opposing Party', sideDefault: 'OPPOSING_SIDE', counsel: false },
+      { key: 'co_counsel', label: 'Co-Counsel', sideDefault: 'CLIENT_SIDE', counsel: true },
+      { key: 'local_counsel', label: 'Local Counsel', sideDefault: 'CLIENT_SIDE', counsel: true },
+      { key: 'adjuster', label: 'Adjuster', sideDefault: 'OPPOSING_SIDE', counsel: false },
+      { key: 'insurer', label: 'Insurer', sideDefault: 'OPPOSING_SIDE', counsel: false },
+      { key: 'mediator', label: 'Mediator', sideDefault: 'NEUTRAL', counsel: false },
+      { key: 'arbitrator', label: 'Arbitrator', sideDefault: 'NEUTRAL', counsel: false },
+      { key: 'judge', label: 'Judge', sideDefault: 'COURT', counsel: false },
+      { key: 'court_staff', label: 'Court Staff', sideDefault: 'COURT', counsel: false },
+      { key: 'expert', label: 'Expert', sideDefault: 'NEUTRAL', counsel: false },
+      { key: 'inspector', label: 'Inspector', sideDefault: 'NEUTRAL', counsel: false },
+      { key: 'process_server', label: 'Process Server', sideDefault: 'NEUTRAL', counsel: false },
+      { key: 'lien_claimant', label: 'Lien Claimant', sideDefault: 'OPPOSING_SIDE', counsel: false },
+      { key: 'witness', label: 'Witness', sideDefault: 'NEUTRAL', counsel: false },
+      { key: 'subcontractor', label: 'Subcontractor', sideDefault: 'OPPOSING_SIDE', counsel: false },
+      { key: 'supplier', label: 'Supplier', sideDefault: 'OPPOSING_SIDE', counsel: false },
+    ];
+    const roleMap = new Map(categories.map((category) => [category.key, { id: `role-${category.key}`, ...category }]));
+    const matterParticipantCreate = jest.fn().mockImplementation(async ({ data }: any) => ({ id: `p-${data.participantRoleKey}` }));
+
+    const prisma = {
+      contact: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'contact-exists' }),
+      },
+      participantRoleDefinition: {
+        findFirst: jest.fn().mockImplementation(async ({ where }: any) => roleMap.get(where.key) || null),
+      },
+      matterParticipant: {
+        create: matterParticipantCreate,
+      },
+    } as any;
+
+    const service = new MattersService(
+      prisma,
+      { appendEvent: jest.fn() } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    for (const category of categories) {
+      await service.addParticipant({
+        user: baseUser,
+        matterId: 'matter1',
+        contactId: `contact-${category.key}`,
+        participantRoleKey: category.key,
+        lawFirmContactId: category.counsel ? `firm-${category.key}` : undefined,
+        representedByContactId: category.counsel ? undefined : `counsel-for-${category.key}`,
+      });
+    }
+
+    expect(matterParticipantCreate).toHaveBeenCalledTimes(categories.length);
+    const createdKeys = matterParticipantCreate.mock.calls.map((call: any) => call[0].data.participantRoleKey);
+    expect(new Set(createdKeys)).toEqual(new Set(categories.map((category) => category.key)));
   });
 });

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -10,12 +10,18 @@ export default function AdminPage() {
   const [users, setUsers] = useState<Array<{ id: string; user: { email: string }; role?: { name: string } }>>([]);
   const [roles, setRoles] = useState<Array<{ id: string; name: string }>>([]);
   const [stages, setStages] = useState<Array<{ id: string; practiceArea: string; name: string }>>([]);
+  const [participantRoles, setParticipantRoles] = useState<
+    Array<{ id: string; key: string; label: string; sideDefault?: 'CLIENT_SIDE' | 'OPPOSING_SIDE' | 'NEUTRAL' | 'COURT' }>
+  >([]);
   const [auditEvents, setAuditEvents] = useState<Array<{ id: string; action: string; createdAt: string }>>([]);
   const [customFields, setCustomFields] = useState<Array<{ id: string; key: string; entityType: string; label: string }>>([]);
   const [sections, setSections] = useState<Array<{ id: string; name: string }>>([]);
   const [customFieldKey, setCustomFieldKey] = useState('project_address');
   const [customFieldLabel, setCustomFieldLabel] = useState('Project Address');
   const [sectionName, setSectionName] = useState('Defect Summary');
+  const [participantRoleKey, setParticipantRoleKey] = useState('opposing_party');
+  const [participantRoleLabel, setParticipantRoleLabel] = useState('Opposing Party');
+  const [participantRoleSide, setParticipantRoleSide] = useState<'CLIENT_SIDE' | 'OPPOSING_SIDE' | 'NEUTRAL' | 'COURT'>('OPPOSING_SIDE');
 
   useEffect(() => {
     Promise.all([
@@ -23,15 +29,19 @@ export default function AdminPage() {
       apiFetch<Array<{ id: string; user: { email: string }; role?: { name: string } }>>('/admin/users'),
       apiFetch<Array<{ id: string; name: string }>>('/admin/roles'),
       apiFetch<Array<{ id: string; practiceArea: string; name: string }>>('/admin/stages'),
+      apiFetch<Array<{ id: string; key: string; label: string; sideDefault?: 'CLIENT_SIDE' | 'OPPOSING_SIDE' | 'NEUTRAL' | 'COURT' }>>(
+        '/admin/participant-roles',
+      ),
       apiFetch<Array<{ id: string; action: string; createdAt: string }>>('/audit?limit=25'),
       apiFetch<Array<{ id: string; key: string; entityType: string; label: string }>>('/config/custom-fields'),
       apiFetch<Array<{ id: string; name: string }>>('/config/sections'),
     ])
-      .then(([o, u, r, s, a, cf, sec]) => {
+      .then(([o, u, r, s, pr, a, cf, sec]) => {
         setOrg(o);
         setUsers(u);
         setRoles(r);
         setStages(s);
+        setParticipantRoles(pr);
         setAuditEvents(a);
         setCustomFields(cf);
         setSections(sec);
@@ -64,6 +74,24 @@ export default function AdminPage() {
     });
     setSectionName('');
     setSections(await apiFetch<Array<{ id: string; name: string }>>('/config/sections'));
+  }
+
+  async function createParticipantRole() {
+    await apiFetch('/admin/participant-roles', {
+      method: 'POST',
+      body: JSON.stringify({
+        key: participantRoleKey,
+        label: participantRoleLabel,
+        sideDefault: participantRoleSide,
+      }),
+    });
+    setParticipantRoleKey('');
+    setParticipantRoleLabel('');
+    setParticipantRoles(
+      await apiFetch<Array<{ id: string; key: string; label: string; sideDefault?: 'CLIENT_SIDE' | 'OPPOSING_SIDE' | 'NEUTRAL' | 'COURT' }>>(
+        '/admin/participant-roles',
+      ),
+    );
   }
 
   return (
@@ -120,6 +148,54 @@ export default function AdminPage() {
             </tbody>
           </table>
         </div>
+
+        <div className="card" style={{ gridColumn: '1 / -1' }}>
+          <h3 style={{ marginTop: 0 }}>Participant Roles</h3>
+          <div style={{ display: 'grid', gap: 8, gridTemplateColumns: '1fr 1fr 220px auto', marginBottom: 12 }}>
+            <input
+              className="input"
+              value={participantRoleKey}
+              onChange={(e) => setParticipantRoleKey(e.target.value)}
+              placeholder="Role key (e.g. opposing_counsel)"
+            />
+            <input
+              className="input"
+              value={participantRoleLabel}
+              onChange={(e) => setParticipantRoleLabel(e.target.value)}
+              placeholder="Role label"
+            />
+            <select
+              className="input"
+              value={participantRoleSide}
+              onChange={(e) => setParticipantRoleSide(e.target.value as 'CLIENT_SIDE' | 'OPPOSING_SIDE' | 'NEUTRAL' | 'COURT')}
+            >
+              <option value="CLIENT_SIDE">CLIENT_SIDE</option>
+              <option value="OPPOSING_SIDE">OPPOSING_SIDE</option>
+              <option value="NEUTRAL">NEUTRAL</option>
+              <option value="COURT">COURT</option>
+            </select>
+            <button className="button secondary" onClick={createParticipantRole}>Save Role</button>
+          </div>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Key</th>
+                <th>Label</th>
+                <th>Default Side</th>
+              </tr>
+            </thead>
+            <tbody>
+              {participantRoles.map((role) => (
+                <tr key={role.id}>
+                  <td>{role.key}</td>
+                  <td>{role.label}</td>
+                  <td>{role.sideDefault || 'None'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
         <div className="card" style={{ gridColumn: '1 / -1' }}>
           <h3 style={{ marginTop: 0 }}>Audit Log</h3>
           <table className="table">

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T00:48:31.625Z`
+- Snapshot Timestamp: `2026-02-17T01:02:52.090Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T00:48:26.377Z`
+- Last Successful Mirror Verify: `2026-02-17T01:02:45.092Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Completed `REQ-MAT-001` with org-configurable participant role definition endpoints, represented-by/law-firm semantic validation in matter participant creation, and matrix tests spanning all required participant categories.
 - 2026-02-17: Completed `REQ-DATA-001` parity audit artifact at `docs/parity/data-model-checklist.md` with prompt-entity/model mapping and explicit gap linkage to active requirement IDs.
 - 2026-02-16: Established new-chat continuity protocol, snapshot tooling, and freshness checks for context-compaction resilience.
 - 2026-02-16: Added five end-goal features as `phase-2` planned scope (`REQ-COMM-004`, `REQ-MAT-004`, `REQ-MAT-005`, `REQ-BILL-003`, `REQ-BILL-004`) and enabled phase-aware snapshot prioritization.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -253,7 +253,7 @@
           "title": "Complete participant role configurability and side semantics coverage",
           "requirementId": "REQ-MAT-001",
           "promptSection": "MatterParticipant role model requirements",
-          "parityStatus": "Partial",
+          "parityStatus": "Complete",
           "component": "API",
           "risk": "High",
           "labels": ["parity", "matters"],
@@ -267,7 +267,7 @@
           "apiImpact": "Role definition endpoints and validation rules strengthened.",
           "securityImpact": "Matter access checks remain enforced on participant mutations.",
           "definitionOfDone": [
-            "Participant role matrix test suite passes."
+            "Participant role matrix test suite passes and participant role definitions are configurable through admin endpoints."
           ]
         },
         {

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T00:48:31.625Z",
+  "generatedAt": "2026-02-17T01:02:52.090Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -24,8 +24,8 @@
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 5,
-      "Partial": 24,
+      "Complete": 6,
+      "Partial": 23,
       "Missing": 5
     },
     "unresolvedCountsByRisk": {
@@ -33,9 +33,9 @@
       "Medium": 17
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:High": 4,
+      "Complete:High": 5,
       "Partial:Medium": 11,
-      "Partial:High": 13,
+      "Partial:High": 12,
       "Missing:Medium": 5,
       "Complete:Medium": 1
     }
@@ -98,15 +98,6 @@
         "phase": "phase-1"
       },
       {
-        "requirementId": "REQ-MAT-001",
-        "parityStatus": "Partial",
-        "risk": "High",
-        "title": "Complete participant role configurability and side semantics coverage",
-        "component": "API",
-        "epicCode": "PARITY-04",
-        "phase": "phase-1"
-      },
-      {
         "requirementId": "REQ-MAT-003",
         "parityStatus": "Partial",
         "risk": "High",
@@ -132,6 +123,15 @@
         "component": "API",
         "epicCode": "PARITY-03",
         "phase": "phase-1"
+      },
+      {
+        "requirementId": "REQ-PORT-002",
+        "parityStatus": "Partial",
+        "risk": "High",
+        "title": "Finalize Clio CSV/XLSX template importer coverage",
+        "component": "API",
+        "epicCode": "PARITY-03",
+        "phase": "phase-1"
       }
     ]
   },
@@ -140,13 +140,27 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 44,
     "stateCounts": {
-      "Backlog": 33,
-      "In Review": 3,
-      "Done": 8
+      "Backlog": 31,
+      "In Review": 4,
+      "Done": 9
     },
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-19",
+        "title": "Complete participant role configurability and side semantics coverage",
+        "state": "In Review",
+        "updatedAt": "2026-02-17T01:02:30.511Z",
+        "requirementId": "REQ-MAT-001"
+      },
+      {
+        "key": "KAR-10",
+        "title": "Validate all required entities and relation semantics against prompt",
+        "state": "Done",
+        "updatedAt": "2026-02-17T00:52:13.393Z",
+        "requirementId": "REQ-DATA-001"
+      },
       {
         "key": "KAR-28",
         "title": "Complete trust accounting reports and ledger invariants",
@@ -202,32 +216,29 @@
         "state": "Done",
         "updatedAt": "2026-02-16T21:48:24.385Z",
         "requirementId": "REQ-INT-003"
-      },
-      {
-        "key": "KAR-48",
-        "title": "Implement LEDES/UTBMS export jobs with validation profiles",
-        "state": "Backlog",
-        "updatedAt": "2026-02-16T20:39:08.468Z",
-        "requirementId": "REQ-BILL-004"
-      },
-      {
-        "key": "KAR-47",
-        "title": "Implement trust reconciliation workflows with discrepancy resolution",
-        "state": "Backlog",
-        "updatedAt": "2026-02-16T20:39:07.918Z",
-        "requirementId": "REQ-BILL-003"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T00:48:26.377Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T01:02:45.092Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "53caac54612fbbdb93b4d8cdcb90641f6c1e85ea",
+    "gitHead": "60dc39b859fa938b5b6929f6f5ae4f8ad5a6c7b7",
     "gitStatusShort": [
-      "## lin/KAR-10-data-model-parity-validation...origin/lin/KAR-10-data-model-parity-validation"
+      "## lin/KAR-19-participant-role-semantics-coverage",
+      " M apps/api/prisma/seed.ts",
+      " M apps/api/src/admin/admin.controller.ts",
+      " M apps/api/src/admin/admin.service.ts",
+      " M apps/api/src/matters/matters.service.ts",
+      " M apps/api/test/matters.spec.ts",
+      " M apps/web/app/admin/page.tsx",
+      " M docs/SESSION_HANDOFF.md",
+      " M tools/backlog-sync/requirements.matrix.json",
+      " M tools/backlog-sync/session.snapshot.json",
+      "?? apps/api/src/admin/dto/create-participant-role.dto.ts",
+      "?? apps/api/test/admin.spec.ts"
     ],
-    "dirtyFileCount": 0
+    "dirtyFileCount": 11
   }
 }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-19
- URL: https://linear.app/karenap/issue/KAR-19/complete-participant-role-configurability-and-side-semantics-coverage

## Requirement ID
- REQ-MAT-001

## Summary
- Added organization-configurable participant role definition APIs:
  - `GET /admin/participant-roles`
  - `POST /admin/participant-roles`
- Added admin UI management section for participant roles on `apps/web/app/admin/page.tsx`.
- Strengthened participant semantics in `MattersService.addParticipant`:
  - role definition is required and side defaults from role definition when omitted
  - represented-by and law-firm links validated for organization membership
  - counsel-role vs non-counsel semantics enforced
- Expanded seed participant role definitions to cover all required participant categories.
- Added tests:
  - `apps/api/test/matters.spec.ts` role semantics + full category matrix
  - `apps/api/test/admin.spec.ts` participant-role admin service coverage
- Updated parity tracking:
  - `REQ-MAT-001` marked `Complete` in requirements matrix
  - handoff + snapshot refreshed

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm test`
  - `pnpm build`
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - Full tests: pass (`20` API suites + `8` web suites)
  - Build: pass (API tsc + web Next build)
  - Mirror sync/verify: pass (`44` mirrored / `44` scoped, no missing/orphan)
  - Snapshot and handoff freshness: pass

## Notes
- Linear issue `KAR-19` moved to `In Review` with verification evidence block.
- No unrelated files were modified.
