### PR TITLE
[KAR-25] Complete REQ-COMM-003 document automation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Production-oriented monorepo scaffold for a multi-tenant legal practice manageme
 - Matters with participants, dashboard aggregation, intake wizard + construction domain profiles
 - Tasks, calendar, ICS export, docket
 - Communications threads/messages + ranked full-text/fallback keyword search + configurable outbound providers (stub/Resend/Twilio) with persisted delivery metadata
-- Documents upload/version/share/signed URLs + configurable malware scanning (stub/ClamAV) + DOCX/PDF generation flows
+- Documents upload/version/share/signed URLs + configurable malware scanning (stub/ClamAV) + DOCX/PDF generation flows with template provenance + strict merge validation
 - Billing/time/expenses/invoices/payments + Stripe checkout link + trust ledger
 - Client portal snapshot/messages/intake/e-sign stub + secure attachment upload/download workflow
 - Plugin import framework:
@@ -164,6 +164,15 @@ Communications provider workflow:
 - `MESSAGE_EMAIL_PROVIDER=stub|resend`
 - `MESSAGE_SMS_PROVIDER=stub|twilio`
 - delivery metadata persisted in `CommunicationMessage.rawSourcePayload.delivery`
+
+Document template merge workflow:
+
+- `POST /documents/template-merge`
+  - accepts optional `mergeData` overrides
+  - defaults to strict missing-placeholder validation (`strictValidation=true`)
+- merge context includes matter/contact/custom-field graph for nested placeholders
+- generated metadata persisted in `Document.rawSourcePayload` with template/source provenance
+- parity evidence: `docs/parity/document-automation-coverage.md`
 
 AI style pack governance workflow:
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "@nestjs/swagger": "^11.0.6",
     "@prisma/client": "^6.3.1",
     "adm-zip": "^0.5.16",
+    "angular-expressions": "^1.5.1",
     "archiver": "^7.0.1",
     "bcryptjs": "^2.4.3",
     "bullmq": "^5.40.6",

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -96,12 +96,20 @@ export class DocumentsController {
   @RequirePermissions('documents:write')
   templateMerge(
     @CurrentUser() user: AuthenticatedUser,
-    @Body() body: { templateVersionId: string; mergeData: Record<string, unknown>; matterId: string; title: string },
+    @Body()
+    body: {
+      templateVersionId: string;
+      mergeData?: Record<string, unknown>;
+      strictValidation?: boolean;
+      matterId: string;
+      title: string;
+    },
   ) {
     return this.documentsService.mergeDocxTemplate({
       user,
       templateVersionId: body.templateVersionId,
       mergeData: body.mergeData,
+      strictValidation: body.strictValidation,
       matterId: body.matterId,
       title: body.title,
     });

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';
 import PizZip from 'pizzip';
 import Docxtemplater from 'docxtemplater';
+import { ContactKind, DocumentConfidentiality } from '@prisma/client';
 import { PDFDocument, StandardFonts } from 'pdf-lib';
 import { PrismaService } from '../prisma/prisma.service';
 import { AccessService } from '../access/access.service';
@@ -10,6 +11,82 @@ import { AuthenticatedUser, UploadedFile } from '../common/types';
 import { S3Service } from '../files/s3.service';
 import { MalwareScanService } from '../files/malware-scan.service';
 import { AuditService } from '../audit/audit.service';
+
+// Docxtemplater nested expressions (matter.name, customFields.matter.key, etc.)
+// are enabled via the angular expression parser.
+const expressionParser = require('docxtemplater/expressions.js');
+
+type MergeContact = {
+  id: string;
+  kind: ContactKind;
+  displayName: string;
+  primaryEmail: string | null;
+  primaryPhone: string | null;
+  tags: string[];
+  person: {
+    firstName: string | null;
+    lastName: string | null;
+    title: string | null;
+    barNumber: string | null;
+    licenseJurisdiction: string | null;
+  } | null;
+  organization: {
+    legalName: string;
+    dba: string | null;
+    website: string | null;
+  } | null;
+  customFields: Record<string, unknown>;
+};
+
+type TemplateMergeContext = {
+  generated: {
+    at: string;
+    byUserId: string;
+  };
+  matter: {
+    id: string;
+    matterNumber: string;
+    name: string;
+    practiceArea: string;
+    jurisdiction: string | null;
+    venue: string | null;
+    status: string;
+    openedAt: string;
+    closedAt: string | null;
+    stage: {
+      id: string;
+      name: string;
+      practiceArea: string;
+    } | null;
+    matterType: {
+      id: string;
+      name: string;
+    } | null;
+  };
+  participants: Array<{
+    id: string;
+    roleKey: string;
+    roleLabel: string;
+    side: string | null;
+    isPrimary: boolean;
+    notes: string | null;
+    contact: MergeContact;
+    representedBy: MergeContact | null;
+    lawFirm: MergeContact | null;
+  }>;
+  contacts: {
+    primaryClient: MergeContact | null;
+    clientSide: MergeContact[];
+    opposingSide: MergeContact[];
+    neutral: MergeContact[];
+    court: MergeContact[];
+    all: MergeContact[];
+  };
+  customFields: {
+    matter: Record<string, unknown>;
+    contacts: Record<string, Record<string, unknown>>;
+  };
+};
 
 @Injectable()
 export class DocumentsService {
@@ -44,6 +121,8 @@ export class DocumentsService {
     category?: string;
     tags?: string[];
     sharedWithClient?: boolean;
+    confidentialityLevel?: DocumentConfidentiality;
+    rawSourcePayload?: Record<string, unknown>;
     file: UploadedFile;
   }) {
     await this.access.assertMatterAccess(input.user, input.matterId, 'write');
@@ -71,6 +150,8 @@ export class DocumentsService {
         category: input.category,
         tags: input.tags ?? [],
         sharedWithClient: input.sharedWithClient ?? false,
+        confidentialityLevel: input.confidentialityLevel,
+        rawSourcePayload: input.rawSourcePayload as object | undefined,
         createdByUserId: input.user.id,
       },
     });
@@ -237,7 +318,8 @@ export class DocumentsService {
   async mergeDocxTemplate(input: {
     user: AuthenticatedUser;
     templateVersionId: string;
-    mergeData: Record<string, unknown>;
+    mergeData?: Record<string, unknown>;
+    strictValidation?: boolean;
     matterId: string;
     title: string;
   }) {
@@ -257,18 +339,73 @@ export class DocumentsService {
       throw new NotFoundException('Template document version not found');
     }
 
+    const strictValidation = input.strictValidation ?? true;
+    const baseMergeContext = await this.buildTemplateMergeContext(input.user, input.matterId);
+    const mergeContext = this.deepMergeRecords(baseMergeContext, input.mergeData ?? {});
+
     const templateBuffer = await this.s3.getObjectBuffer(template.storageKey);
     const zip = new PizZip(templateBuffer);
-    const doc = new Docxtemplater(zip, { paragraphLoop: true, linebreaks: true });
-    doc.render(input.mergeData);
-    const generated = doc.getZip().generate({ type: 'nodebuffer' });
+    const unresolvedMergeFieldSet = new Set<string>();
+    const doc = new Docxtemplater(zip, {
+      paragraphLoop: true,
+      linebreaks: true,
+      parser: expressionParser,
+      nullGetter: (part: { value?: string }) => {
+        if (part?.value) {
+          unresolvedMergeFieldSet.add(String(part.value));
+        }
+        return '';
+      },
+    });
 
-    return this.uploadNew({
+    try {
+      doc.render(mergeContext);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Template render failed';
+      throw new UnprocessableEntityException(`Template render failed: ${message}`);
+    }
+
+    const unresolvedMergeFields = this.normalizeMissingTemplateFields(unresolvedMergeFieldSet);
+    if (strictValidation && unresolvedMergeFields.length > 0) {
+      throw new UnprocessableEntityException(
+        `Template merge validation failed. Missing merge fields: ${unresolvedMergeFields.join(', ')}`,
+      );
+    }
+
+    const generated = doc.getZip().generate({ type: 'nodebuffer' });
+    const generatedAt = new Date().toISOString();
+    const provenance = {
+      generatedBy: 'template-merge',
+      generatedAt,
+      templateDocumentId: template.document.id,
+      templateVersionId: template.id,
+      strictValidation,
+      unresolvedMergeFields,
+      providedMergeDataKeys: Object.keys(input.mergeData ?? {}),
+      mergeContextSummary: {
+        participantCount: baseMergeContext.participants.length,
+        matterCustomFieldCount: Object.keys(baseMergeContext.customFields.matter).length,
+        contactCustomFieldContactCount: Object.keys(baseMergeContext.customFields.contacts).length,
+      },
+    };
+
+    const generatedDocument = await this.uploadNew({
       user: input.user,
       matterId: input.matterId,
       title: input.title,
       category: 'Generated',
-      tags: ['generated', 'docx'],
+      tags: ['generated', 'docx', 'template-merge'],
+      sharedWithClient: template.document.sharedWithClient,
+      confidentialityLevel: template.document.confidentialityLevel,
+      rawSourcePayload: {
+        source: 'template-merge',
+        template: {
+          documentId: template.document.id,
+          versionId: template.id,
+          storageKey: template.storageKey,
+        },
+        provenance,
+      },
       file: {
         buffer: generated,
         mimetype: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -276,6 +413,24 @@ export class DocumentsService {
         size: generated.byteLength,
       } as UploadedFile,
     });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.template.generated',
+      entityType: 'document',
+      entityId: generatedDocument.document.id,
+      metadata: provenance,
+    });
+
+    return {
+      ...generatedDocument,
+      mergeSummary: {
+        strictValidation,
+        unresolvedMergeFields,
+        mergeContextSummary: provenance.mergeContextSummary,
+      },
+    };
   }
 
   async generateSimplePdf(input: {
@@ -301,12 +456,20 @@ export class DocumentsService {
     }
 
     const bytes = await pdf.save();
-    return this.uploadNew({
+    const generatedAt = new Date().toISOString();
+    const generatedDocument = await this.uploadNew({
       user: input.user,
       matterId: input.matterId,
       title: input.title,
       category: 'Generated',
       tags: ['generated', 'pdf'],
+      rawSourcePayload: {
+        source: 'simple-pdf',
+        provenance: {
+          generatedAt,
+          lineCount: input.lines.length,
+        },
+      },
       file: {
         buffer: Buffer.from(bytes),
         mimetype: 'application/pdf',
@@ -314,6 +477,299 @@ export class DocumentsService {
         size: bytes.byteLength,
       } as UploadedFile,
     });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.pdf.generated',
+      entityType: 'document',
+      entityId: generatedDocument.document.id,
+      metadata: {
+        generatedAt,
+        lineCount: input.lines.length,
+      },
+    });
+
+    return generatedDocument;
+  }
+
+  private async buildTemplateMergeContext(user: AuthenticatedUser, matterId: string): Promise<TemplateMergeContext> {
+    const matter = await this.prisma.matter.findFirst({
+      where: {
+        id: matterId,
+        organizationId: user.organizationId,
+      },
+      include: {
+        stage: true,
+        matterType: true,
+        participants: {
+          include: {
+            participantRoleDefinition: true,
+            contact: {
+              include: {
+                personProfile: true,
+                organizationProfile: true,
+              },
+            },
+            representedByContact: {
+              include: {
+                personProfile: true,
+                organizationProfile: true,
+              },
+            },
+            lawFirmContact: {
+              include: {
+                personProfile: true,
+                organizationProfile: true,
+              },
+            },
+          },
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    });
+
+    if (!matter) {
+      throw new NotFoundException('Matter not found');
+    }
+
+    const contactIds = new Set<string>();
+    for (const participant of matter.participants) {
+      contactIds.add(participant.contactId);
+      if (participant.representedByContactId) {
+        contactIds.add(participant.representedByContactId);
+      }
+      if (participant.lawFirmContactId) {
+        contactIds.add(participant.lawFirmContactId);
+      }
+    }
+
+    const customFieldOrClauses: Array<{ entityType: string; entityId: string | { in: string[] } }> = [
+      {
+        entityType: 'matter',
+        entityId: matter.id,
+      },
+    ];
+    if (contactIds.size > 0) {
+      customFieldOrClauses.push({
+        entityType: 'contact',
+        entityId: { in: Array.from(contactIds) },
+      });
+    }
+
+    const customFieldValues = await this.prisma.customFieldValue.findMany({
+      where: {
+        organizationId: user.organizationId,
+        OR: customFieldOrClauses,
+      },
+      include: {
+        fieldDefinition: {
+          select: {
+            key: true,
+          },
+        },
+      },
+    });
+
+    const matterCustomFields: Record<string, unknown> = {};
+    const contactCustomFields: Record<string, Record<string, unknown>> = {};
+    for (const customField of customFieldValues) {
+      const fieldKey = customField.fieldDefinition.key;
+      if (customField.entityType === 'matter') {
+        matterCustomFields[fieldKey] = customField.valueJson as unknown;
+        continue;
+      }
+
+      if (customField.entityType !== 'contact') {
+        continue;
+      }
+
+      if (!contactCustomFields[customField.entityId]) {
+        contactCustomFields[customField.entityId] = {};
+      }
+      contactCustomFields[customField.entityId][fieldKey] = customField.valueJson as unknown;
+    }
+
+    const participants = matter.participants.map((participant) => ({
+      id: participant.id,
+      roleKey: participant.participantRoleKey,
+      roleLabel: participant.participantRoleDefinition?.label ?? participant.participantRoleKey,
+      side: participant.side,
+      isPrimary: participant.isPrimary,
+      notes: participant.notes,
+      contact: this.toMergeContact(participant.contact, contactCustomFields[participant.contact.id]),
+      representedBy: participant.representedByContact
+        ? this.toMergeContact(
+            participant.representedByContact,
+            contactCustomFields[participant.representedByContact.id],
+          )
+        : null,
+      lawFirm: participant.lawFirmContact
+        ? this.toMergeContact(participant.lawFirmContact, contactCustomFields[participant.lawFirmContact.id])
+        : null,
+    }));
+
+    const clientSide = this.uniqueContacts(
+      participants.filter((participant) => participant.side === 'CLIENT_SIDE').map((participant) => participant.contact),
+    );
+    const opposingSide = this.uniqueContacts(
+      participants
+        .filter((participant) => participant.side === 'OPPOSING_SIDE')
+        .map((participant) => participant.contact),
+    );
+    const neutral = this.uniqueContacts(
+      participants.filter((participant) => participant.side === 'NEUTRAL').map((participant) => participant.contact),
+    );
+    const court = this.uniqueContacts(
+      participants.filter((participant) => participant.side === 'COURT').map((participant) => participant.contact),
+    );
+
+    const all = this.uniqueContacts(
+      participants.flatMap((participant) =>
+        [participant.contact, participant.representedBy, participant.lawFirm].filter(
+          (entry): entry is MergeContact => entry !== null,
+        ),
+      ),
+    );
+
+    const primaryClient = participants.find((participant) => participant.side === 'CLIENT_SIDE' && participant.isPrimary)
+      ?.contact ?? clientSide[0] ?? null;
+
+    return {
+      generated: {
+        at: new Date().toISOString(),
+        byUserId: user.id,
+      },
+      matter: {
+        id: matter.id,
+        matterNumber: matter.matterNumber,
+        name: matter.name,
+        practiceArea: matter.practiceArea,
+        jurisdiction: matter.jurisdiction,
+        venue: matter.venue,
+        status: matter.status,
+        openedAt: matter.openedAt.toISOString(),
+        closedAt: matter.closedAt ? matter.closedAt.toISOString() : null,
+        stage: matter.stage
+          ? {
+              id: matter.stage.id,
+              name: matter.stage.name,
+              practiceArea: matter.stage.practiceArea,
+            }
+          : null,
+        matterType: matter.matterType
+          ? {
+              id: matter.matterType.id,
+              name: matter.matterType.name,
+            }
+          : null,
+      },
+      participants,
+      contacts: {
+        primaryClient,
+        clientSide,
+        opposingSide,
+        neutral,
+        court,
+        all,
+      },
+      customFields: {
+        matter: matterCustomFields,
+        contacts: contactCustomFields,
+      },
+    };
+  }
+
+  private toMergeContact(
+    contact: {
+      id: string;
+      kind: ContactKind;
+      displayName: string;
+      primaryEmail: string | null;
+      primaryPhone: string | null;
+      tags: string[];
+      personProfile?: {
+        firstName: string | null;
+        lastName: string | null;
+        title: string | null;
+        barNumber: string | null;
+        licenseJurisdiction: string | null;
+      } | null;
+      organizationProfile?: {
+        legalName: string;
+        dba: string | null;
+        website: string | null;
+      } | null;
+    },
+    customFields: Record<string, unknown> = {},
+  ): MergeContact {
+    return {
+      id: contact.id,
+      kind: contact.kind,
+      displayName: contact.displayName,
+      primaryEmail: contact.primaryEmail,
+      primaryPhone: contact.primaryPhone,
+      tags: contact.tags,
+      person: contact.personProfile
+        ? {
+            firstName: contact.personProfile.firstName,
+            lastName: contact.personProfile.lastName,
+            title: contact.personProfile.title,
+            barNumber: contact.personProfile.barNumber,
+            licenseJurisdiction: contact.personProfile.licenseJurisdiction,
+          }
+        : null,
+      organization: contact.organizationProfile
+        ? {
+            legalName: contact.organizationProfile.legalName,
+            dba: contact.organizationProfile.dba,
+            website: contact.organizationProfile.website,
+          }
+        : null,
+      customFields,
+    };
+  }
+
+  private uniqueContacts(contacts: MergeContact[]) {
+    const unique = new Map<string, MergeContact>();
+    for (const contact of contacts) {
+      unique.set(contact.id, contact);
+    }
+    return Array.from(unique.values());
+  }
+
+  private normalizeMissingTemplateFields(rawFields: Iterable<string>) {
+    const normalized = new Set<string>();
+    for (const rawField of rawFields) {
+      const value = rawField.trim();
+      if (!value) {
+        continue;
+      }
+      if (!/^[a-zA-Z0-9_.[\]-]+$/.test(value)) {
+        continue;
+      }
+      normalized.add(value);
+    }
+    return Array.from(normalized).sort((a, b) => a.localeCompare(b));
+  }
+
+  private deepMergeRecords<T extends Record<string, unknown>>(base: T, patch: Record<string, unknown>): T {
+    const merged: Record<string, unknown> = { ...base };
+    for (const [key, value] of Object.entries(patch)) {
+      if (this.isRecord(value) && this.isRecord(merged[key])) {
+        merged[key] = this.deepMergeRecords(
+          merged[key] as Record<string, unknown>,
+          value as Record<string, unknown>,
+        );
+        continue;
+      }
+      merged[key] = value;
+    }
+    return merged as T;
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
   }
 
   private async auditBlockedUpload(

--- a/apps/api/test/documents-template-merge.spec.ts
+++ b/apps/api/test/documents-template-merge.spec.ts
@@ -1,0 +1,349 @@
+import PizZip from 'pizzip';
+import { DocumentsService } from '../src/documents/documents.service';
+
+function createDocxTemplateBuffer(tags: string[]) {
+  const zip = new PizZip();
+  zip.file(
+    '[Content_Types].xml',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">' +
+      '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>' +
+      '<Default Extension="xml" ContentType="application/xml"/>' +
+      '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>' +
+      '</Types>',
+  );
+  zip.folder('_rels')?.file(
+    '.rels',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+      '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>' +
+      '</Relationships>',
+  );
+  const body = tags.map((tag) => `<w:p><w:r><w:t>${tag}</w:t></w:r></w:p>`).join('');
+  zip.folder('word')?.file(
+    'document.xml',
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+      `<w:body>${body}</w:body>` +
+      '</w:document>',
+  );
+  return zip.generate({ type: 'nodebuffer' });
+}
+
+function buildMatterFixture() {
+  return {
+    id: 'matter-1',
+    organizationId: 'org-1',
+    matterNumber: 'M-001',
+    name: 'Kitchen Remodel Dispute',
+    practiceArea: 'Construction Litigation',
+    jurisdiction: 'CA',
+    venue: 'Los Angeles Superior Court',
+    status: 'OPEN',
+    openedAt: new Date('2026-01-10T00:00:00.000Z'),
+    closedAt: null,
+    stage: {
+      id: 'stage-1',
+      name: 'Pleadings',
+      practiceArea: 'Construction Litigation',
+    },
+    matterType: {
+      id: 'type-1',
+      name: 'Residential Construction Defect',
+    },
+    participants: [
+      {
+        id: 'participant-client',
+        contactId: 'contact-client',
+        participantRoleKey: 'client',
+        participantRoleDefinition: { label: 'Client' },
+        side: 'CLIENT_SIDE',
+        isPrimary: true,
+        notes: null,
+        representedByContactId: null,
+        lawFirmContactId: null,
+        contact: {
+          id: 'contact-client',
+          kind: 'PERSON',
+          displayName: 'Chris Homeowner',
+          primaryEmail: 'chris@example.com',
+          primaryPhone: '555-0100',
+          tags: ['client'],
+          personProfile: {
+            firstName: 'Chris',
+            lastName: 'Homeowner',
+            title: null,
+            barNumber: null,
+            licenseJurisdiction: null,
+          },
+          organizationProfile: null,
+        },
+        representedByContact: null,
+        lawFirmContact: null,
+      },
+      {
+        id: 'participant-opposing-counsel',
+        contactId: 'contact-opposing-counsel',
+        participantRoleKey: 'opposing_counsel',
+        participantRoleDefinition: { label: 'Opposing Counsel' },
+        side: 'OPPOSING_SIDE',
+        isPrimary: true,
+        notes: null,
+        representedByContactId: null,
+        lawFirmContactId: 'contact-opposing-firm',
+        contact: {
+          id: 'contact-opposing-counsel',
+          kind: 'PERSON',
+          displayName: 'Avery Defense',
+          primaryEmail: 'avery@defensefirm.test',
+          primaryPhone: '555-0200',
+          tags: ['opposing-counsel'],
+          personProfile: {
+            firstName: 'Avery',
+            lastName: 'Defense',
+            title: 'Attorney',
+            barNumber: 'BAR123',
+            licenseJurisdiction: 'CA',
+          },
+          organizationProfile: null,
+        },
+        representedByContact: null,
+        lawFirmContact: {
+          id: 'contact-opposing-firm',
+          kind: 'ORGANIZATION',
+          displayName: 'Defense Firm LLP',
+          primaryEmail: 'intake@defensefirm.test',
+          primaryPhone: '555-0300',
+          tags: ['opposing-firm'],
+          personProfile: null,
+          organizationProfile: {
+            legalName: 'Defense Firm LLP',
+            dba: null,
+            website: 'https://defensefirm.test',
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe('DocumentsService mergeDocxTemplate', () => {
+  it('builds matter/contact/custom-field context, supports override merge data, and logs provenance', async () => {
+    const templateBuffer = createDocxTemplateBuffer([
+      '{matter.name}',
+      '{matter.matterNumber}',
+      '{contacts.primaryClient.displayName}',
+      '{customFields.matter.claimNumber}',
+    ]);
+
+    const prisma = {
+      documentVersion: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'template-version-1',
+          storageKey: 'templates/1.docx',
+          document: {
+            id: 'template-document-1',
+            sharedWithClient: true,
+            confidentialityLevel: 'ATTORNEY_EYES_ONLY',
+          },
+        }),
+        create: jest.fn().mockResolvedValue({ id: 'generated-version-1' }),
+      },
+      matter: {
+        findFirst: jest.fn().mockResolvedValue(buildMatterFixture()),
+      },
+      customFieldValue: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            entityType: 'matter',
+            entityId: 'matter-1',
+            valueJson: 'CLM-991',
+            fieldDefinition: { key: 'claimNumber' },
+          },
+          {
+            entityType: 'contact',
+            entityId: 'contact-client',
+            valueJson: 'Chris',
+            fieldDefinition: { key: 'preferredName' },
+          },
+        ]),
+      },
+      document: {
+        create: jest.fn().mockResolvedValue({ id: 'generated-document-1' }),
+      },
+    } as any;
+
+    const appendEvent = jest.fn();
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      {
+        getObjectBuffer: jest.fn().mockResolvedValue(templateBuffer),
+        upload: jest.fn().mockResolvedValue({ key: 'org/org-1/matter/matter-1/generated.docx' }),
+      } as any,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent } as any,
+    );
+
+    const result = await service.mergeDocxTemplate({
+      user: { id: 'user-1', organizationId: 'org-1' } as any,
+      templateVersionId: 'template-version-1',
+      matterId: 'matter-1',
+      title: 'Demand Letter Draft',
+      mergeData: {
+        matter: {
+          name: 'Override Matter Name',
+        },
+      },
+    });
+
+    expect(prisma.document.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          confidentialityLevel: 'ATTORNEY_EYES_ONLY',
+          sharedWithClient: true,
+          rawSourcePayload: expect.objectContaining({
+            source: 'template-merge',
+            template: expect.objectContaining({
+              versionId: 'template-version-1',
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(prisma.documentVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        }),
+      }),
+    );
+
+    expect(result.mergeSummary).toEqual(
+      expect.objectContaining({
+        strictValidation: true,
+        unresolvedMergeFields: [],
+        mergeContextSummary: expect.objectContaining({
+          participantCount: 2,
+          matterCustomFieldCount: 1,
+          contactCustomFieldContactCount: 1,
+        }),
+      }),
+    );
+
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.template.generated',
+        entityType: 'document',
+        entityId: 'generated-document-1',
+      }),
+    );
+  });
+
+  it('fails strict template validation when merge placeholders are missing', async () => {
+    const templateBuffer = createDocxTemplateBuffer(['{matter.name}', '{customFields.matter.missingField}']);
+    const prisma = {
+      documentVersion: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'template-version-1',
+          storageKey: 'templates/1.docx',
+          document: {
+            id: 'template-document-1',
+            sharedWithClient: false,
+            confidentialityLevel: 'CONFIDENTIAL',
+          },
+        }),
+      },
+      matter: {
+        findFirst: jest.fn().mockResolvedValue(buildMatterFixture()),
+      },
+      customFieldValue: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      document: {
+        create: jest.fn(),
+      },
+    } as any;
+
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      {
+        getObjectBuffer: jest.fn().mockResolvedValue(templateBuffer),
+        upload: jest.fn(),
+      } as any,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent: jest.fn() } as any,
+    );
+
+    await expect(
+      service.mergeDocxTemplate({
+        user: { id: 'user-1', organizationId: 'org-1' } as any,
+        templateVersionId: 'template-version-1',
+        matterId: 'matter-1',
+        title: 'Demand Letter Draft',
+      }),
+    ).rejects.toThrow('Template merge validation failed');
+
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('allows unresolved placeholders when strictValidation is false and records them', async () => {
+    const templateBuffer = createDocxTemplateBuffer(['{matter.name}', '{customFields.matter.optionalField}']);
+    const prisma = {
+      documentVersion: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'template-version-1',
+          storageKey: 'templates/1.docx',
+          document: {
+            id: 'template-document-1',
+            sharedWithClient: false,
+            confidentialityLevel: 'CONFIDENTIAL',
+          },
+        }),
+        create: jest.fn().mockResolvedValue({ id: 'generated-version-1' }),
+      },
+      matter: {
+        findFirst: jest.fn().mockResolvedValue(buildMatterFixture()),
+      },
+      customFieldValue: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      document: {
+        create: jest.fn().mockResolvedValue({ id: 'generated-document-1' }),
+      },
+    } as any;
+
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      {
+        getObjectBuffer: jest.fn().mockResolvedValue(templateBuffer),
+        upload: jest.fn().mockResolvedValue({ key: 'org/org-1/matter/matter-1/generated.docx' }),
+      } as any,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent: jest.fn() } as any,
+    );
+
+    const result = await service.mergeDocxTemplate({
+      user: { id: 'user-1', organizationId: 'org-1' } as any,
+      templateVersionId: 'template-version-1',
+      matterId: 'matter-1',
+      title: 'Demand Letter Draft',
+      strictValidation: false,
+    });
+
+    expect(result.mergeSummary.unresolvedMergeFields).toContain('customFields.matter.optionalField');
+    expect(prisma.document.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          rawSourcePayload: expect.objectContaining({
+            provenance: expect.objectContaining({
+              unresolvedMergeFields: expect.arrayContaining(['customFields.matter.optionalField']),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T16:53:23.713Z`
+- Snapshot Timestamp: `2026-02-17T17:15:02.663Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T16:53:21.675Z`
+- Last Successful Mirror Verify: `2026-02-17T17:15:01.310Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Completed `REQ-COMM-003` document automation coverage by adding nested DOCX merge context (matter/participants/custom fields), strict missing-placeholder validation before generation, and generated artifact provenance/audit events for template merges and generated PDFs (`docs/parity/document-automation-coverage.md`).
 - 2026-02-17: Completed `REQ-COMM-002` communications search relevance/indexing with ranked `websearch_to_tsquery` full-text path, snippet generation, substring fallback, and a dedicated GIN FTS index migration plus regression coverage (`docs/parity/communications-search-indexing.md`).
 - 2026-02-17: Completed `REQ-COMM-001` production communication adapters with configurable Resend (email) + Twilio (SMS) providers behind a dispatch interface, retry/fail-open policy, persisted outbound delivery/provider metadata on `CommunicationMessage.rawSourcePayload`, and new delivery-regression tests (`docs/parity/communications-provider-adapters.md`).
 - 2026-02-17: Completed `REQ-AI-003` style-pack governance with admin CRUD/source-doc attachment endpoints, AI job `stylePackId` selection, style-pack provenance persisted in artifact + execution metadata, AI workspace style-pack management UI, and API/Web regression coverage (`docs/parity/style-pack-governance.md`).

--- a/docs/parity/document-automation-coverage.md
+++ b/docs/parity/document-automation-coverage.md
@@ -1,0 +1,41 @@
+# REQ-COMM-003 Parity Evidence: Document Automation Merge Coverage
+
+Requirement: `REQ-COMM-003`  
+Prompt section: `Document Management + Automation`
+
+## Implemented
+
+- Expanded DOCX merge context generation in `DocumentsService.mergeDocxTemplate`:
+  - matter graph (`matter` + stage + matter type)
+  - participant/contact graph (`participants`, `contacts.primaryClient`, side-grouped contacts)
+  - custom field graph (`customFields.matter`, `customFields.contacts`)
+- Enabled nested template expressions (`matter.name`, `contacts.primaryClient.displayName`, etc.) using Docxtemplater expression parsing.
+- Added strict placeholder validation before artifact creation:
+  - unresolved merge fields are collected during render
+  - `strictValidation` defaults to `true`
+  - unresolved placeholders now fail with `422` before upload
+  - optional bypass for deliberate partial drafts: `strictValidation=false`
+- Added generated artifact provenance metadata:
+  - persisted in `Document.rawSourcePayload` for DOCX/PDF generated outputs
+  - includes template source ids, strict mode, unresolved fields, merge-data keys, context summary, timestamp
+- Added generation audit events:
+  - `document.template.generated`
+  - `document.pdf.generated`
+
+## Verification
+
+- API tests:
+  - `apps/api/test/documents-template-merge.spec.ts`
+  - existing compatibility tests retained:
+    - `apps/api/test/documents.spec.ts`
+- Full API + web test pass:
+  - `pnpm test`
+- Build pass:
+  - `pnpm build`
+
+## Notes
+
+- Generated DOCX documents now inherit confidentiality/share defaults from the source template document.
+- Endpoint `POST /documents/template-merge` now supports:
+  - optional `mergeData`
+  - optional `strictValidation` (default `true`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       adm-zip:
         specifier: ^0.5.16
         version: 0.5.16
+      angular-expressions:
+        specifier: ^1.5.1
+        version: 1.5.1
       archiver:
         specifier: ^7.0.1
         version: 7.0.1
@@ -1944,6 +1947,9 @@ packages:
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
+
+  angular-expressions@1.5.1:
+    resolution: {integrity: sha512-Ukcyuye0eb15zuvMFR7Kziuf7gV0gYAZXMevNI40rXF8f9k+/yk8+r5edFWRFOwnqSvAEFoP2bKNXaXgYa+Ayw==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -6463,6 +6469,8 @@ snapshots:
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
+
+  angular-expressions@1.5.1: {}
 
   ansi-escapes@4.3.2:
     dependencies:

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -408,7 +408,7 @@
           "title": "Expand document automation coverage for merge fields and generated outputs",
           "requirementId": "REQ-COMM-003",
           "promptSection": "Document Management + Automation",
-          "parityStatus": "Partial",
+          "parityStatus": "Complete",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "documents"],

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T16:53:23.713Z",
+  "generatedAt": "2026-02-17T17:15:02.663Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -24,8 +24,8 @@
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 24,
-      "Partial": 5,
+      "Complete": 25,
+      "Partial": 4,
       "Missing": 5
     },
     "unresolvedCountsByRisk": {
@@ -34,23 +34,14 @@
     },
     "unresolvedCountsByStatusAndRisk": {
       "Complete:High": 17,
-      "Complete:Medium": 7,
-      "Partial:Medium": 5,
+      "Complete:Medium": 8,
+      "Partial:Medium": 4,
       "Missing:Medium": 5
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-COMM-003",
-        "parityStatus": "Partial",
-        "risk": "Medium",
-        "title": "Expand document automation coverage for merge fields and generated outputs",
-        "component": "API",
-        "epicCode": "PARITY-05",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-DATA-003",
         "parityStatus": "Partial",
@@ -131,6 +122,15 @@
         "component": "Data",
         "epicCode": "PARITY-02",
         "phase": "phase-1"
+      },
+      {
+        "requirementId": "REQ-INT-001",
+        "parityStatus": "Complete",
+        "risk": "High",
+        "title": "Implement Clio connector OAuth + incremental sync + webhook subscription",
+        "component": "Integrations",
+        "epicCode": "PARITY-09",
+        "phase": "phase-1"
       }
     ]
   },
@@ -140,8 +140,8 @@
     "scopedIssueCount": 44,
     "stateCounts": {
       "Backlog": 21,
-      "In Review": 2,
-      "Done": 21
+      "In Review": 1,
+      "Done": 22
     },
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
@@ -149,8 +149,8 @@
       {
         "key": "KAR-24",
         "title": "Complete communication search relevance and indexing strategy",
-        "state": "In Review",
-        "updatedAt": "2026-02-17T16:53:02.355Z",
+        "state": "Done",
+        "updatedAt": "2026-02-17T16:56:32.091Z",
         "requirementId": "REQ-COMM-002"
       },
       {
@@ -219,14 +219,24 @@
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T16:53:21.675Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T17:15:01.310Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "70d88775dc627611ddd1916c0c240c86f442d2b8",
+    "gitHead": "b6d57bdf2df7197301380caff6dfe401e17dca52",
     "gitStatusShort": [
-      "## lin/KAR-24-communications-search-indexing...origin/lin/KAR-24-communications-search-indexing"
+      "## lin/KAR-25-document-automation-coverage",
+      " M README.md",
+      " M apps/api/package.json",
+      " M apps/api/src/documents/documents.controller.ts",
+      " M apps/api/src/documents/documents.service.ts",
+      " M docs/SESSION_HANDOFF.md",
+      " M pnpm-lock.yaml",
+      " M tools/backlog-sync/requirements.matrix.json",
+      " M tools/backlog-sync/session.snapshot.json",
+      "?? apps/api/test/documents-template-merge.spec.ts",
+      "?? docs/parity/document-automation-coverage.md"
     ],
-    "dirtyFileCount": 0
+    "dirtyFileCount": 10
   }
 }


### PR DESCRIPTION
## Linear Issue
- KAR-25

## Summary
- complete REQ-COMM-003 document automation parity
- add nested DOCX merge context (matter/participants/custom fields)
- enforce strict missing-placeholder validation by default with optional override
- persist generated document provenance metadata and add generation audit events
- add acceptance tests for template merge validation/provenance

## Requirement ID
- REQ-COMM-003

## Verification
- pnpm --filter api test -- documents-template-merge.spec.ts
- pnpm test
- pnpm build
- set -a; source .env >/dev/null 2>&1; set +a; pnpm backlog:sync
- set -a; source .env >/dev/null 2>&1; set +a; pnpm backlog:verify
- set -a; source .env >/dev/null 2>&1; set +a; pnpm backlog:snapshot
- set -a; source .env >/dev/null 2>&1; set +a; pnpm backlog:handoff:check

## Prompt Section
- Document Management + Automation