### PR TITLE
[KAR-16] Build user-confirm dedupe merge workflow

### DIFF
--- a/apps/api/src/contacts/contacts.controller.ts
+++ b/apps/api/src/contacts/contacts.controller.ts
@@ -61,4 +61,19 @@ export class ContactsController {
       duplicateId: body.duplicateId,
     });
   }
+
+  @Post('dedupe/decisions')
+  @RequirePermissions('contacts:write')
+  dedupeDecision(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() body: { primaryId: string; duplicateId: string; decision: 'OPEN' | 'IGNORE' | 'DEFER' },
+  ) {
+    return this.contactsService.setDedupeDecision({
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      primaryId: body.primaryId,
+      duplicateId: body.duplicateId,
+      decision: body.decision,
+    });
+  }
 }

--- a/apps/api/src/contacts/contacts.service.ts
+++ b/apps/api/src/contacts/contacts.service.ts
@@ -4,6 +4,17 @@ import { distance } from 'fastest-levenshtein';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 
+type DedupeDecision = 'OPEN' | 'IGNORE' | 'DEFER';
+
+type ContactSnapshot = {
+  id: string;
+  displayName: string;
+  kind: ContactKind;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  tags: string[];
+};
+
 @Injectable()
 export class ContactsService {
   constructor(
@@ -158,11 +169,18 @@ export class ContactsService {
 
   async dedupeSuggestions(organizationId: string) {
     const contacts = await this.prisma.contact.findMany({ where: { organizationId } });
+    const decisions = await this.latestDedupeDecisions(organizationId);
     const suggestions: Array<{
       primaryId: string;
       duplicateId: string;
+      pairKey: string;
       score: number;
+      confidence: 'HIGH' | 'MEDIUM' | 'LOW';
+      decision: DedupeDecision;
       reasons: string[];
+      primary: ContactSnapshot;
+      duplicate: ContactSnapshot;
+      fieldDiffs: Array<{ field: string; primaryValue: string | null; duplicateValue: string | null }>;
     }> = [];
 
     for (let i = 0; i < contacts.length; i += 1) {
@@ -190,17 +208,31 @@ export class ContactsService {
         }
 
         if (score >= 0.6) {
+          const pairKey = this.pairKey(a.id, b.id);
+          const decision = decisions.get(pairKey) || 'OPEN';
           suggestions.push({
             primaryId: a.id,
             duplicateId: b.id,
+            pairKey,
             score: Math.min(1, score),
+            confidence: this.confidenceFromScore(Math.min(1, score)),
+            decision,
             reasons,
+            primary: this.snapshotContact(a),
+            duplicate: this.snapshotContact(b),
+            fieldDiffs: this.fieldDiffs(a, b),
           });
         }
       }
     }
 
-    return suggestions.sort((a, b) => b.score - a.score).slice(0, 100);
+    return suggestions
+      .sort((a, b) => {
+        const decisionSort = this.decisionSortWeight(a.decision) - this.decisionSortWeight(b.decision);
+        if (decisionSort !== 0) return decisionSort;
+        return b.score - a.score;
+      })
+      .slice(0, 100);
   }
 
   async mergeContacts(input: {
@@ -262,6 +294,142 @@ export class ContactsService {
       },
     });
 
+    await this.audit.appendEvent({
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+      action: 'contact.dedupe.merged',
+      entityType: 'contactDedupe',
+      entityId: this.pairKey(primary.id, duplicate.id),
+      metadata: {
+        primaryId: primary.id,
+        duplicateId: duplicate.id,
+        decision: 'MERGED',
+      },
+    });
+
     return this.prisma.contact.findUnique({ where: { id: primary.id } });
+  }
+
+  async setDedupeDecision(input: {
+    organizationId: string;
+    actorUserId: string;
+    primaryId: string;
+    duplicateId: string;
+    decision: DedupeDecision;
+  }) {
+    const primary = await this.prisma.contact.findFirst({ where: { id: input.primaryId, organizationId: input.organizationId } });
+    const duplicate = await this.prisma.contact.findFirst({ where: { id: input.duplicateId, organizationId: input.organizationId } });
+
+    if (!primary || !duplicate) {
+      throw new NotFoundException('Contact not found');
+    }
+
+    const pairKey = this.pairKey(primary.id, duplicate.id);
+    const action =
+      input.decision === 'IGNORE'
+        ? 'contact.dedupe.ignored'
+        : input.decision === 'DEFER'
+          ? 'contact.dedupe.deferred'
+          : 'contact.dedupe.reopened';
+
+    await this.audit.appendEvent({
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+      action,
+      entityType: 'contactDedupe',
+      entityId: pairKey,
+      metadata: {
+        primaryId: primary.id,
+        duplicateId: duplicate.id,
+        decision: input.decision,
+      },
+    });
+
+    return {
+      pairKey,
+      decision: input.decision,
+      primaryId: primary.id,
+      duplicateId: duplicate.id,
+    };
+  }
+
+  private async latestDedupeDecisions(organizationId: string) {
+    const events = await this.prisma.auditLogEvent.findMany({
+      where: {
+        organizationId,
+        entityType: 'contactDedupe',
+        action: {
+          in: ['contact.dedupe.ignored', 'contact.dedupe.deferred', 'contact.dedupe.reopened', 'contact.dedupe.merged'],
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+      take: 1000,
+    });
+
+    const decisions = new Map<string, DedupeDecision>();
+    for (const event of events) {
+      if (event.action === 'contact.dedupe.ignored') decisions.set(event.entityId, 'IGNORE');
+      if (event.action === 'contact.dedupe.deferred') decisions.set(event.entityId, 'DEFER');
+      if (event.action === 'contact.dedupe.reopened') decisions.set(event.entityId, 'OPEN');
+      if (event.action === 'contact.dedupe.merged') decisions.set(event.entityId, 'OPEN');
+    }
+    return decisions;
+  }
+
+  private pairKey(primaryId: string, duplicateId: string) {
+    return [primaryId, duplicateId].sort().join('::');
+  }
+
+  private snapshotContact(contact: {
+    id: string;
+    displayName: string;
+    kind: ContactKind;
+    primaryEmail: string | null;
+    primaryPhone: string | null;
+    tags: string[];
+  }): ContactSnapshot {
+    return {
+      id: contact.id,
+      displayName: contact.displayName,
+      kind: contact.kind,
+      primaryEmail: contact.primaryEmail,
+      primaryPhone: contact.primaryPhone,
+      tags: contact.tags || [],
+    };
+  }
+
+  private fieldDiffs(
+    a: { displayName: string; kind: ContactKind; primaryEmail: string | null; primaryPhone: string | null; tags: string[] },
+    b: { displayName: string; kind: ContactKind; primaryEmail: string | null; primaryPhone: string | null; tags: string[] },
+  ) {
+    const pairs: Array<{ field: string; primaryValue: string | null; duplicateValue: string | null }> = [];
+    const fields: Array<{ field: string; left: string | null; right: string | null }> = [
+      { field: 'displayName', left: a.displayName || null, right: b.displayName || null },
+      { field: 'kind', left: a.kind || null, right: b.kind || null },
+      { field: 'primaryEmail', left: a.primaryEmail || null, right: b.primaryEmail || null },
+      { field: 'primaryPhone', left: a.primaryPhone || null, right: b.primaryPhone || null },
+      { field: 'tags', left: (a.tags || []).join(', ') || null, right: (b.tags || []).join(', ') || null },
+    ];
+    for (const item of fields) {
+      if ((item.left || '') === (item.right || '')) continue;
+      pairs.push({
+        field: item.field,
+        primaryValue: item.left,
+        duplicateValue: item.right,
+      });
+    }
+    return pairs;
+  }
+
+  private confidenceFromScore(score: number): 'HIGH' | 'MEDIUM' | 'LOW' {
+    if (score >= 0.85) return 'HIGH';
+    if (score >= 0.7) return 'MEDIUM';
+    return 'LOW';
+  }
+
+  private decisionSortWeight(decision: DedupeDecision) {
+    if (decision === 'OPEN') return 0;
+    if (decision === 'DEFER') return 1;
+    return 2;
   }
 }

--- a/apps/api/test/contacts-dedupe.spec.ts
+++ b/apps/api/test/contacts-dedupe.spec.ts
@@ -1,0 +1,169 @@
+import { ContactKind } from '@prisma/client';
+import { ContactsService } from '../src/contacts/contacts.service';
+
+describe('ContactsService dedupe workflow', () => {
+  it('returns dedupe suggestions with confidence, decision state, and field diffs', async () => {
+    const prisma = {
+      contact: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'c1',
+            organizationId: 'org1',
+            kind: ContactKind.PERSON,
+            displayName: 'Jane Doe',
+            primaryEmail: 'jane@example.com',
+            primaryPhone: '555-1000',
+            tags: ['client'],
+          },
+          {
+            id: 'c2',
+            organizationId: 'org1',
+            kind: ContactKind.PERSON,
+            displayName: 'J. Doe',
+            primaryEmail: 'jane@example.com',
+            primaryPhone: '555-1000',
+            tags: [],
+          },
+        ]),
+      },
+      auditLogEvent: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            action: 'contact.dedupe.ignored',
+            entityId: 'c1::c2',
+            metadataJson: {},
+            createdAt: new Date(),
+          },
+        ]),
+      },
+    } as any;
+
+    const service = new ContactsService(prisma, { appendEvent: jest.fn() } as any);
+    const suggestions = await service.dedupeSuggestions('org1');
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      primaryId: 'c1',
+      duplicateId: 'c2',
+      pairKey: 'c1::c2',
+      decision: 'IGNORE',
+      confidence: 'HIGH',
+    });
+    expect(suggestions[0].fieldDiffs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'displayName' }),
+      ]),
+    );
+  });
+
+  it('records explicit dedupe decisions with audit trail', async () => {
+    const prisma = {
+      contact: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce({ id: 'c1', organizationId: 'org1' })
+          .mockResolvedValueOnce({ id: 'c2', organizationId: 'org1' }),
+      },
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue({}) } as any;
+    const service = new ContactsService(prisma, audit);
+
+    const decision = await service.setDedupeDecision({
+      organizationId: 'org1',
+      actorUserId: 'u1',
+      primaryId: 'c1',
+      duplicateId: 'c2',
+      decision: 'DEFER',
+    });
+
+    expect(decision).toEqual({
+      pairKey: 'c1::c2',
+      decision: 'DEFER',
+      primaryId: 'c1',
+      duplicateId: 'c2',
+    });
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'contact.dedupe.deferred',
+        entityType: 'contactDedupe',
+        entityId: 'c1::c2',
+      }),
+    );
+  });
+
+  it('merges duplicate contacts and preserves referential integrity updates', async () => {
+    const tx = {
+      matterParticipant: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      contactMethod: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      contactRelationship: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      externalReference: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      contact: { delete: jest.fn().mockResolvedValue({ id: 'c2' }) },
+    };
+
+    const prisma = {
+      contact: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'c1',
+            organizationId: 'org1',
+            displayName: 'Jane Doe',
+            kind: ContactKind.PERSON,
+            primaryEmail: 'jane@example.com',
+            primaryPhone: '555-1000',
+            tags: ['client'],
+          })
+          .mockResolvedValueOnce({
+            id: 'c2',
+            organizationId: 'org1',
+            displayName: 'J. Doe',
+            kind: ContactKind.PERSON,
+            primaryEmail: 'jane.alt@example.com',
+            primaryPhone: '555-1000',
+            tags: [],
+          }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'c1', displayName: 'Jane Doe' }),
+      },
+      $transaction: jest.fn().mockImplementation(async (fn) => fn(tx)),
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue({}) } as any;
+    const service = new ContactsService(prisma, audit);
+
+    const merged = await service.mergeContacts({
+      organizationId: 'org1',
+      actorUserId: 'u1',
+      primaryId: 'c1',
+      duplicateId: 'c2',
+    });
+
+    expect(merged).toEqual({ id: 'c1', displayName: 'Jane Doe' });
+    expect(tx.matterParticipant.updateMany).toHaveBeenCalledWith({
+      where: { contactId: 'c2' },
+      data: { contactId: 'c1' },
+    });
+    expect(tx.contactMethod.updateMany).toHaveBeenCalledWith({
+      where: { contactId: 'c2' },
+      data: { contactId: 'c1' },
+    });
+    expect(tx.contactRelationship.updateMany).toHaveBeenCalledTimes(2);
+    expect(tx.externalReference.updateMany).toHaveBeenCalledWith({
+      where: { organizationId: 'org1', entityType: 'contact', entityId: 'c2' },
+      data: { entityId: 'c1' },
+    });
+    expect(tx.contact.delete).toHaveBeenCalledWith({ where: { id: 'c2' } });
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'contact.merged',
+        entityType: 'contact',
+        entityId: 'c1',
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'contact.dedupe.merged',
+        entityType: 'contactDedupe',
+        entityId: 'c1::c2',
+      }),
+    );
+  });
+});

--- a/apps/web/app/contacts/page.tsx
+++ b/apps/web/app/contacts/page.tsx
@@ -13,16 +13,45 @@ type Contact = {
   primaryPhone?: string;
 };
 
+type DedupeSuggestion = {
+  primaryId: string;
+  duplicateId: string;
+  pairKey: string;
+  score: number;
+  confidence: 'HIGH' | 'MEDIUM' | 'LOW';
+  decision: 'OPEN' | 'IGNORE' | 'DEFER';
+  reasons: string[];
+  primary: {
+    id: string;
+    displayName: string;
+    kind: 'PERSON' | 'ORGANIZATION';
+    primaryEmail?: string | null;
+    primaryPhone?: string | null;
+    tags?: string[];
+  };
+  duplicate: {
+    id: string;
+    displayName: string;
+    kind: 'PERSON' | 'ORGANIZATION';
+    primaryEmail?: string | null;
+    primaryPhone?: string | null;
+    tags?: string[];
+  };
+  fieldDiffs: Array<{ field: string; primaryValue: string | null; duplicateValue: string | null }>;
+};
+
 export default function ContactsPage() {
   const [contacts, setContacts] = useState<Contact[]>([]);
-  const [dedupe, setDedupe] = useState<Array<{ primaryId: string; duplicateId: string; score: number; reasons: string[] }>>([]);
+  const [dedupe, setDedupe] = useState<DedupeSuggestion[]>([]);
   const [name, setName] = useState('');
   const [kind, setKind] = useState<'PERSON' | 'ORGANIZATION'>('PERSON');
+  const [includeResolved, setIncludeResolved] = useState(false);
+  const [actionKey, setActionKey] = useState<string | null>(null);
 
   async function load() {
     const [contactData, dedupeData] = await Promise.all([
       apiFetch<Contact[]>('/contacts'),
-      apiFetch<Array<{ primaryId: string; duplicateId: string; score: number; reasons: string[] }>>('/contacts/dedupe/suggestions'),
+      apiFetch<DedupeSuggestion[]>('/contacts/dedupe/suggestions'),
     ]);
     setContacts(contactData);
     setDedupe(dedupeData);
@@ -42,13 +71,44 @@ export default function ContactsPage() {
     await load();
   }
 
-  async function merge(primaryId: string, duplicateId: string) {
-    await apiFetch('/contacts/dedupe/merge', {
-      method: 'POST',
-      body: JSON.stringify({ primaryId, duplicateId }),
-    });
-    await load();
+  async function merge(item: DedupeSuggestion) {
+    const confirmed = window.confirm(
+      `Merge ${item.duplicate.displayName} into ${item.primary.displayName}? This cannot be automatically undone.`,
+    );
+    if (!confirmed) return;
+    const key = `${item.pairKey}:merge`;
+    setActionKey(key);
+    try {
+      await apiFetch('/contacts/dedupe/merge', {
+        method: 'POST',
+        body: JSON.stringify({ primaryId: item.primaryId, duplicateId: item.duplicateId }),
+      });
+      await load();
+    } finally {
+      setActionKey(null);
+    }
   }
+
+  async function decision(item: DedupeSuggestion, nextDecision: 'OPEN' | 'IGNORE' | 'DEFER') {
+    const label = nextDecision === 'IGNORE' ? 'ignore' : nextDecision === 'DEFER' ? 'defer' : 'reopen';
+    const confirmed = window.confirm(
+      `Confirm ${label} decision for duplicate pair ${item.primary.displayName} ↔ ${item.duplicate.displayName}?`,
+    );
+    if (!confirmed) return;
+    const key = `${item.pairKey}:${nextDecision}`;
+    setActionKey(key);
+    try {
+      await apiFetch('/contacts/dedupe/decisions', {
+        method: 'POST',
+        body: JSON.stringify({ primaryId: item.primaryId, duplicateId: item.duplicateId, decision: nextDecision }),
+      });
+      await load();
+    } finally {
+      setActionKey(null);
+    }
+  }
+
+  const visibleDedupe = includeResolved ? dedupe : dedupe.filter((item) => item.decision === 'OPEN');
 
   return (
     <AppShell>
@@ -92,17 +152,73 @@ export default function ContactsPage() {
 
         <div className="card">
           <h3 style={{ marginTop: 0 }}>Dedupe Suggestions</h3>
-          {dedupe.length === 0 ? <p>No suggestions</p> : null}
-          {dedupe.map((item) => (
+          <label style={{ display: 'inline-flex', gap: 8, alignItems: 'center', marginBottom: 8 }}>
+            <input type="checkbox" checked={includeResolved} onChange={(e) => setIncludeResolved(e.target.checked)} />
+            Show deferred/ignored pairs
+          </label>
+          {visibleDedupe.length === 0 ? <p>No suggestions</p> : null}
+          {visibleDedupe.map((item) => (
             <div key={`${item.primaryId}-${item.duplicateId}`} style={{ marginBottom: 8 }}>
               <div>
-                {item.primaryId.slice(0, 8)} ↔ {item.duplicateId.slice(0, 8)} ({Math.round(item.score * 100)}%)
+                {item.primary.displayName} ↔ {item.duplicate.displayName} ({Math.round(item.score * 100)}%)
               </div>
-              <small style={{ color: 'var(--muted)' }}>{item.reasons.join(', ')}</small>
-              <div>
-                <button className="button ghost" style={{ marginTop: 6 }} onClick={() => merge(item.primaryId, item.duplicateId)}>
-                  Merge
+              <small style={{ color: 'var(--muted)' }}>
+                Confidence: {item.confidence} | Status: {item.decision} | {item.reasons.join(', ')}
+              </small>
+              {item.fieldDiffs.length > 0 ? (
+                <table className="table" style={{ marginTop: 6 }}>
+                  <thead>
+                    <tr>
+                      <th>Field</th>
+                      <th>Primary</th>
+                      <th>Duplicate</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {item.fieldDiffs.map((diff) => (
+                      <tr key={`${item.pairKey}:${diff.field}`}>
+                        <td>{diff.field}</td>
+                        <td>{diff.primaryValue || '-'}</td>
+                        <td>{diff.duplicateValue || '-'}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              ) : null}
+              <div style={{ display: 'flex', gap: 8, marginTop: 6 }}>
+                <button
+                  className="button ghost"
+                  onClick={() => merge(item)}
+                  disabled={actionKey !== null}
+                >
+                  {actionKey === `${item.pairKey}:merge` ? 'Merging...' : 'Merge'}
                 </button>
+                {item.decision === 'OPEN' ? (
+                  <>
+                    <button
+                      className="button ghost"
+                      onClick={() => decision(item, 'DEFER')}
+                      disabled={actionKey !== null}
+                    >
+                      {actionKey === `${item.pairKey}:DEFER` ? 'Saving...' : 'Defer'}
+                    </button>
+                    <button
+                      className="button ghost"
+                      onClick={() => decision(item, 'IGNORE')}
+                      disabled={actionKey !== null}
+                    >
+                      {actionKey === `${item.pairKey}:IGNORE` ? 'Saving...' : 'Ignore'}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    className="button ghost"
+                    onClick={() => decision(item, 'OPEN')}
+                    disabled={actionKey !== null}
+                  >
+                    {actionKey === `${item.pairKey}:OPEN` ? 'Saving...' : 'Reopen'}
+                  </button>
+                )}
               </div>
             </div>
           ))}

--- a/apps/web/test/contacts-page.spec.tsx
+++ b/apps/web/test/contacts-page.spec.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ContactsPage from '../app/contacts/page';
+
+function jsonResponse<T>(payload: T, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}
+
+const contactsFixture = [
+  { id: 'c1', kind: 'PERSON', displayName: 'Jane Doe', primaryEmail: 'jane@example.com', primaryPhone: '555-000-1111' },
+  { id: 'c2', kind: 'PERSON', displayName: 'J. Doe', primaryEmail: 'jane.alt@example.com', primaryPhone: '555-000-1111' },
+];
+
+const dedupeOpenFixture = [
+  {
+    primaryId: 'c1',
+    duplicateId: 'c2',
+    pairKey: 'c1::c2',
+    score: 0.9,
+    confidence: 'HIGH',
+    decision: 'OPEN',
+    reasons: ['same phone', 'similar name'],
+    primary: {
+      id: 'c1',
+      displayName: 'Jane Doe',
+      kind: 'PERSON',
+      primaryEmail: 'jane@example.com',
+      primaryPhone: '555-000-1111',
+      tags: [],
+    },
+    duplicate: {
+      id: 'c2',
+      displayName: 'J. Doe',
+      kind: 'PERSON',
+      primaryEmail: 'jane.alt@example.com',
+      primaryPhone: '555-000-1111',
+      tags: [],
+    },
+    fieldDiffs: [
+      { field: 'displayName', primaryValue: 'Jane Doe', duplicateValue: 'J. Doe' },
+      { field: 'primaryEmail', primaryValue: 'jane@example.com', duplicateValue: 'jane.alt@example.com' },
+    ],
+  },
+];
+
+describe('ContactsPage', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts dedupe decision actions and refreshes suggestion list', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(contactsFixture))
+      .mockResolvedValueOnce(jsonResponse(dedupeOpenFixture))
+      .mockResolvedValueOnce(jsonResponse({ pairKey: 'c1::c2', decision: 'IGNORE' }))
+      .mockResolvedValueOnce(jsonResponse(contactsFixture))
+      .mockResolvedValueOnce(jsonResponse([{ ...dedupeOpenFixture[0], decision: 'IGNORE' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ContactsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Jane Doe ↔ J. Doe (90%)')).toBeInTheDocument();
+      expect(screen.getByText('displayName')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ignore' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/contacts/dedupe/decisions',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ primaryId: 'c1', duplicateId: 'c2', decision: 'IGNORE' }),
+        }),
+      );
+    });
+  });
+
+  it('confirms and posts merge actions for dedupe suggestions', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(contactsFixture))
+      .mockResolvedValueOnce(jsonResponse(dedupeOpenFixture))
+      .mockResolvedValueOnce(jsonResponse({ id: 'c1', displayName: 'Jane Doe' }))
+      .mockResolvedValueOnce(jsonResponse([contactsFixture[0]]))
+      .mockResolvedValueOnce(jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ContactsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Merge' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Merge' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/contacts/dedupe/merge',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ primaryId: 'c1', duplicateId: 'c2' }),
+        }),
+      );
+    });
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T03:48:05.074Z`
+- Snapshot Timestamp: `2026-02-17T03:58:59.555Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T03:48:03.803Z`
+- Last Successful Mirror Verify: `2026-02-17T03:58:58.361Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Completed `REQ-PORT-003` with confirmed dedupe workflow (`merge/ignore/defer/reopen`), field-diff candidate UX, dedupe decision API endpoints with audit events, and merge referential-integrity tests plus UI action tests (`docs/parity/dedupe-merge-workflow.md`).
 - 2026-02-17: Completed `REQ-PORT-002` with parity-level Clio CSV/XLSX mapping for contacts/matters/tasks/calendar/activities/notes/phone logs/emails, row-level unmapped-column diagnostics in `warningsJson`, and import batch summary breakdown (`warningCodeCounts`, `unmappedColumnsBySource`) plus coverage tests/artifact `docs/parity/clio-import-coverage.md`.
 - 2026-02-17: Completed `REQ-PORT-001` with expanded MyCase ZIP entity coverage (contacts/companies/matters/tasks/calendar/invoices/payments/time/notes/messages), dependency-safe import ordering, row-level warning/error mapping context in `ImportItem`, and updated fixture/test coverage plus `docs/parity/mycase-import-coverage.md`.
 - 2026-02-17: Completed `REQ-MAT-003` with full construction-intake domain capture (damages/liens/insurance/expert in wizard + API), draft save/resume endpoints and UI flow, and matter dashboard domain completeness indicators with API/Web regression tests.

--- a/docs/parity/dedupe-merge-workflow.md
+++ b/docs/parity/dedupe-merge-workflow.md
@@ -1,0 +1,46 @@
+# Import Dedupe Merge Workflow
+
+Requirement: `REQ-PORT-003`  
+Scope: user-confirm dedupe workflow across API + web UI.
+
+## API Behavior
+
+- `GET /contacts/dedupe/suggestions`
+  - returns candidate pairs with:
+    - confidence score + confidence bucket (`HIGH|MEDIUM|LOW`)
+    - matching reasons
+    - field-level diffs (`displayName`, `kind`, `primaryEmail`, `primaryPhone`, `tags`)
+    - current workflow decision (`OPEN|IGNORE|DEFER`)
+- `POST /contacts/dedupe/merge`
+  - merges duplicate into primary contact.
+  - preserves referential integrity via updates to:
+    - `MatterParticipant`
+    - `ContactMethod`
+    - `ContactRelationship` (`from` and `to`)
+    - `ExternalReference` (`entityType=contact`)
+- `POST /contacts/dedupe/decisions`
+  - records explicit user decision (`OPEN|IGNORE|DEFER`) for a candidate pair.
+
+## Audit Events
+
+- Decision actions:
+  - `contact.dedupe.ignored`
+  - `contact.dedupe.deferred`
+  - `contact.dedupe.reopened`
+- Merge actions:
+  - `contact.merged`
+  - `contact.dedupe.merged`
+
+All events are append-only through `AuditService` and keyed by deterministic pair id (`<contactA>::<contactB>` sorted).
+
+## UI Workflow
+
+- Contacts page dedupe panel now includes:
+  - confidence + decision status
+  - side-by-side field diffs
+  - explicit user-confirm actions:
+    - `Merge`
+    - `Defer`
+    - `Ignore`
+    - `Reopen` (for deferred/ignored pairs)
+- Users can toggle visibility of resolved candidates.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -203,7 +203,7 @@
           "title": "Build user-confirm merge workflow for dedupe suggestions",
           "requirementId": "REQ-PORT-003",
           "promptSection": "Import Framework / Dedupe engine + user-confirm merge UI",
-          "parityStatus": "Partial",
+          "parityStatus": "Complete",
           "component": "Web",
           "risk": "High",
           "labels": ["parity", "migration", "imports", "contacts"],

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T03:48:05.074Z",
+  "generatedAt": "2026-02-17T03:58:59.555Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -24,8 +24,8 @@
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 10,
-      "Partial": 19,
+      "Complete": 11,
+      "Partial": 18,
       "Missing": 5
     },
     "unresolvedCountsByRisk": {
@@ -33,11 +33,11 @@
       "Medium": 17
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:High": 8,
+      "Complete:High": 9,
       "Complete:Medium": 2,
       "Partial:Medium": 10,
-      "Partial:High": 9,
-      "Missing:Medium": 5
+      "Missing:Medium": 5,
+      "Partial:High": 8
     }
   },
   "priority": {
@@ -107,15 +107,6 @@
         "phase": "phase-1"
       },
       {
-        "requirementId": "REQ-PORT-003",
-        "parityStatus": "Partial",
-        "risk": "High",
-        "title": "Build user-confirm merge workflow for dedupe suggestions",
-        "component": "Web",
-        "epicCode": "PARITY-03",
-        "phase": "phase-1"
-      },
-      {
         "requirementId": "REQ-PORTAL-001",
         "parityStatus": "Partial",
         "risk": "High",
@@ -132,6 +123,15 @@
         "component": "Web",
         "epicCode": "PARITY-08",
         "phase": "phase-1"
+      },
+      {
+        "requirementId": "REQ-COMM-001",
+        "parityStatus": "Partial",
+        "risk": "Medium",
+        "title": "Implement production email/SMS providers behind provider interface",
+        "component": "API",
+        "epicCode": "PARITY-05",
+        "phase": "phase-1"
       }
     ]
   },
@@ -140,21 +140,28 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 44,
     "stateCounts": {
-      "Backlog": 28,
+      "Backlog": 27,
       "In Review": 3,
-      "Done": 12,
+      "Done": 13,
       "In Progress": 1
     },
     "inProgressIssueKeys": [
-      "KAR-15"
+      "KAR-16"
     ],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
       {
+        "key": "KAR-16",
+        "title": "Build user-confirm merge workflow for dedupe suggestions",
+        "state": "In Progress",
+        "updatedAt": "2026-02-17T03:58:46.301Z",
+        "requirementId": "REQ-PORT-003"
+      },
+      {
         "key": "KAR-15",
         "title": "Finalize Clio CSV/XLSX template importer coverage",
-        "state": "In Progress",
-        "updatedAt": "2026-02-17T03:47:51.767Z",
+        "state": "Done",
+        "updatedAt": "2026-02-17T03:51:06.319Z",
         "requirementId": "REQ-PORT-002"
       },
       {
@@ -212,32 +219,25 @@
         "state": "Done",
         "updatedAt": "2026-02-16T22:39:11.183Z",
         "requirementId": "REQ-AI-001"
-      },
-      {
-        "key": "KAR-41",
-        "title": "Add web application automated test suite for critical workflows",
-        "state": "Done",
-        "updatedAt": "2026-02-16T22:01:33.254Z",
-        "requirementId": "REQ-OPS-001"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T03:48:03.803Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T03:58:58.361Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "fb66bc6c9afdd0760bc2a169ec748d4c098ea9b4",
+    "gitHead": "02f9691eef84800fc4b6cf3f8d6619ff387561f2",
     "gitStatusShort": [
-      "## lin/KAR-15-clio-template-importer-coverage",
-      " M apps/api/src/imports/imports.service.ts",
-      " M apps/api/src/imports/plugins/clio-template.plugin.ts",
-      " M apps/api/test/imports.spec.ts",
+      "## lin/KAR-16-import-dedupe-merge-workflow",
+      " M apps/api/src/contacts/contacts.controller.ts",
+      " M apps/api/src/contacts/contacts.service.ts",
+      " M apps/web/app/contacts/page.tsx",
       " M docs/SESSION_HANDOFF.md",
       " M tools/backlog-sync/requirements.matrix.json",
-      "?? apps/api/test/fixtures/import-export/clio-template-full.csv",
-      "?? apps/api/test/fixtures/import-export/clio-template.xlsx",
-      "?? docs/parity/clio-import-coverage.md"
+      "?? apps/api/test/contacts-dedupe.spec.ts",
+      "?? apps/web/test/contacts-page.spec.tsx",
+      "?? docs/parity/dedupe-merge-workflow.md"
     ],
     "dirtyFileCount": 8
   }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-16
- URL: https://linear.app/karenap/issue/KAR-16/build-user-confirm-merge-workflow-for-dedupe-suggestions

## Requirement ID
- REQ-PORT-003

## Summary
- Extended dedupe suggestion API payload with confidence, decision status, and field-level diffs.
- Added decision endpoint (`POST /contacts/dedupe/decisions`) for `OPEN|IGNORE|DEFER` and append-only audit events.
- Added merge decision audit event (`contact.dedupe.merged`) and preserved existing referential merge updates.
- Updated Contacts UI to require explicit confirmation for merge/ignore/defer/reopen actions and support resolved-candidate visibility.
- Added API + web tests for dedupe decisions, merge referential integrity, and UI workflow actions.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- test/contacts-dedupe.spec.ts`
  - `pnpm --filter web test -- test/contacts-page.spec.tsx`
  - `pnpm test`
  - `pnpm build`
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - All commands passed.
  - Merge referential integrity is covered by dedicated API tests.

## Notes
- Added workflow artifact: `docs/parity/dedupe-merge-workflow.md`.
