### PR TITLE
[KAR-17] Enforce full backup export conformance checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ Data dictionary page:
 
 - `GET http://localhost:3000/data-dictionary`
 
+Export contract + conformance rules:
+
+- `apps/api/src/exports/full-backup-contract.ts`
+- `docs/parity/export-conformance.md`
+
 ## Tests
 
 Run API tests:

--- a/apps/api/src/exports/exports.service.ts
+++ b/apps/api/src/exports/exports.service.ts
@@ -7,6 +7,34 @@ import { PrismaService } from '../prisma/prisma.service';
 import { AuthenticatedUser } from '../common/types';
 import { S3Service } from '../files/s3.service';
 import { AuditService } from '../audit/audit.service';
+import {
+  FULL_BACKUP_CONTRACT_VERSION,
+  FULL_BACKUP_CSV_CONTRACT,
+  FULL_BACKUP_MANIFEST_FILE,
+  FullBackupManifestEntry,
+  validateFullBackupPackageConformance,
+} from './full-backup-contract';
+
+type FullBackupCsvArtifact = {
+  fileName: string;
+  columns: string[];
+  rowCount: number;
+  content: string;
+};
+
+type FullBackupDocumentArtifact = {
+  path: string;
+  content: Buffer;
+  placeholder: boolean;
+};
+
+type FullBackupBuildResult = {
+  zipBuffer: Buffer;
+  csvFiles: FullBackupCsvArtifact[];
+  documentFiles: FullBackupDocumentArtifact[];
+  manifestEntries: FullBackupManifestEntry[];
+  validation: ReturnType<typeof validateFullBackupPackageConformance>;
+};
 
 @Injectable()
 export class ExportsService {
@@ -34,8 +62,8 @@ export class ExportsService {
     });
 
     try {
-      const zipBuffer = await this.buildFullBackupZip(user.organizationId);
-      const uploaded = await this.s3.upload(zipBuffer, 'application/zip', `org/${user.organizationId}/exports`);
+      const built = await this.buildFullBackupZip(user.organizationId);
+      const uploaded = await this.s3.upload(built.zipBuffer, 'application/zip', `org/${user.organizationId}/exports`);
       const downloadUrl = await this.s3.signedDownloadUrl(uploaded.key, 60 * 60);
 
       await this.prisma.exportJob.update({
@@ -45,7 +73,12 @@ export class ExportsService {
           finishedAt: new Date(),
           storageKey: uploaded.key,
           summaryJson: {
-            sizeBytes: zipBuffer.byteLength,
+            sizeBytes: built.zipBuffer.byteLength,
+            contractVersion: FULL_BACKUP_CONTRACT_VERSION,
+            csvFileCount: built.csvFiles.length,
+            documentFileCount: built.documentFiles.length,
+            manifestEntryCount: built.manifestEntries.length,
+            validation: built.validation,
           },
         },
       });
@@ -76,7 +109,7 @@ export class ExportsService {
     }
   }
 
-  private async buildFullBackupZip(organizationId: string): Promise<Buffer> {
+  private async buildFullBackupZip(organizationId: string): Promise<FullBackupBuildResult> {
     const [
       contacts,
       matters,
@@ -105,44 +138,59 @@ export class ExportsService {
       this.prisma.documentVersion.findMany({ where: { organizationId } }),
     ]);
 
-    const archive = archiver('zip', { zlib: { level: 9 } });
-    const output = new PassThrough();
-    const chunks: Buffer[] = [];
+    const rowsByCsvFile: Record<string, Array<Record<string, unknown>>> = {
+      'contacts.csv': contacts as Array<Record<string, unknown>>,
+      'matters.csv': matters as Array<Record<string, unknown>>,
+      'tasks.csv': tasks as Array<Record<string, unknown>>,
+      'events.csv': events as Array<Record<string, unknown>>,
+      'time_entries.csv': timeEntries as Array<Record<string, unknown>>,
+      'invoices.csv': invoices as Array<Record<string, unknown>>,
+      'payments.csv': payments as Array<Record<string, unknown>>,
+      'messages.csv': messages as Array<Record<string, unknown>>,
+      'notes.csv': notes as Array<Record<string, unknown>>,
+      'custom_fields.csv': customFields as Array<Record<string, unknown>>,
+    };
 
-    output.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
-    archive.pipe(output);
+    const csvFiles = FULL_BACKUP_CSV_CONTRACT.map((contract) => {
+      const rows = rowsByCsvFile[contract.fileName] || [];
+      const columns = this.resolveColumns(rows, contract.requiredColumns);
+      return {
+        fileName: contract.fileName,
+        columns,
+        rowCount: rows.length,
+        content: this.toCsv(rows, columns),
+      };
+    });
 
-    archive.append(this.toCsv(contacts), { name: 'contacts.csv' });
-    archive.append(this.toCsv(matters), { name: 'matters.csv' });
-    archive.append(this.toCsv(tasks), { name: 'tasks.csv' });
-    archive.append(this.toCsv(events), { name: 'events.csv' });
-    archive.append(this.toCsv(timeEntries), { name: 'time_entries.csv' });
-    archive.append(this.toCsv(invoices), { name: 'invoices.csv' });
-    archive.append(this.toCsv(payments), { name: 'payments.csv' });
-    archive.append(this.toCsv(messages), { name: 'messages.csv' });
-    archive.append(this.toCsv(notes), { name: 'notes.csv' });
-    archive.append(this.toCsv(customFields), { name: 'custom_fields.csv' });
-
-    const manifest: Array<{
-      documentId: string;
-      documentVersionId: string;
-      path: string;
-      matterId: string;
-      title: string;
-    }> = [];
+    const documentById = new Map(documents.map((item) => [item.id, item]));
+    const documentFiles: FullBackupDocumentArtifact[] = [];
+    const manifest: FullBackupManifestEntry[] = [];
+    const archivePaths = new Set<string>(csvFiles.map((item) => item.fileName));
 
     for (const version of documentVersions) {
-      const document = documents.find((item) => item.id === version.documentId);
+      const document = documentById.get(version.documentId);
       if (!document) continue;
       const filename = `${document.title.replace(/[^a-z0-9-_]/gi, '_').slice(0, 80)}-${version.id}`;
-      const path = `documents/${document.matterId}/${filename}`;
+      const basePath = `documents/${document.matterId}/${filename}`;
+
+      let path = basePath;
+      let content: Buffer;
+      let placeholder = false;
 
       try {
-        const content = await this.s3.getObjectBuffer(version.storageKey);
-        archive.append(content, { name: path });
+        content = await this.s3.getObjectBuffer(version.storageKey);
       } catch {
-        archive.append(Buffer.from('Document blob not available in export environment.'), { name: `${path}.txt` });
+        placeholder = true;
+        path = `${basePath}.missing.txt`;
+        content = Buffer.from('Document blob not available in export environment.');
       }
+
+      documentFiles.push({
+        path,
+        content,
+        placeholder,
+      });
+      archivePaths.add(path);
 
       manifest.push({
         documentId: document.id,
@@ -150,32 +198,94 @@ export class ExportsService {
         path,
         matterId: document.matterId,
         title: document.title,
+        storageKey: version.storageKey,
+        mimeType: version.mimeType,
+        size: version.size,
+        sha256: version.sha256,
+        placeholder,
       });
     }
 
-    archive.append(JSON.stringify(manifest, null, 2), { name: 'documents/manifest.json' });
+    archivePaths.add(FULL_BACKUP_MANIFEST_FILE);
+    const validation = validateFullBackupPackageConformance({
+      csvColumnsByFile: Object.fromEntries(csvFiles.map((item) => [item.fileName, item.columns])),
+      manifestEntries: manifest,
+      archivePaths,
+    });
 
-    await archive.finalize();
-    await new Promise<void>((resolve, reject) => {
+    if (!validation.valid) {
+      const summary = validation.issues
+        .slice(0, 5)
+        .map((issue) => issue.message)
+        .join('; ');
+      throw new Error(
+        `Full backup package failed conformance checks (${validation.issues.length} issues): ${summary}`,
+      );
+    }
+
+    const archive = archiver('zip', { zlib: { level: 9 } });
+    const output = new PassThrough();
+    const chunks: Buffer[] = [];
+
+    output.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+    archive.pipe(output);
+
+    const archiveCompletion = new Promise<void>((resolve, reject) => {
+      output.on('close', () => resolve());
       output.on('end', () => resolve());
       output.on('error', reject);
       archive.on('error', reject);
     });
 
-    return Buffer.concat(chunks);
-  }
-
-  private toCsv(rows: object[]): string {
-    if (rows.length === 0) {
-      return '';
+    for (const csvFile of csvFiles) {
+      archive.append(csvFile.content, { name: csvFile.fileName });
     }
 
-    return stringify(rows, {
+    for (const documentFile of documentFiles) {
+      archive.append(documentFile.content, { name: documentFile.path });
+    }
+
+    archive.append(JSON.stringify(manifest, null, 2), { name: FULL_BACKUP_MANIFEST_FILE });
+
+    await archive.finalize();
+    await archiveCompletion;
+
+    return {
+      zipBuffer: Buffer.concat(chunks),
+      csvFiles,
+      documentFiles,
+      manifestEntries: manifest,
+      validation,
+    };
+  }
+
+  private toCsv(rows: Array<Record<string, unknown>>, columns: string[]): string {
+    const normalized = rows.map((row) => this.normalizeCsvRow(row, columns));
+    return stringify(normalized, {
       header: true,
-      columns: Object.keys(rows[0]),
+      columns,
       cast: {
         object: (value) => JSON.stringify(value),
       },
     });
+  }
+
+  private resolveColumns(rows: Array<Record<string, unknown>>, requiredColumns: string[]): string[] {
+    const dynamicColumns = new Set<string>();
+    for (const row of rows) {
+      for (const column of Object.keys(row)) {
+        dynamicColumns.add(column);
+      }
+    }
+
+    return [...requiredColumns, ...Array.from(dynamicColumns).filter((column) => !requiredColumns.includes(column))];
+  }
+
+  private normalizeCsvRow(row: Record<string, unknown>, columns: string[]) {
+    const normalized: Record<string, unknown> = {};
+    for (const column of columns) {
+      normalized[column] = column in row ? row[column] : null;
+    }
+    return normalized;
   }
 }

--- a/apps/api/src/exports/full-backup-contract.ts
+++ b/apps/api/src/exports/full-backup-contract.ts
@@ -1,0 +1,312 @@
+export const FULL_BACKUP_CONTRACT_VERSION = '1.0.0';
+
+export type FullBackupCsvContract = {
+  fileName: string;
+  requiredColumns: string[];
+};
+
+export const FULL_BACKUP_CSV_CONTRACT: FullBackupCsvContract[] = [
+  {
+    fileName: 'contacts.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'kind',
+      'displayName',
+      'primaryEmail',
+      'primaryPhone',
+      'tags',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'matters.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'matterNumber',
+      'name',
+      'practiceArea',
+      'jurisdiction',
+      'venue',
+      'stageId',
+      'matterTypeId',
+      'status',
+      'ethicalWallEnabled',
+      'openedAt',
+      'closedAt',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'tasks.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'matterId',
+      'title',
+      'description',
+      'assigneeUserId',
+      'dueAt',
+      'priority',
+      'status',
+      'checklistJson',
+      'dependenciesJson',
+      'createdByUserId',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'events.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'matterId',
+      'startAt',
+      'endAt',
+      'type',
+      'location',
+      'attendeesJson',
+      'description',
+      'source',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'time_entries.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'matterId',
+      'userId',
+      'description',
+      'startedAt',
+      'endedAt',
+      'durationMinutes',
+      'billableRate',
+      'amount',
+      'utbmsPhaseCode',
+      'utbmsTaskCode',
+      'status',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'invoices.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'matterId',
+      'invoiceNumber',
+      'status',
+      'issuedAt',
+      'dueAt',
+      'subtotal',
+      'tax',
+      'total',
+      'balanceDue',
+      'notes',
+      'jurisdictionDisclaimer',
+      'pdfStorageKey',
+      'stripeCheckoutUrl',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'payments.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'invoiceId',
+      'amount',
+      'method',
+      'stripePaymentIntentId',
+      'receivedAt',
+      'reference',
+      'rawSourcePayload',
+      'createdAt',
+    ],
+  },
+  {
+    fileName: 'messages.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'threadId',
+      'type',
+      'direction',
+      'subject',
+      'body',
+      'occurredAt',
+      'createdByUserId',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'notes.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'threadId',
+      'type',
+      'direction',
+      'subject',
+      'body',
+      'occurredAt',
+      'createdByUserId',
+      'rawSourcePayload',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+  {
+    fileName: 'custom_fields.csv',
+    requiredColumns: [
+      'id',
+      'organizationId',
+      'entityType',
+      'entityId',
+      'fieldDefinitionId',
+      'valueJson',
+      'createdAt',
+      'updatedAt',
+    ],
+  },
+];
+
+export const FULL_BACKUP_MANIFEST_FILE = 'documents/manifest.json';
+const MANIFEST_REQUIRED_FIELDS = ['documentId', 'documentVersionId', 'path', 'matterId', 'title'] as const;
+
+export type FullBackupManifestEntry = {
+  documentId: string;
+  documentVersionId: string;
+  path: string;
+  matterId: string;
+  title: string;
+  storageKey?: string;
+  mimeType?: string;
+  size?: number;
+  sha256?: string;
+  placeholder?: boolean;
+};
+
+export type FullBackupValidationIssueCode =
+  | 'missing_required_file'
+  | 'missing_required_column'
+  | 'manifest_missing_field'
+  | 'manifest_invalid_path'
+  | 'manifest_missing_blob';
+
+export type FullBackupValidationIssue = {
+  code: FullBackupValidationIssueCode;
+  file?: string;
+  field?: string;
+  entryIndex?: number;
+  message: string;
+};
+
+export type FullBackupValidationResult = {
+  valid: boolean;
+  contractVersion: string;
+  checkedAt: string;
+  issues: FullBackupValidationIssue[];
+};
+
+export function validateFullBackupPackageConformance(input: {
+  csvColumnsByFile: Record<string, string[]>;
+  manifestEntries: FullBackupManifestEntry[];
+  archivePaths: Iterable<string>;
+}): FullBackupValidationResult {
+  const issues: FullBackupValidationIssue[] = [];
+  const archivePaths = new Set(input.archivePaths);
+
+  for (const contract of FULL_BACKUP_CSV_CONTRACT) {
+    if (!archivePaths.has(contract.fileName) || !input.csvColumnsByFile[contract.fileName]) {
+      issues.push({
+        code: 'missing_required_file',
+        file: contract.fileName,
+        message: `Missing required export file: ${contract.fileName}`,
+      });
+      continue;
+    }
+
+    const actualColumns = new Set(input.csvColumnsByFile[contract.fileName]);
+    for (const column of contract.requiredColumns) {
+      if (!actualColumns.has(column)) {
+        issues.push({
+          code: 'missing_required_column',
+          file: contract.fileName,
+          field: column,
+          message: `Missing required column "${column}" in ${contract.fileName}`,
+        });
+      }
+    }
+  }
+
+  if (!archivePaths.has(FULL_BACKUP_MANIFEST_FILE)) {
+    issues.push({
+      code: 'missing_required_file',
+      file: FULL_BACKUP_MANIFEST_FILE,
+      message: `Missing required export file: ${FULL_BACKUP_MANIFEST_FILE}`,
+    });
+  }
+
+  input.manifestEntries.forEach((entry, entryIndex) => {
+    MANIFEST_REQUIRED_FIELDS.forEach((field) => {
+      const value = entry[field];
+      if (typeof value !== 'string' || value.trim().length === 0) {
+        issues.push({
+          code: 'manifest_missing_field',
+          file: FULL_BACKUP_MANIFEST_FILE,
+          field,
+          entryIndex,
+          message: `Manifest entry ${entryIndex} missing required field "${field}"`,
+        });
+      }
+    });
+
+    const path = entry.path;
+    if (typeof path === 'string') {
+      if (!path.startsWith('documents/') || path.includes('..')) {
+        issues.push({
+          code: 'manifest_invalid_path',
+          file: FULL_BACKUP_MANIFEST_FILE,
+          field: 'path',
+          entryIndex,
+          message: `Manifest entry ${entryIndex} has invalid path "${path}"`,
+        });
+      }
+
+      if (!archivePaths.has(path)) {
+        issues.push({
+          code: 'manifest_missing_blob',
+          file: FULL_BACKUP_MANIFEST_FILE,
+          field: 'path',
+          entryIndex,
+          message: `Manifest entry ${entryIndex} references missing file "${path}"`,
+        });
+      }
+    }
+  });
+
+  return {
+    valid: issues.length === 0,
+    contractVersion: FULL_BACKUP_CONTRACT_VERSION,
+    checkedAt: new Date().toISOString(),
+    issues,
+  };
+}

--- a/apps/api/test/exports-conformance.spec.ts
+++ b/apps/api/test/exports-conformance.spec.ts
@@ -1,0 +1,235 @@
+import AdmZip from 'adm-zip';
+import { parse } from 'csv-parse/sync';
+import { ExportsService } from '../src/exports/exports.service';
+import {
+  FULL_BACKUP_CONTRACT_VERSION,
+  FULL_BACKUP_CSV_CONTRACT,
+  FULL_BACKUP_MANIFEST_FILE,
+  validateFullBackupPackageConformance,
+} from '../src/exports/full-backup-contract';
+
+describe('ExportsService full backup conformance', () => {
+  it('builds a contract-conformant full backup package and tracks validation metadata', async () => {
+    const jobUpdates: any[] = [];
+    let uploadedBuffer: Buffer | null = null;
+
+    const prisma = {
+      exportJob: {
+        create: jest.fn().mockResolvedValue({ id: 'job-1' }),
+        update: jest.fn().mockImplementation(async (payload) => {
+          jobUpdates.push(payload);
+          return payload;
+        }),
+      },
+      contact: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'contact-1',
+            organizationId: 'org-1',
+            kind: 'PERSON',
+            displayName: 'Elena Homeowner',
+            primaryEmail: 'elena@example.com',
+            primaryPhone: '555-111-2222',
+            tags: ['client'],
+            rawSourcePayload: null,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+          },
+        ]),
+      },
+      matter: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'matter-1',
+            organizationId: 'org-1',
+            matterNumber: 'MAT-001',
+            name: 'Roofing dispute',
+            practiceArea: 'Construction Litigation',
+            jurisdiction: 'CA',
+            venue: 'Orange County',
+            stageId: null,
+            matterTypeId: null,
+            status: 'OPEN',
+            ethicalWallEnabled: false,
+            openedAt: new Date('2026-01-05T00:00:00.000Z'),
+            closedAt: null,
+            rawSourcePayload: null,
+            createdAt: new Date('2026-01-05T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-06T00:00:00.000Z'),
+          },
+        ]),
+      },
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      calendarEvent: { findMany: jest.fn().mockResolvedValue([]) },
+      timeEntry: { findMany: jest.fn().mockResolvedValue([]) },
+      invoice: { findMany: jest.fn().mockResolvedValue([]) },
+      payment: { findMany: jest.fn().mockResolvedValue([]) },
+      communicationMessage: {
+        findMany: jest
+          .fn()
+          .mockResolvedValueOnce([
+            {
+              id: 'message-1',
+              organizationId: 'org-1',
+              threadId: 'thread-1',
+              type: 'EMAIL',
+              direction: 'OUTBOUND',
+              subject: 'Status update',
+              body: 'Update body',
+              occurredAt: new Date('2026-01-10T00:00:00.000Z'),
+              createdByUserId: 'user-1',
+              rawSourcePayload: null,
+              createdAt: new Date('2026-01-10T00:00:00.000Z'),
+              updatedAt: new Date('2026-01-10T00:00:00.000Z'),
+            },
+          ])
+          .mockResolvedValueOnce([
+            {
+              id: 'note-1',
+              organizationId: 'org-1',
+              threadId: 'thread-2',
+              type: 'INTERNAL_NOTE',
+              direction: 'INTERNAL',
+              subject: 'Case note',
+              body: 'Note body',
+              occurredAt: new Date('2026-01-11T00:00:00.000Z'),
+              createdByUserId: 'user-1',
+              rawSourcePayload: null,
+              createdAt: new Date('2026-01-11T00:00:00.000Z'),
+              updatedAt: new Date('2026-01-11T00:00:00.000Z'),
+            },
+          ]),
+      },
+      customFieldValue: { findMany: jest.fn().mockResolvedValue([]) },
+      document: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'document-1',
+            organizationId: 'org-1',
+            matterId: 'matter-1',
+            title: 'Scope Agreement',
+          },
+          {
+            id: 'document-2',
+            organizationId: 'org-1',
+            matterId: 'matter-1',
+            title: 'Inspection Photos',
+          },
+        ]),
+      },
+      documentVersion: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'version-1',
+            organizationId: 'org-1',
+            documentId: 'document-1',
+            storageKey: 'docs/version-1',
+            sha256: 'abc123',
+            mimeType: 'application/pdf',
+            size: 512,
+          },
+          {
+            id: 'version-2',
+            organizationId: 'org-1',
+            documentId: 'document-2',
+            storageKey: 'docs/version-2',
+            sha256: 'def456',
+            mimeType: 'image/jpeg',
+            size: 1024,
+          },
+        ]),
+      },
+    } as any;
+
+    const s3 = {
+      upload: jest.fn().mockImplementation(async (buffer: Buffer) => {
+        uploadedBuffer = buffer;
+        return { key: 'org/org-1/exports/export.zip' };
+      }),
+      signedDownloadUrl: jest.fn().mockResolvedValue('https://download.local/export.zip'),
+      getObjectBuffer: jest.fn().mockImplementation(async (key: string) => {
+        if (key === 'docs/version-1') {
+          return Buffer.from('present-document');
+        }
+        throw new Error('blob missing');
+      }),
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new ExportsService(prisma, s3, audit);
+
+    const result = await service.runFullBackup({ id: 'user-1', organizationId: 'org-1' } as any);
+
+    expect(result.jobId).toBe('job-1');
+    expect(result.downloadUrl).toBe('https://download.local/export.zip');
+    expect(uploadedBuffer).not.toBeNull();
+    if (!uploadedBuffer) {
+      throw new Error('Expected upload buffer to be present');
+    }
+
+    const zip = new AdmZip(uploadedBuffer);
+    const zipEntries = zip.getEntries().map((entry) => entry.entryName);
+
+    for (const contract of FULL_BACKUP_CSV_CONTRACT) {
+      expect(zipEntries).toContain(contract.fileName);
+      const csvText = zip.readAsText(contract.fileName);
+      const header = parse(csvText, { to_line: 1 })[0] as string[];
+      for (const column of contract.requiredColumns) {
+        expect(header).toContain(column);
+      }
+    }
+
+    expect(zipEntries).toContain(FULL_BACKUP_MANIFEST_FILE);
+    const manifest = JSON.parse(zip.readAsText(FULL_BACKUP_MANIFEST_FILE)) as Array<Record<string, unknown>>;
+    expect(manifest).toHaveLength(2);
+    manifest.forEach((entry) => {
+      expect(typeof entry.path).toBe('string');
+      expect(zipEntries).toContain(String(entry.path));
+    });
+
+    const missingEntry = manifest.find((entry) => entry.documentVersionId === 'version-2');
+    expect(String(missingEntry?.path)).toMatch(/\.missing\.txt$/);
+    expect(missingEntry?.placeholder).toBe(true);
+
+    const completionUpdate = jobUpdates.find((item) => item.data?.status === 'COMPLETED');
+    expect(completionUpdate).toBeTruthy();
+    expect(completionUpdate.data.summaryJson).toMatchObject({
+      contractVersion: FULL_BACKUP_CONTRACT_VERSION,
+      validation: expect.objectContaining({
+        valid: true,
+      }),
+      csvFileCount: FULL_BACKUP_CSV_CONTRACT.length,
+      documentFileCount: 2,
+      manifestEntryCount: 2,
+    });
+  });
+
+  it('reports validation errors for missing files, columns, and invalid manifest references', async () => {
+    const result = validateFullBackupPackageConformance({
+      csvColumnsByFile: {
+        'contacts.csv': ['id'],
+      },
+      manifestEntries: [
+        {
+          documentId: '',
+          documentVersionId: 'dv-1',
+          path: '../outside/path',
+          matterId: '',
+          title: '',
+        },
+      ],
+      archivePaths: ['contacts.csv', FULL_BACKUP_MANIFEST_FILE],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing_required_file' }),
+        expect.objectContaining({ code: 'missing_required_column', file: 'contacts.csv' }),
+        expect.objectContaining({ code: 'manifest_missing_field' }),
+        expect.objectContaining({ code: 'manifest_invalid_path' }),
+        expect.objectContaining({ code: 'manifest_missing_blob' }),
+      ]),
+    );
+  });
+});

--- a/apps/api/test/roundtrip.spec.ts
+++ b/apps/api/test/roundtrip.spec.ts
@@ -1,8 +1,10 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import AdmZip from 'adm-zip';
 import { parse } from 'csv-parse/sync';
 import { stringify } from 'csv-stringify/sync';
 import { ImportsService } from '../src/imports/imports.service';
+import { ExportsService } from '../src/exports/exports.service';
 
 describe('Import/Export roundtrip fixture', () => {
   it('imports generic CSV contacts and exports canonical contacts CSV rows', async () => {
@@ -61,5 +63,80 @@ describe('Import/Export roundtrip fixture', () => {
     const exported = stringify(contacts, { header: true });
     const expected = readFileSync(join(__dirname, 'fixtures/import-export/expected-generic-roundtrip.csv'), 'utf8');
     expect(exported.trim()).toBe(expected.trim());
+
+    let uploadedBuffer: Buffer | null = null;
+
+    const exportPrisma = {
+      exportJob: {
+        create: jest.fn().mockResolvedValue({ id: 'export-job-1' }),
+        update: jest.fn().mockResolvedValue({ id: 'export-job-1' }),
+      },
+      contact: {
+        findMany: jest.fn().mockResolvedValue(
+          contacts.map((contact) => ({
+            id: contact.id,
+            organizationId: 'org1',
+            kind: 'PERSON',
+            displayName: contact.displayName,
+            primaryEmail: contact.primaryEmail,
+            primaryPhone: contact.primaryPhone,
+            tags: [],
+            rawSourcePayload: null,
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          })),
+        ),
+      },
+      matter: { findMany: jest.fn().mockResolvedValue([]) },
+      task: { findMany: jest.fn().mockResolvedValue([]) },
+      calendarEvent: { findMany: jest.fn().mockResolvedValue([]) },
+      timeEntry: { findMany: jest.fn().mockResolvedValue([]) },
+      invoice: { findMany: jest.fn().mockResolvedValue([]) },
+      payment: { findMany: jest.fn().mockResolvedValue([]) },
+      communicationMessage: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      customFieldValue: { findMany: jest.fn().mockResolvedValue([]) },
+      document: { findMany: jest.fn().mockResolvedValue([]) },
+      documentVersion: { findMany: jest.fn().mockResolvedValue([]) },
+    } as any;
+
+    const exportsService = new ExportsService(
+      exportPrisma,
+      {
+        upload: jest.fn().mockImplementation(async (buffer: Buffer) => {
+          uploadedBuffer = buffer;
+          return { key: 'org/org1/exports/export-1.zip' };
+        }),
+        signedDownloadUrl: jest.fn().mockResolvedValue('https://download.local/export-1.zip'),
+        getObjectBuffer: jest.fn(),
+      } as any,
+      { appendEvent: jest.fn() } as any,
+    );
+
+    await exportsService.runFullBackup({ id: 'user1', organizationId: 'org1' } as any);
+
+    if (!uploadedBuffer) {
+      throw new Error('Expected upload buffer to be present');
+    }
+
+    const zip = new AdmZip(uploadedBuffer);
+    const contactsCsv = zip.readAsText('contacts.csv');
+    const exportedRows = parse(contactsCsv, { columns: true, skip_empty_lines: true }) as Array<
+      Record<string, string>
+    >;
+
+    expect(exportedRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          displayName: 'Jane Doe',
+          primaryEmail: 'jane@example.com',
+        }),
+        expect.objectContaining({
+          displayName: 'John Doe',
+          primaryEmail: 'john@example.com',
+        }),
+      ]),
+    );
   });
 });

--- a/apps/web/app/data-dictionary/page.tsx
+++ b/apps/web/app/data-dictionary/page.tsx
@@ -2,17 +2,61 @@ import { AppShell } from '../../components/app-shell';
 import { PageHeader } from '../../components/page-header';
 
 const ROWS = [
-  ['contacts.csv', 'Unified contacts (person/org), tags, primary methods'],
-  ['matters.csv', 'Matter core data including stage, type, status'],
-  ['tasks.csv', 'Task records with due dates, status, assignees'],
-  ['events.csv', 'Calendar and deadline-related events'],
-  ['time_entries.csv', 'Billable/non-billable time capture'],
-  ['invoices.csv', 'Invoices and financial totals'],
-  ['payments.csv', 'Payment records (manual/stripe)'],
-  ['messages.csv', 'Communications excluding internal notes'],
-  ['notes.csv', 'Internal notes and memo-style communications'],
-  ['custom_fields.csv', 'Custom field values by entity'],
-  ['documents/manifest.json', 'Links document files to records and matter folders'],
+  {
+    file: 'contacts.csv',
+    description: 'Unified contacts (person/org), tags, and primary methods.',
+    requiredColumns: 'id, organizationId, kind, displayName, primaryEmail, primaryPhone',
+  },
+  {
+    file: 'matters.csv',
+    description: 'Matter core data including stage, type, status, and ethical wall flag.',
+    requiredColumns: 'id, organizationId, matterNumber, name, practiceArea, status, openedAt',
+  },
+  {
+    file: 'tasks.csv',
+    description: 'Task records with due dates, assignees, checklist/dependency JSON.',
+    requiredColumns: 'id, organizationId, matterId, title, dueAt, priority, status',
+  },
+  {
+    file: 'events.csv',
+    description: 'Calendar/deadline events with attendance and location fields.',
+    requiredColumns: 'id, organizationId, matterId, startAt, endAt, type, location',
+  },
+  {
+    file: 'time_entries.csv',
+    description: 'Billable/non-billable time capture with UTBMS support fields.',
+    requiredColumns: 'id, organizationId, matterId, startedAt, durationMinutes, amount, status',
+  },
+  {
+    file: 'invoices.csv',
+    description: 'Invoice header records including totals, balances, and checkout URL.',
+    requiredColumns: 'id, organizationId, matterId, invoiceNumber, status, total, balanceDue',
+  },
+  {
+    file: 'payments.csv',
+    description: 'Payment records (manual/stripe) linked to invoices.',
+    requiredColumns: 'id, organizationId, invoiceId, amount, method, receivedAt',
+  },
+  {
+    file: 'messages.csv',
+    description: 'Communications excluding internal notes.',
+    requiredColumns: 'id, organizationId, threadId, type, direction, body, occurredAt',
+  },
+  {
+    file: 'notes.csv',
+    description: 'Internal notes and memo-style communications.',
+    requiredColumns: 'id, organizationId, threadId, type, direction, body, occurredAt',
+  },
+  {
+    file: 'custom_fields.csv',
+    description: 'Custom field values by entity with definition linkage.',
+    requiredColumns: 'id, organizationId, entityType, entityId, fieldDefinitionId, valueJson',
+  },
+  {
+    file: 'documents/manifest.json',
+    description: 'Links document files to records and matter folders.',
+    requiredColumns: 'documentId, documentVersionId, path, matterId, title',
+  },
 ];
 
 export default function DataDictionaryPage() {
@@ -25,13 +69,15 @@ export default function DataDictionaryPage() {
             <tr>
               <th>File</th>
               <th>Description</th>
+              <th>Required Columns</th>
             </tr>
           </thead>
           <tbody>
-            {ROWS.map(([file, description]) => (
-              <tr key={file}>
-                <td>{file}</td>
-                <td>{description}</td>
+            {ROWS.map((row) => (
+              <tr key={row.file}>
+                <td>{row.file}</td>
+                <td>{row.description}</td>
+                <td>{row.requiredColumns}</td>
               </tr>
             ))}
           </tbody>

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T03:58:59.555Z`
+- Snapshot Timestamp: `2026-02-17T04:19:11.136Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T03:58:58.361Z`
+- Last Successful Mirror Verify: `2026-02-17T04:19:09.936Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Completed `REQ-PORT-004` with a strict full-backup export contract (required files/columns + manifest schema/path checks), conformance-aware export job summaries, placeholder manifest-path integrity for missing document blobs, and new conformance/roundtrip regression coverage (`docs/parity/export-conformance.md`).
 - 2026-02-17: Completed `REQ-PORT-003` with confirmed dedupe workflow (`merge/ignore/defer/reopen`), field-diff candidate UX, dedupe decision API endpoints with audit events, and merge referential-integrity tests plus UI action tests (`docs/parity/dedupe-merge-workflow.md`).
 - 2026-02-17: Completed `REQ-PORT-002` with parity-level Clio CSV/XLSX mapping for contacts/matters/tasks/calendar/activities/notes/phone logs/emails, row-level unmapped-column diagnostics in `warningsJson`, and import batch summary breakdown (`warningCodeCounts`, `unmappedColumnsBySource`) plus coverage tests/artifact `docs/parity/clio-import-coverage.md`.
 - 2026-02-17: Completed `REQ-PORT-001` with expanded MyCase ZIP entity coverage (contacts/companies/matters/tasks/calendar/invoices/payments/time/notes/messages), dependency-safe import ordering, row-level warning/error mapping context in `ImportItem`, and updated fixture/test coverage plus `docs/parity/mycase-import-coverage.md`.

--- a/docs/parity/export-conformance.md
+++ b/docs/parity/export-conformance.md
@@ -1,0 +1,45 @@
+# Export Conformance Coverage (REQ-PORT-004)
+
+This artifact records full-backup export conformance checks for portability parity.
+
+## Contract Coverage
+
+- Required files are enforced for every full backup:
+  - `contacts.csv`
+  - `matters.csv`
+  - `tasks.csv`
+  - `events.csv`
+  - `time_entries.csv`
+  - `invoices.csv`
+  - `payments.csv`
+  - `messages.csv`
+  - `notes.csv`
+  - `custom_fields.csv`
+  - `documents/manifest.json`
+- Required columns are enforced per CSV file via `apps/api/src/exports/full-backup-contract.ts`.
+- Manifest schema checks enforce required fields:
+  - `documentId`
+  - `documentVersionId`
+  - `path`
+  - `matterId`
+  - `title`
+- Manifest paths must remain under `documents/` and resolve to an actual ZIP entry.
+
+## Runtime Behavior
+
+- `POST /exports/full-backup` now validates package conformance before completing the job.
+- Export job `summaryJson` records:
+  - contract version
+  - validation result and issues
+  - CSV/document/manifest counts
+- Missing document blobs are exported as placeholder text files and mapped in `manifest.json` to preserve path integrity.
+
+## Test Evidence
+
+- `apps/api/test/exports-conformance.spec.ts`
+  - validates required file/column presence in produced ZIP
+  - validates manifest-to-ZIP path linkage
+  - validates placeholder-path behavior when document blob retrieval fails
+  - validates conformance error reporting for malformed packages
+- `apps/api/test/roundtrip.spec.ts`
+  - validates generic contacts import can be exported into canonical full backup contacts CSV (roundtrip coherence)

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -224,7 +224,7 @@
           "title": "Implement full backup export package conformance checks",
           "requirementId": "REQ-PORT-004",
           "promptSection": "Export / Exit Strategy",
-          "parityStatus": "Partial",
+          "parityStatus": "Complete",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "migration", "exports"],

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T03:58:59.555Z",
+  "generatedAt": "2026-02-17T04:19:11.136Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -24,8 +24,8 @@
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 11,
-      "Partial": 18,
+      "Complete": 12,
+      "Partial": 17,
       "Missing": 5
     },
     "unresolvedCountsByRisk": {
@@ -34,8 +34,8 @@
     },
     "unresolvedCountsByStatusAndRisk": {
       "Complete:High": 9,
-      "Complete:Medium": 2,
-      "Partial:Medium": 10,
+      "Complete:Medium": 3,
+      "Partial:Medium": 9,
       "Missing:Medium": 5,
       "Partial:High": 8
     }
@@ -140,21 +140,25 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 44,
     "stateCounts": {
-      "Backlog": 27,
-      "In Review": 3,
-      "Done": 13,
-      "In Progress": 1
+      "Backlog": 26,
+      "In Review": 4,
+      "Done": 14
     },
-    "inProgressIssueKeys": [
-      "KAR-16"
-    ],
+    "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
       {
+        "key": "KAR-17",
+        "title": "Implement full backup export package conformance checks",
+        "state": "In Review",
+        "updatedAt": "2026-02-17T04:18:56.564Z",
+        "requirementId": "REQ-PORT-004"
+      },
+      {
         "key": "KAR-16",
         "title": "Build user-confirm merge workflow for dedupe suggestions",
-        "state": "In Progress",
-        "updatedAt": "2026-02-17T03:58:46.301Z",
+        "state": "Done",
+        "updatedAt": "2026-02-17T04:02:02.184Z",
         "requirementId": "REQ-PORT-003"
       },
       {
@@ -212,33 +216,28 @@
         "state": "Done",
         "updatedAt": "2026-02-17T00:13:22.799Z",
         "requirementId": "REQ-AI-002"
-      },
-      {
-        "key": "KAR-33",
-        "title": "Implement source-cited deadline extraction side-by-side evidence UI",
-        "state": "Done",
-        "updatedAt": "2026-02-16T22:39:11.183Z",
-        "requirementId": "REQ-AI-001"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T03:58:58.361Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T04:19:09.936Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "02f9691eef84800fc4b6cf3f8d6619ff387561f2",
+    "gitHead": "02311749c3644dd1aa7f41e1480898db10c6664f",
     "gitStatusShort": [
-      "## lin/KAR-16-import-dedupe-merge-workflow",
-      " M apps/api/src/contacts/contacts.controller.ts",
-      " M apps/api/src/contacts/contacts.service.ts",
-      " M apps/web/app/contacts/page.tsx",
+      "## lin/KAR-17-export-conformance-checks",
+      " M README.md",
+      " M apps/api/src/exports/exports.service.ts",
+      " M apps/api/test/roundtrip.spec.ts",
+      " M apps/web/app/data-dictionary/page.tsx",
       " M docs/SESSION_HANDOFF.md",
       " M tools/backlog-sync/requirements.matrix.json",
-      "?? apps/api/test/contacts-dedupe.spec.ts",
-      "?? apps/web/test/contacts-page.spec.tsx",
-      "?? docs/parity/dedupe-merge-workflow.md"
+      " M tools/backlog-sync/session.snapshot.json",
+      "?? apps/api/src/exports/full-backup-contract.ts",
+      "?? apps/api/test/exports-conformance.spec.ts",
+      "?? docs/parity/export-conformance.md"
     ],
-    "dirtyFileCount": 8
+    "dirtyFileCount": 10
   }
 }


### PR DESCRIPTION
## Summary
- enforce a formal full-backup export contract (required files, required CSV columns, and manifest schema/path checks)
- harden export generation to keep manifest paths aligned with actual archived documents, including missing-blob placeholders
- add conformance + roundtrip tests and update Data Dictionary/export parity docs

## Linear Issue
- KAR-17

## Requirement
- Requirement ID: REQ-PORT-004

## Verification Evidence
- pnpm --filter api test -- exports-conformance.spec.ts
- pnpm --filter api test -- roundtrip.spec.ts
- pnpm --filter api test -- imports.spec.ts
- pnpm test
- pnpm build