### PR TITLE
[KAR-46] Add document retention, legal hold, and disposition workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Production-oriented monorepo scaffold for a multi-tenant legal practice manageme
 - Conflict rule profiles with weighted check scoring + attorney resolution/audit workflow
 - Tasks, calendar, jurisdictional deadline rules packs (preview/apply + override reason capture), ICS export, docket
 - Communications threads/messages + ranked full-text/fallback keyword search + configurable outbound providers (stub/Resend/Twilio) with persisted delivery metadata
-- Documents upload/version/share/signed URLs + configurable malware scanning (stub/ClamAV) + DOCX/PDF generation flows with template provenance + strict merge validation
+- Documents upload/version/share/signed URLs + configurable malware scanning (stub/ClamAV) + retention policies/legal holds/disposition runs + DOCX/PDF generation flows with template provenance + strict merge validation
 - Billing/time/expenses/invoices/payments + Stripe checkout link + trust ledger
 - Client portal snapshot/messages/intake + provider-based e-sign workflow (stub/sandbox) + secure attachment upload/download
 - Plugin import framework:
@@ -255,7 +255,6 @@ Live provider pull sync mode (optional, defaults to scaffold mode):
 
 ## Phase-2 Planned End-Goal Features
 
-- Document retention policies (including legal hold and disposition controls)
 - Advanced conflict rules (profile-based matching and conflict resolution workflow)
 - Trust reconciliation workflows (run lifecycle, discrepancy queue, sign-off)
 - LEDES/UTBMS export jobs (validation + standards-oriented outputs)

--- a/apps/api/prisma/migrations/20260217191000_document_retention_workflows/migration.sql
+++ b/apps/api/prisma/migrations/20260217191000_document_retention_workflows/migration.sql
@@ -1,0 +1,134 @@
+-- Document retention policies, legal holds, and disposition workflows
+
+CREATE TYPE "DocumentDispositionStatus" AS ENUM ('ACTIVE', 'PENDING_DISPOSITION', 'DISPOSED');
+CREATE TYPE "RetentionScope" AS ENUM ('ALL_DOCUMENTS', 'MATTER', 'CATEGORY');
+CREATE TYPE "RetentionTrigger" AS ENUM ('DOCUMENT_UPLOADED', 'MATTER_CLOSED');
+CREATE TYPE "DocumentLegalHoldStatus" AS ENUM ('ACTIVE', 'RELEASED');
+CREATE TYPE "DocumentDispositionRunStatus" AS ENUM ('DRAFT', 'PENDING_APPROVAL', 'APPROVED', 'COMPLETED', 'CANCELED');
+CREATE TYPE "DocumentDispositionItemStatus" AS ENUM ('PENDING', 'SKIPPED_LEGAL_HOLD', 'DISPOSED');
+
+ALTER TABLE "Document"
+  ADD COLUMN "retentionPolicyId" UUID,
+  ADD COLUMN "retentionEligibleAt" TIMESTAMP(3),
+  ADD COLUMN "legalHoldActive" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "dispositionStatus" "DocumentDispositionStatus" NOT NULL DEFAULT 'ACTIVE',
+  ADD COLUMN "disposedAt" TIMESTAMP(3);
+
+CREATE TABLE "DocumentRetentionPolicy" (
+  "id" UUID NOT NULL,
+  "organizationId" UUID NOT NULL,
+  "matterId" UUID,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "scope" "RetentionScope" NOT NULL DEFAULT 'ALL_DOCUMENTS',
+  "category" TEXT,
+  "retentionDays" INTEGER NOT NULL,
+  "trigger" "RetentionTrigger" NOT NULL DEFAULT 'DOCUMENT_UPLOADED',
+  "requireApproval" BOOLEAN NOT NULL DEFAULT true,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "createdByUserId" UUID,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "DocumentRetentionPolicy_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DocumentLegalHold" (
+  "id" UUID NOT NULL,
+  "organizationId" UUID NOT NULL,
+  "documentId" UUID NOT NULL,
+  "matterId" UUID,
+  "reason" TEXT NOT NULL,
+  "status" "DocumentLegalHoldStatus" NOT NULL DEFAULT 'ACTIVE',
+  "placedByUserId" UUID,
+  "releasedByUserId" UUID,
+  "placedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "releasedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "DocumentLegalHold_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DocumentDispositionRun" (
+  "id" UUID NOT NULL,
+  "organizationId" UUID NOT NULL,
+  "policyId" UUID,
+  "status" "DocumentDispositionRunStatus" NOT NULL DEFAULT 'DRAFT',
+  "cutoffAt" TIMESTAMP(3) NOT NULL,
+  "notes" TEXT,
+  "requestedByUserId" UUID,
+  "approvedByUserId" UUID,
+  "approvedAt" TIMESTAMP(3),
+  "executedByUserId" UUID,
+  "executedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "DocumentDispositionRun_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "DocumentDispositionItem" (
+  "id" UUID NOT NULL,
+  "organizationId" UUID NOT NULL,
+  "runId" UUID NOT NULL,
+  "documentId" UUID NOT NULL,
+  "status" "DocumentDispositionItemStatus" NOT NULL DEFAULT 'PENDING',
+  "scheduledAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "appliedAt" TIMESTAMP(3),
+  "note" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "DocumentDispositionItem_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Document_organizationId_retentionEligibleAt_idx" ON "Document"("organizationId", "retentionEligibleAt");
+CREATE INDEX "Document_organizationId_dispositionStatus_idx" ON "Document"("organizationId", "dispositionStatus");
+
+CREATE INDEX "DocumentRetentionPolicy_organizationId_isActive_idx" ON "DocumentRetentionPolicy"("organizationId", "isActive");
+CREATE INDEX "DocumentRetentionPolicy_organizationId_scope_idx" ON "DocumentRetentionPolicy"("organizationId", "scope");
+
+CREATE INDEX "DocumentLegalHold_organizationId_status_placedAt_idx" ON "DocumentLegalHold"("organizationId", "status", "placedAt");
+CREATE INDEX "DocumentLegalHold_organizationId_documentId_idx" ON "DocumentLegalHold"("organizationId", "documentId");
+
+CREATE INDEX "DocumentDispositionRun_organizationId_status_createdAt_idx" ON "DocumentDispositionRun"("organizationId", "status", "createdAt");
+
+CREATE UNIQUE INDEX "DocumentDispositionItem_runId_documentId_key" ON "DocumentDispositionItem"("runId", "documentId");
+CREATE INDEX "DocumentDispositionItem_organizationId_status_scheduledAt_idx" ON "DocumentDispositionItem"("organizationId", "status", "scheduledAt");
+
+ALTER TABLE "Document"
+  ADD CONSTRAINT "Document_retentionPolicyId_fkey"
+  FOREIGN KEY ("retentionPolicyId") REFERENCES "DocumentRetentionPolicy"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DocumentRetentionPolicy"
+  ADD CONSTRAINT "DocumentRetentionPolicy_matterId_fkey"
+  FOREIGN KEY ("matterId") REFERENCES "Matter"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentRetentionPolicy_createdByUserId_fkey"
+  FOREIGN KEY ("createdByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DocumentLegalHold"
+  ADD CONSTRAINT "DocumentLegalHold_documentId_fkey"
+  FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentLegalHold_matterId_fkey"
+  FOREIGN KEY ("matterId") REFERENCES "Matter"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentLegalHold_placedByUserId_fkey"
+  FOREIGN KEY ("placedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentLegalHold_releasedByUserId_fkey"
+  FOREIGN KEY ("releasedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DocumentDispositionRun"
+  ADD CONSTRAINT "DocumentDispositionRun_policyId_fkey"
+  FOREIGN KEY ("policyId") REFERENCES "DocumentRetentionPolicy"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentDispositionRun_requestedByUserId_fkey"
+  FOREIGN KEY ("requestedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentDispositionRun_approvedByUserId_fkey"
+  FOREIGN KEY ("approvedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentDispositionRun_executedByUserId_fkey"
+  FOREIGN KEY ("executedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "DocumentDispositionItem"
+  ADD CONSTRAINT "DocumentDispositionItem_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "DocumentDispositionRun"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  ADD CONSTRAINT "DocumentDispositionItem_documentId_fkey"
+  FOREIGN KEY ("documentId") REFERENCES "Document"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -84,6 +84,42 @@ enum DocumentConfidentiality {
   HIGHLY_CONFIDENTIAL
 }
 
+enum DocumentDispositionStatus {
+  ACTIVE
+  PENDING_DISPOSITION
+  DISPOSED
+}
+
+enum RetentionScope {
+  ALL_DOCUMENTS
+  MATTER
+  CATEGORY
+}
+
+enum RetentionTrigger {
+  DOCUMENT_UPLOADED
+  MATTER_CLOSED
+}
+
+enum DocumentLegalHoldStatus {
+  ACTIVE
+  RELEASED
+}
+
+enum DocumentDispositionRunStatus {
+  DRAFT
+  PENDING_APPROVAL
+  APPROVED
+  COMPLETED
+  CANCELED
+}
+
+enum DocumentDispositionItemStatus {
+  PENDING
+  SKIPPED_LEGAL_HOLD
+  DISPOSED
+}
+
 enum InvoiceStatus {
   DRAFT
   SENT
@@ -211,6 +247,12 @@ model User {
   documentsCreated   Document[]
   documentVersions   DocumentVersion[]
   documentShareLinks DocumentShareLink[]
+  retentionPoliciesCreated DocumentRetentionPolicy[]
+  documentLegalHoldsPlaced DocumentLegalHold[] @relation("DocumentLegalHoldPlacedBy")
+  documentLegalHoldsReleased DocumentLegalHold[] @relation("DocumentLegalHoldReleasedBy")
+  documentDispositionRunsRequested DocumentDispositionRun[] @relation("DocumentDispositionRunRequestedBy")
+  documentDispositionRunsApproved DocumentDispositionRun[] @relation("DocumentDispositionRunApprovedBy")
+  documentDispositionRunsExecuted DocumentDispositionRun[] @relation("DocumentDispositionRunExecutedBy")
   timeEntries        TimeEntry[]
   expenses           Expense[]
   leadsAssigned      Lead[]
@@ -468,6 +510,8 @@ model Matter {
   communicationThreads CommunicationThread[]
   documentFolders     DocumentFolder[]
   documents            Document[]
+  documentRetentionPolicies DocumentRetentionPolicy[]
+  documentLegalHolds  DocumentLegalHold[]
   evidenceItems        EvidenceItem[]
   timeEntries          TimeEntry[]
   expenses             Expense[]
@@ -837,26 +881,36 @@ model Document {
   organizationId       String                 @db.Uuid
   matterId             String                 @db.Uuid
   folderId             String?                @db.Uuid
+  retentionPolicyId    String?                @db.Uuid
   title                String
   category             String?
   tags                 String[]               @default([])
   confidentialityLevel DocumentConfidentiality @default(CONFIDENTIAL)
   sharedWithClient     Boolean                @default(false)
+  retentionEligibleAt  DateTime?
+  legalHoldActive      Boolean                @default(false)
+  dispositionStatus    DocumentDispositionStatus @default(ACTIVE)
+  disposedAt           DateTime?
   createdByUserId      String?                @db.Uuid
   rawSourcePayload     Json?
   createdAt            DateTime               @default(now())
   updatedAt            DateTime               @updatedAt
   matter               Matter                 @relation(fields: [matterId], references: [id], onDelete: Cascade)
   folder               DocumentFolder?        @relation(fields: [folderId], references: [id], onDelete: SetNull)
+  retentionPolicy      DocumentRetentionPolicy? @relation(fields: [retentionPolicyId], references: [id], onDelete: SetNull)
   createdBy            User?                  @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
   versions             DocumentVersion[]
   shareLinks           DocumentShareLink[]
+  legalHolds           DocumentLegalHold[]
+  dispositionItems     DocumentDispositionItem[]
   docketEntries        DocketEntry[]
   lienModels           LienModel[]
   expertEngagements    ExpertEngagement[]
   eSignEnvelopes       ESignEnvelope[]
 
   @@index([organizationId, matterId])
+  @@index([organizationId, retentionEligibleAt])
+  @@index([organizationId, dispositionStatus])
 }
 
 model DocumentVersion {
@@ -891,6 +945,93 @@ model DocumentShareLink {
   createdAt      DateTime @default(now())
   document       Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
   createdBy      User?    @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
+}
+
+model DocumentRetentionPolicy {
+  id             String         @id @default(uuid()) @db.Uuid
+  organizationId String         @db.Uuid
+  matterId       String?        @db.Uuid
+  name           String
+  description    String?
+  scope          RetentionScope @default(ALL_DOCUMENTS)
+  category       String?
+  retentionDays  Int
+  trigger        RetentionTrigger @default(DOCUMENT_UPLOADED)
+  requireApproval Boolean       @default(true)
+  isActive       Boolean        @default(true)
+  createdByUserId String?       @db.Uuid
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
+  matter         Matter?        @relation(fields: [matterId], references: [id], onDelete: SetNull)
+  createdBy      User?          @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
+  documents      Document[]
+  dispositionRuns DocumentDispositionRun[]
+
+  @@index([organizationId, isActive])
+  @@index([organizationId, scope])
+}
+
+model DocumentLegalHold {
+  id               String                 @id @default(uuid()) @db.Uuid
+  organizationId   String                 @db.Uuid
+  documentId       String                 @db.Uuid
+  matterId         String?                @db.Uuid
+  reason           String
+  status           DocumentLegalHoldStatus @default(ACTIVE)
+  placedByUserId   String?                @db.Uuid
+  releasedByUserId String?                @db.Uuid
+  placedAt         DateTime               @default(now())
+  releasedAt       DateTime?
+  createdAt        DateTime               @default(now())
+  updatedAt        DateTime               @updatedAt
+  document         Document               @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  matter           Matter?                @relation(fields: [matterId], references: [id], onDelete: SetNull)
+  placedBy         User?                  @relation("DocumentLegalHoldPlacedBy", fields: [placedByUserId], references: [id], onDelete: SetNull)
+  releasedBy       User?                  @relation("DocumentLegalHoldReleasedBy", fields: [releasedByUserId], references: [id], onDelete: SetNull)
+
+  @@index([organizationId, status, placedAt])
+  @@index([organizationId, documentId])
+}
+
+model DocumentDispositionRun {
+  id               String                     @id @default(uuid()) @db.Uuid
+  organizationId   String                     @db.Uuid
+  policyId         String?                    @db.Uuid
+  status           DocumentDispositionRunStatus @default(DRAFT)
+  cutoffAt         DateTime
+  notes            String?
+  requestedByUserId String?                   @db.Uuid
+  approvedByUserId String?                    @db.Uuid
+  approvedAt       DateTime?
+  executedByUserId String?                    @db.Uuid
+  executedAt       DateTime?
+  createdAt        DateTime                   @default(now())
+  updatedAt        DateTime                   @updatedAt
+  policy           DocumentRetentionPolicy?   @relation(fields: [policyId], references: [id], onDelete: SetNull)
+  requestedBy      User?                      @relation("DocumentDispositionRunRequestedBy", fields: [requestedByUserId], references: [id], onDelete: SetNull)
+  approvedBy       User?                      @relation("DocumentDispositionRunApprovedBy", fields: [approvedByUserId], references: [id], onDelete: SetNull)
+  executedBy       User?                      @relation("DocumentDispositionRunExecutedBy", fields: [executedByUserId], references: [id], onDelete: SetNull)
+  items            DocumentDispositionItem[]
+
+  @@index([organizationId, status, createdAt])
+}
+
+model DocumentDispositionItem {
+  id             String                       @id @default(uuid()) @db.Uuid
+  organizationId String                       @db.Uuid
+  runId          String                       @db.Uuid
+  documentId     String                       @db.Uuid
+  status         DocumentDispositionItemStatus @default(PENDING)
+  scheduledAt    DateTime                     @default(now())
+  appliedAt      DateTime?
+  note           String?
+  createdAt      DateTime                     @default(now())
+  updatedAt      DateTime                     @updatedAt
+  run            DocumentDispositionRun       @relation(fields: [runId], references: [id], onDelete: Cascade)
+  document       Document                     @relation(fields: [documentId], references: [id], onDelete: Cascade)
+
+  @@unique([runId, documentId])
+  @@index([organizationId, status, scheduledAt])
 }
 
 model EvidenceItem {

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -22,6 +22,10 @@ async function main() {
     prisma.stylePackSourceDoc.deleteMany(),
     prisma.stylePack.deleteMany(),
     prisma.eSignEnvelope.deleteMany(),
+    prisma.documentDispositionItem.deleteMany(),
+    prisma.documentDispositionRun.deleteMany(),
+    prisma.documentLegalHold.deleteMany(),
+    prisma.documentRetentionPolicy.deleteMany(),
     prisma.engagementLetterTemplate.deleteMany(),
     prisma.conflictCheckResult.deleteMany(),
     prisma.intakeSubmission.deleteMany(),
@@ -722,6 +726,49 @@ async function main() {
         uploadedByUserId: paralegalUser.id,
       },
     ],
+  });
+
+  const retentionPolicy = await prisma.documentRetentionPolicy.create({
+    data: {
+      organizationId: org.id,
+      name: 'Construction Litigation Standard - 7 Year',
+      description: 'Retain client matter documents for 7 years from upload unless legal hold is active.',
+      scope: 'ALL_DOCUMENTS',
+      retentionDays: 365 * 7,
+      trigger: 'DOCUMENT_UPLOADED',
+      requireApproval: true,
+      createdByUserId: adminUser.id,
+    },
+  });
+
+  await prisma.document.updateMany({
+    where: {
+      id: {
+        in: [contractDoc.id, changeOrderDoc.id, inspectionDoc.id, schedulingOrderDoc.id],
+      },
+    },
+    data: {
+      retentionPolicyId: retentionPolicy.id,
+      retentionEligibleAt: new Date('2033-01-01T00:00:00Z'),
+    },
+  });
+
+  await prisma.documentLegalHold.create({
+    data: {
+      organizationId: org.id,
+      documentId: inspectionDoc.id,
+      matterId: matter1.id,
+      reason: 'Preserve inspection media for pending mediation and potential trial exhibits.',
+      placedByUserId: attorneyUser.id,
+      status: 'ACTIVE',
+    },
+  });
+
+  await prisma.document.update({
+    where: { id: inspectionDoc.id },
+    data: {
+      legalHoldActive: true,
+    },
   });
 
   await prisma.calendarEvent.createMany({

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -18,6 +18,10 @@ import { RequirePermissions } from '../common/decorators/permissions.decorator';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { AuthenticatedUser, UploadedFile as UploadedBinary } from '../common/types';
 import { UploadDocumentDto } from './dto/upload-document.dto';
+import { CreateRetentionPolicyDto } from './dto/create-retention-policy.dto';
+import { AssignRetentionPolicyDto } from './dto/assign-retention-policy.dto';
+import { PlaceLegalHoldDto, ReleaseLegalHoldDto } from './dto/legal-hold.dto';
+import { CreateDispositionRunDto, DispositionRunActionDto } from './dto/disposition-run.dto';
 
 @Controller('documents')
 export class DocumentsController {
@@ -127,6 +131,117 @@ export class DocumentsController {
       matterId: body.matterId,
       title: body.title,
       lines: body.lines,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Get('retention/policies')
+  @RequirePermissions('documents:read')
+  listRetentionPolicies(@CurrentUser() user: AuthenticatedUser) {
+    return this.documentsService.listRetentionPolicies(user);
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post('retention/policies')
+  @RequirePermissions('documents:write')
+  createRetentionPolicy(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateRetentionPolicyDto) {
+    return this.documentsService.createRetentionPolicy({
+      user,
+      ...dto,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post(':id/retention-policy')
+  @RequirePermissions('documents:write')
+  assignRetentionPolicy(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') documentId: string,
+    @Body() dto: AssignRetentionPolicyDto,
+  ) {
+    return this.documentsService.assignRetentionPolicy({
+      user,
+      documentId,
+      policyId: dto.policyId,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post(':id/legal-hold')
+  @RequirePermissions('documents:write')
+  placeLegalHold(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') documentId: string,
+    @Body() dto: PlaceLegalHoldDto,
+  ) {
+    return this.documentsService.placeLegalHold({
+      user,
+      documentId,
+      reason: dto.reason,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post(':id/legal-hold/release')
+  @RequirePermissions('documents:write')
+  releaseLegalHold(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') documentId: string,
+    @Body() dto: ReleaseLegalHoldDto,
+  ) {
+    return this.documentsService.releaseLegalHold({
+      user,
+      documentId,
+      reason: dto.reason,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Get('disposition/runs')
+  @RequirePermissions('documents:read')
+  listDispositionRuns(@CurrentUser() user: AuthenticatedUser) {
+    return this.documentsService.listDispositionRuns(user);
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post('disposition/runs')
+  @RequirePermissions('documents:write')
+  createDispositionRun(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateDispositionRunDto) {
+    return this.documentsService.createDispositionRun({
+      user,
+      policyId: dto.policyId,
+      cutoffAt: dto.cutoffAt,
+      notes: dto.notes,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post('disposition/runs/:id/approve')
+  @RequirePermissions('documents:write')
+  approveDispositionRun(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') runId: string,
+    @Body() dto: DispositionRunActionDto,
+  ) {
+    return this.documentsService.approveDispositionRun({
+      user,
+      runId,
+      notes: dto.notes,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Post('disposition/runs/:id/execute')
+  @RequirePermissions('documents:write')
+  executeDispositionRun(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') runId: string,
+    @Body() dto: DispositionRunActionDto,
+  ) {
+    return this.documentsService.executeDispositionRun({
+      user,
+      runId,
+      notes: dto.notes,
     });
   }
 }

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -3,7 +3,16 @@ import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';
 import PizZip from 'pizzip';
 import Docxtemplater from 'docxtemplater';
-import { ContactKind, DocumentConfidentiality } from '@prisma/client';
+import {
+  ContactKind,
+  DocumentConfidentiality,
+  DocumentDispositionItemStatus,
+  DocumentDispositionRunStatus,
+  DocumentDispositionStatus,
+  DocumentLegalHoldStatus,
+  RetentionScope,
+  RetentionTrigger,
+} from '@prisma/client';
 import { PDFDocument, StandardFonts } from 'pdf-lib';
 import { PrismaService } from '../prisma/prisma.service';
 import { AccessService } from '../access/access.service';
@@ -109,9 +118,576 @@ export class DocumentsService {
       },
       include: {
         versions: { orderBy: { uploadedAt: 'desc' } },
+        retentionPolicy: true,
+        legalHolds: {
+          where: { status: DocumentLegalHoldStatus.ACTIVE },
+          orderBy: { placedAt: 'desc' },
+          take: 1,
+        },
       },
       orderBy: { createdAt: 'desc' },
     });
+  }
+
+  async listRetentionPolicies(user: AuthenticatedUser) {
+    return this.prisma.documentRetentionPolicy.findMany({
+      where: {
+        organizationId: user.organizationId,
+      },
+      include: {
+        matter: {
+          select: {
+            id: true,
+            matterNumber: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [{ isActive: 'desc' }, { updatedAt: 'desc' }],
+    });
+  }
+
+  async createRetentionPolicy(input: {
+    user: AuthenticatedUser;
+    name: string;
+    description?: string;
+    scope: RetentionScope;
+    matterId?: string;
+    category?: string;
+    retentionDays: number;
+    trigger: RetentionTrigger;
+    requireApproval?: boolean;
+    isActive?: boolean;
+  }) {
+    if (input.scope === RetentionScope.MATTER && !input.matterId) {
+      throw new UnprocessableEntityException('matterId is required when scope is MATTER');
+    }
+    if (input.scope === RetentionScope.CATEGORY && !input.category?.trim()) {
+      throw new UnprocessableEntityException('category is required when scope is CATEGORY');
+    }
+    if (input.matterId) {
+      await this.access.assertMatterAccess(input.user, input.matterId, 'write');
+    }
+
+    const policy = await this.prisma.documentRetentionPolicy.create({
+      data: {
+        organizationId: input.user.organizationId,
+        name: input.name.trim(),
+        description: input.description?.trim() || null,
+        scope: input.scope,
+        matterId: input.matterId || null,
+        category: input.category?.trim() || null,
+        retentionDays: input.retentionDays,
+        trigger: input.trigger,
+        requireApproval: input.requireApproval ?? true,
+        isActive: input.isActive ?? true,
+        createdByUserId: input.user.id,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.retention_policy.created',
+      entityType: 'documentRetentionPolicy',
+      entityId: policy.id,
+      metadata: {
+        scope: policy.scope,
+        trigger: policy.trigger,
+        retentionDays: policy.retentionDays,
+        requireApproval: policy.requireApproval,
+      },
+    });
+
+    return policy;
+  }
+
+  async assignRetentionPolicy(input: {
+    user: AuthenticatedUser;
+    documentId: string;
+    policyId: string;
+  }) {
+    const document = await this.prisma.document.findFirst({
+      where: {
+        id: input.documentId,
+        organizationId: input.user.organizationId,
+      },
+      include: {
+        matter: {
+          select: {
+            id: true,
+            closedAt: true,
+          },
+        },
+      },
+    });
+    if (!document) {
+      throw new NotFoundException('Document not found');
+    }
+    if (document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
+      throw new UnprocessableEntityException('Cannot assign retention policy to a disposed document');
+    }
+    await this.access.assertMatterAccess(input.user, document.matterId, 'write');
+
+    const policy = await this.prisma.documentRetentionPolicy.findFirst({
+      where: {
+        id: input.policyId,
+        organizationId: input.user.organizationId,
+        isActive: true,
+      },
+    });
+    if (!policy) {
+      throw new NotFoundException('Retention policy not found');
+    }
+    if (policy.scope === RetentionScope.MATTER && policy.matterId && policy.matterId !== document.matterId) {
+      throw new UnprocessableEntityException('Retention policy scope does not match document matter');
+    }
+    if (policy.scope === RetentionScope.CATEGORY && policy.category && policy.category !== (document.category || '')) {
+      throw new UnprocessableEntityException('Retention policy scope does not match document category');
+    }
+
+    const retentionEligibleAt = this.computeRetentionEligibleAt({
+      trigger: policy.trigger,
+      retentionDays: policy.retentionDays,
+      documentCreatedAt: document.createdAt,
+      matterClosedAt: document.matter.closedAt,
+    });
+
+    const updated = await this.prisma.document.update({
+      where: { id: document.id },
+      data: {
+        retentionPolicyId: policy.id,
+        retentionEligibleAt,
+      },
+      include: {
+        retentionPolicy: true,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.retention_policy.assigned',
+      entityType: 'document',
+      entityId: document.id,
+      metadata: {
+        retentionPolicyId: policy.id,
+        retentionEligibleAt: retentionEligibleAt.toISOString(),
+      },
+    });
+
+    return updated;
+  }
+
+  async placeLegalHold(input: {
+    user: AuthenticatedUser;
+    documentId: string;
+    reason: string;
+  }) {
+    const document = await this.prisma.document.findFirst({
+      where: {
+        id: input.documentId,
+        organizationId: input.user.organizationId,
+      },
+    });
+    if (!document) {
+      throw new NotFoundException('Document not found');
+    }
+    if (document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
+      throw new UnprocessableEntityException('Cannot place legal hold on a disposed document');
+    }
+    await this.access.assertMatterAccess(input.user, document.matterId, 'write');
+    if (!input.reason.trim()) {
+      throw new UnprocessableEntityException('Legal hold reason is required');
+    }
+
+    const existing = await this.prisma.documentLegalHold.findFirst({
+      where: {
+        organizationId: input.user.organizationId,
+        documentId: document.id,
+        status: DocumentLegalHoldStatus.ACTIVE,
+      },
+    });
+    if (existing) {
+      return existing;
+    }
+
+    const hold = await this.prisma.documentLegalHold.create({
+      data: {
+        organizationId: input.user.organizationId,
+        documentId: document.id,
+        matterId: document.matterId,
+        reason: input.reason.trim(),
+        status: DocumentLegalHoldStatus.ACTIVE,
+        placedByUserId: input.user.id,
+      },
+    });
+
+    await this.prisma.document.update({
+      where: { id: document.id },
+      data: {
+        legalHoldActive: true,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.legal_hold.placed',
+      entityType: 'document',
+      entityId: document.id,
+      metadata: {
+        legalHoldId: hold.id,
+        reason: hold.reason,
+      },
+    });
+
+    return hold;
+  }
+
+  async releaseLegalHold(input: {
+    user: AuthenticatedUser;
+    documentId: string;
+    reason?: string;
+  }) {
+    const document = await this.prisma.document.findFirst({
+      where: {
+        id: input.documentId,
+        organizationId: input.user.organizationId,
+      },
+    });
+    if (!document) {
+      throw new NotFoundException('Document not found');
+    }
+    await this.access.assertMatterAccess(input.user, document.matterId, 'write');
+
+    const activeHold = await this.prisma.documentLegalHold.findFirst({
+      where: {
+        organizationId: input.user.organizationId,
+        documentId: document.id,
+        status: DocumentLegalHoldStatus.ACTIVE,
+      },
+      orderBy: {
+        placedAt: 'desc',
+      },
+    });
+    if (!activeHold) {
+      throw new NotFoundException('Active legal hold not found for document');
+    }
+
+    const released = await this.prisma.documentLegalHold.update({
+      where: { id: activeHold.id },
+      data: {
+        status: DocumentLegalHoldStatus.RELEASED,
+        releasedByUserId: input.user.id,
+        releasedAt: new Date(),
+        reason: input.reason?.trim()
+          ? `${activeHold.reason}\n\nRelease note: ${input.reason.trim()}`
+          : activeHold.reason,
+      },
+    });
+
+    await this.prisma.document.update({
+      where: { id: document.id },
+      data: {
+        legalHoldActive: false,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.legal_hold.released',
+      entityType: 'document',
+      entityId: document.id,
+      metadata: {
+        legalHoldId: released.id,
+        releaseReason: input.reason?.trim() || null,
+      },
+    });
+
+    return released;
+  }
+
+  async listDispositionRuns(user: AuthenticatedUser) {
+    return this.prisma.documentDispositionRun.findMany({
+      where: {
+        organizationId: user.organizationId,
+      },
+      include: {
+        policy: true,
+        items: {
+          include: {
+            document: {
+              select: {
+                id: true,
+                title: true,
+                matterId: true,
+                legalHoldActive: true,
+                dispositionStatus: true,
+              },
+            },
+          },
+          orderBy: {
+            createdAt: 'asc',
+          },
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      take: 25,
+    });
+  }
+
+  async createDispositionRun(input: {
+    user: AuthenticatedUser;
+    policyId?: string;
+    cutoffAt?: string;
+    notes?: string;
+  }) {
+    const cutoffAt = input.cutoffAt ? new Date(input.cutoffAt) : new Date();
+    if (Number.isNaN(cutoffAt.getTime())) {
+      throw new UnprocessableEntityException('Invalid cutoffAt');
+    }
+
+    let policy = null;
+    if (input.policyId) {
+      policy = await this.prisma.documentRetentionPolicy.findFirst({
+        where: {
+          id: input.policyId,
+          organizationId: input.user.organizationId,
+          isActive: true,
+        },
+      });
+      if (!policy) {
+        throw new NotFoundException('Retention policy not found');
+      }
+    }
+
+    const candidateDocuments = await this.prisma.document.findMany({
+      where: {
+        organizationId: input.user.organizationId,
+        dispositionStatus: {
+          not: DocumentDispositionStatus.DISPOSED,
+        },
+        retentionEligibleAt: {
+          lte: cutoffAt,
+        },
+        ...(policy ? { retentionPolicyId: policy.id } : {}),
+      },
+      select: {
+        id: true,
+        matterId: true,
+        legalHoldActive: true,
+      },
+    });
+
+    const accessibleCandidates: Array<{ id: string; legalHoldActive: boolean }> = [];
+    for (const candidate of candidateDocuments) {
+      try {
+        await this.access.assertMatterAccess(input.user, candidate.matterId, 'write');
+        accessibleCandidates.push({
+          id: candidate.id,
+          legalHoldActive: candidate.legalHoldActive,
+        });
+      } catch {
+        continue;
+      }
+    }
+
+    const runStatus = policy?.requireApproval ?? true
+      ? DocumentDispositionRunStatus.PENDING_APPROVAL
+      : DocumentDispositionRunStatus.APPROVED;
+
+    const run = await this.prisma.documentDispositionRun.create({
+      data: {
+        organizationId: input.user.organizationId,
+        policyId: policy?.id || null,
+        status: runStatus,
+        cutoffAt,
+        notes: input.notes?.trim() || null,
+        requestedByUserId: input.user.id,
+        items: {
+          create: accessibleCandidates.map((document) => ({
+            organizationId: input.user.organizationId,
+            documentId: document.id,
+            status: document.legalHoldActive
+              ? DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD
+              : DocumentDispositionItemStatus.PENDING,
+            note: document.legalHoldActive ? 'Skipped because legal hold is active.' : null,
+          })),
+        },
+      },
+      include: {
+        items: true,
+      },
+    });
+
+    const pendingDocumentIds = run.items
+      .filter((item) => item.status === DocumentDispositionItemStatus.PENDING)
+      .map((item) => item.documentId);
+    if (pendingDocumentIds.length > 0) {
+      await this.prisma.document.updateMany({
+        where: {
+          id: { in: pendingDocumentIds },
+          organizationId: input.user.organizationId,
+          dispositionStatus: DocumentDispositionStatus.ACTIVE,
+        },
+        data: {
+          dispositionStatus: DocumentDispositionStatus.PENDING_DISPOSITION,
+        },
+      });
+    }
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.disposition_run.created',
+      entityType: 'documentDispositionRun',
+      entityId: run.id,
+      metadata: {
+        policyId: policy?.id || null,
+        cutoffAt: cutoffAt.toISOString(),
+        totalItems: run.items.length,
+        pendingItems: run.items.filter((item) => item.status === DocumentDispositionItemStatus.PENDING).length,
+        skippedForLegalHold: run.items.filter((item) => item.status === DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD).length,
+      },
+    });
+
+    return run;
+  }
+
+  async approveDispositionRun(input: {
+    user: AuthenticatedUser;
+    runId: string;
+    notes?: string;
+  }) {
+    const run = await this.prisma.documentDispositionRun.findFirst({
+      where: {
+        id: input.runId,
+        organizationId: input.user.organizationId,
+      },
+    });
+    if (!run) {
+      throw new NotFoundException('Disposition run not found');
+    }
+    if (run.status !== DocumentDispositionRunStatus.PENDING_APPROVAL && run.status !== DocumentDispositionRunStatus.DRAFT) {
+      throw new UnprocessableEntityException('Only draft or pending-approval runs can be approved');
+    }
+
+    const approved = await this.prisma.documentDispositionRun.update({
+      where: { id: run.id },
+      data: {
+        status: DocumentDispositionRunStatus.APPROVED,
+        approvedByUserId: input.user.id,
+        approvedAt: new Date(),
+        notes: this.combineNotes(run.notes, input.notes),
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.disposition_run.approved',
+      entityType: 'documentDispositionRun',
+      entityId: approved.id,
+      metadata: {
+        approvedAt: approved.approvedAt,
+      },
+    });
+
+    return approved;
+  }
+
+  async executeDispositionRun(input: {
+    user: AuthenticatedUser;
+    runId: string;
+    notes?: string;
+  }) {
+    const run = await this.prisma.documentDispositionRun.findFirst({
+      where: {
+        id: input.runId,
+        organizationId: input.user.organizationId,
+      },
+      include: {
+        items: true,
+      },
+    });
+    if (!run) {
+      throw new NotFoundException('Disposition run not found');
+    }
+    if (run.status !== DocumentDispositionRunStatus.APPROVED) {
+      throw new UnprocessableEntityException('Disposition run must be approved before execution');
+    }
+
+    const now = new Date();
+    const pendingItems = run.items.filter((item) => item.status === DocumentDispositionItemStatus.PENDING);
+    const pendingDocumentIds = pendingItems.map((item) => item.documentId);
+
+    if (pendingDocumentIds.length > 0) {
+      await this.prisma.document.updateMany({
+        where: {
+          id: { in: pendingDocumentIds },
+          organizationId: input.user.organizationId,
+        },
+        data: {
+          dispositionStatus: DocumentDispositionStatus.DISPOSED,
+          disposedAt: now,
+          sharedWithClient: false,
+        },
+      });
+
+      await this.prisma.documentShareLink.updateMany({
+        where: {
+          organizationId: input.user.organizationId,
+          documentId: { in: pendingDocumentIds },
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: now,
+        },
+      });
+
+      await this.prisma.documentDispositionItem.updateMany({
+        where: {
+          runId: run.id,
+          organizationId: input.user.organizationId,
+          status: DocumentDispositionItemStatus.PENDING,
+        },
+        data: {
+          status: DocumentDispositionItemStatus.DISPOSED,
+          appliedAt: now,
+        },
+      });
+    }
+
+    const completed = await this.prisma.documentDispositionRun.update({
+      where: { id: run.id },
+      data: {
+        status: DocumentDispositionRunStatus.COMPLETED,
+        executedByUserId: input.user.id,
+        executedAt: now,
+        notes: this.combineNotes(run.notes, input.notes),
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.disposition_run.completed',
+      entityType: 'documentDispositionRun',
+      entityId: completed.id,
+      metadata: {
+        executedAt: now.toISOString(),
+        disposedCount: pendingDocumentIds.length,
+      },
+    });
+
+    return {
+      ...completed,
+      disposedDocumentCount: pendingDocumentIds.length,
+    };
   }
 
   async uploadNew(input: {
@@ -197,6 +773,9 @@ export class DocumentsService {
     if (!document) {
       throw new NotFoundException('Document not found');
     }
+    if (document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
+      throw new UnprocessableEntityException('Cannot upload a new version for a disposed document');
+    }
 
     await this.access.assertMatterAccess(input.user, document.matterId, 'write');
 
@@ -245,6 +824,9 @@ export class DocumentsService {
     if (!version) {
       throw new NotFoundException('Document version not found');
     }
+    if (version.document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
+      throw new UnprocessableEntityException('Disposed documents are not available for download');
+    }
 
     await this.access.assertMatterAccess(user, version.document.matterId);
 
@@ -264,6 +846,9 @@ export class DocumentsService {
 
     if (!document) {
       throw new NotFoundException('Document not found');
+    }
+    if (document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
+      throw new UnprocessableEntityException('Cannot share a disposed document');
     }
 
     await this.access.assertMatterAccess(input.user, document.matterId, 'write');
@@ -305,6 +890,9 @@ export class DocumentsService {
     });
 
     if (!link || link.document.versions.length === 0) {
+      throw new NotFoundException('Share link not valid');
+    }
+    if (link.document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
       throw new NotFoundException('Share link not valid');
     }
 
@@ -491,6 +1079,39 @@ export class DocumentsService {
     });
 
     return generatedDocument;
+  }
+
+  private computeRetentionEligibleAt(input: {
+    trigger: RetentionTrigger;
+    retentionDays: number;
+    documentCreatedAt: Date;
+    matterClosedAt: Date | null;
+  }) {
+    const anchorDate =
+      input.trigger === RetentionTrigger.MATTER_CLOSED
+        ? input.matterClosedAt
+        : input.documentCreatedAt;
+
+    if (!anchorDate) {
+      throw new UnprocessableEntityException(
+        'Retention trigger requires a closed matter date, but the matter is not closed',
+      );
+    }
+
+    const eligibleAt = new Date(anchorDate);
+    eligibleAt.setUTCDate(eligibleAt.getUTCDate() + input.retentionDays);
+    return eligibleAt;
+  }
+
+  private combineNotes(existing: string | null | undefined, extra?: string) {
+    if (!extra?.trim()) {
+      return existing ?? null;
+    }
+    const normalized = extra.trim();
+    if (!existing?.trim()) {
+      return normalized;
+    }
+    return `${existing.trim()}\n\n${normalized}`;
   }
 
   private async buildTemplateMergeContext(user: AuthenticatedUser, matterId: string): Promise<TemplateMergeContext> {

--- a/apps/api/src/documents/dto/assign-retention-policy.dto.ts
+++ b/apps/api/src/documents/dto/assign-retention-policy.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class AssignRetentionPolicyDto {
+  @IsString()
+  policyId!: string;
+}

--- a/apps/api/src/documents/dto/create-retention-policy.dto.ts
+++ b/apps/api/src/documents/dto/create-retention-policy.dto.ts
@@ -1,0 +1,38 @@
+import { IsBoolean, IsIn, IsInt, IsOptional, IsString, Min } from 'class-validator';
+
+export class CreateRetentionPolicyDto {
+  @IsString()
+  name!: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  @IsIn(['ALL_DOCUMENTS', 'MATTER', 'CATEGORY'])
+  scope!: 'ALL_DOCUMENTS' | 'MATTER' | 'CATEGORY';
+
+  @IsString()
+  @IsOptional()
+  matterId?: string;
+
+  @IsString()
+  @IsOptional()
+  category?: string;
+
+  @IsInt()
+  @Min(1)
+  retentionDays!: number;
+
+  @IsString()
+  @IsIn(['DOCUMENT_UPLOADED', 'MATTER_CLOSED'])
+  trigger!: 'DOCUMENT_UPLOADED' | 'MATTER_CLOSED';
+
+  @IsBoolean()
+  @IsOptional()
+  requireApproval?: boolean;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/apps/api/src/documents/dto/disposition-run.dto.ts
+++ b/apps/api/src/documents/dto/disposition-run.dto.ts
@@ -1,0 +1,21 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateDispositionRunDto {
+  @IsString()
+  @IsOptional()
+  policyId?: string;
+
+  @IsString()
+  @IsOptional()
+  cutoffAt?: string;
+
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}
+
+export class DispositionRunActionDto {
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/apps/api/src/documents/dto/legal-hold.dto.ts
+++ b/apps/api/src/documents/dto/legal-hold.dto.ts
@@ -1,0 +1,12 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class PlaceLegalHoldDto {
+  @IsString()
+  reason!: string;
+}
+
+export class ReleaseLegalHoldDto {
+  @IsString()
+  @IsOptional()
+  reason?: string;
+}

--- a/apps/api/test/document-retention.spec.ts
+++ b/apps/api/test/document-retention.spec.ts
@@ -1,0 +1,275 @@
+import {
+  DocumentDispositionItemStatus,
+  DocumentDispositionRunStatus,
+  DocumentDispositionStatus,
+  DocumentLegalHoldStatus,
+  RetentionScope,
+  RetentionTrigger,
+} from '@prisma/client';
+import { DocumentsService } from '../src/documents/documents.service';
+
+const baseUser = {
+  id: 'user-1',
+  organizationId: 'org-1',
+} as any;
+
+describe('DocumentsService retention/legal-hold/disposition workflows', () => {
+  it('creates retention policy with audit event', async () => {
+    const prisma = {
+      documentRetentionPolicy: {
+        create: jest.fn().mockResolvedValue({
+          id: 'policy-1',
+          scope: RetentionScope.ALL_DOCUMENTS,
+          trigger: RetentionTrigger.DOCUMENT_UPLOADED,
+          retentionDays: 365,
+          requireApproval: true,
+        }),
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn(), getObjectBuffer: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      audit,
+    );
+
+    const created = await service.createRetentionPolicy({
+      user: baseUser,
+      name: 'Standard 1-year',
+      scope: RetentionScope.ALL_DOCUMENTS,
+      retentionDays: 365,
+      trigger: RetentionTrigger.DOCUMENT_UPLOADED,
+    });
+
+    expect(created.id).toBe('policy-1');
+    expect(prisma.documentRetentionPolicy.create).toHaveBeenCalled();
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.retention_policy.created',
+        entityType: 'documentRetentionPolicy',
+      }),
+    );
+  });
+
+  it('assigns retention policy and computes retentionEligibleAt', async () => {
+    const documentUpdate = jest.fn().mockImplementation(({ data }) => Promise.resolve({ id: 'doc-1', ...data }));
+    const prisma = {
+      document: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          category: 'Evidence',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          dispositionStatus: DocumentDispositionStatus.ACTIVE,
+          matter: { id: 'matter-1', closedAt: null },
+        }),
+        update: documentUpdate,
+      },
+      documentRetentionPolicy: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'policy-1',
+          organizationId: 'org-1',
+          isActive: true,
+          scope: RetentionScope.ALL_DOCUMENTS,
+          retentionDays: 30,
+          trigger: RetentionTrigger.DOCUMENT_UPLOADED,
+        }),
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const access = { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new DocumentsService(
+      prisma,
+      access,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn(), getObjectBuffer: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      audit,
+    );
+
+    const updated = await service.assignRetentionPolicy({
+      user: baseUser,
+      documentId: 'doc-1',
+      policyId: 'policy-1',
+    });
+
+    expect(access.assertMatterAccess).toHaveBeenCalledWith(baseUser, 'matter-1', 'write');
+    expect(updated.retentionPolicyId).toBe('policy-1');
+    expect(updated.retentionEligibleAt?.toISOString()).toBe('2026-01-31T00:00:00.000Z');
+  });
+
+  it('places and releases legal hold with audit events', async () => {
+    const prisma = {
+      document: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'doc-1',
+            organizationId: 'org-1',
+            matterId: 'matter-1',
+            dispositionStatus: DocumentDispositionStatus.ACTIVE,
+          })
+          .mockResolvedValueOnce({
+            id: 'doc-1',
+            organizationId: 'org-1',
+            matterId: 'matter-1',
+            dispositionStatus: DocumentDispositionStatus.ACTIVE,
+          }),
+        update: jest.fn().mockResolvedValue(undefined),
+      },
+      documentLegalHold: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            id: 'hold-1',
+            organizationId: 'org-1',
+            documentId: 'doc-1',
+            status: DocumentLegalHoldStatus.ACTIVE,
+            reason: 'Preserve',
+          }),
+        create: jest.fn().mockResolvedValue({
+          id: 'hold-1',
+          organizationId: 'org-1',
+          documentId: 'doc-1',
+          status: DocumentLegalHoldStatus.ACTIVE,
+          reason: 'Preserve',
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'hold-1',
+          organizationId: 'org-1',
+          documentId: 'doc-1',
+          status: DocumentLegalHoldStatus.RELEASED,
+        }),
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const access = { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new DocumentsService(
+      prisma,
+      access,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn(), getObjectBuffer: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      audit,
+    );
+
+    const hold = await service.placeLegalHold({
+      user: baseUser,
+      documentId: 'doc-1',
+      reason: 'Preserve',
+    });
+    expect(hold.id).toBe('hold-1');
+
+    const released = await service.releaseLegalHold({
+      user: baseUser,
+      documentId: 'doc-1',
+      reason: 'No longer needed',
+    });
+    expect(released.status).toBe(DocumentLegalHoldStatus.RELEASED);
+    expect(audit.appendEvent).toHaveBeenCalledWith(expect.objectContaining({ action: 'document.legal_hold.placed' }));
+    expect(audit.appendEvent).toHaveBeenCalledWith(expect.objectContaining({ action: 'document.legal_hold.released' }));
+  });
+
+  it('creates, approves, and executes a disposition run while skipping legal-hold docs', async () => {
+    const documentUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const dispositionUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const runUpdate = jest
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'run-1',
+        organizationId: 'org-1',
+        status: DocumentDispositionRunStatus.APPROVED,
+        approvedAt: new Date('2026-02-01T00:00:00.000Z'),
+      })
+      .mockResolvedValueOnce({
+        id: 'run-1',
+        organizationId: 'org-1',
+        status: DocumentDispositionRunStatus.COMPLETED,
+        executedAt: new Date('2026-02-01T01:00:00.000Z'),
+      });
+
+    const prisma = {
+      document: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'doc-1', matterId: 'matter-1', legalHoldActive: false },
+          { id: 'doc-2', matterId: 'matter-2', legalHoldActive: true },
+        ]),
+        updateMany: documentUpdateMany,
+      },
+      documentDispositionRun: {
+        create: jest.fn().mockResolvedValue({
+          id: 'run-1',
+          organizationId: 'org-1',
+          status: DocumentDispositionRunStatus.PENDING_APPROVAL,
+          items: [
+            { id: 'item-1', documentId: 'doc-1', status: DocumentDispositionItemStatus.PENDING },
+            { id: 'item-2', documentId: 'doc-2', status: DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD },
+          ],
+        }),
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'run-1',
+            organizationId: 'org-1',
+            status: DocumentDispositionRunStatus.PENDING_APPROVAL,
+            notes: null,
+          })
+          .mockResolvedValueOnce({
+            id: 'run-1',
+            organizationId: 'org-1',
+            status: DocumentDispositionRunStatus.APPROVED,
+            notes: null,
+            items: [
+              { id: 'item-1', documentId: 'doc-1', status: DocumentDispositionItemStatus.PENDING },
+              { id: 'item-2', documentId: 'doc-2', status: DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD },
+            ],
+          }),
+        update: runUpdate,
+      },
+      documentShareLink: {
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      documentDispositionItem: {
+        updateMany: dispositionUpdateMany,
+      },
+    } as any;
+
+    const access = {
+      assertMatterAccess: jest.fn().mockResolvedValue(undefined),
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new DocumentsService(
+      prisma,
+      access,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn(), getObjectBuffer: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      audit,
+    );
+
+    const run = await service.createDispositionRun({ user: baseUser });
+    expect(run.items).toHaveLength(2);
+    expect(prisma.documentDispositionRun.create).toHaveBeenCalled();
+
+    const approved = await service.approveDispositionRun({
+      user: baseUser,
+      runId: 'run-1',
+      notes: 'Approved',
+    });
+    expect(approved.status).toBe(DocumentDispositionRunStatus.APPROVED);
+
+    const executed = await service.executeDispositionRun({
+      user: baseUser,
+      runId: 'run-1',
+      notes: 'Execute now',
+    });
+    expect(executed.status).toBe(DocumentDispositionRunStatus.COMPLETED);
+    expect(executed.disposedDocumentCount).toBe(1);
+    expect(documentUpdateMany).toHaveBeenCalled();
+    expect(dispositionUpdateMany).toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/documents/page.tsx
+++ b/apps/web/app/documents/page.tsx
@@ -9,12 +9,20 @@ const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000'
 
 export default function DocumentsPage() {
   const [documents, setDocuments] = useState<any[]>([]);
+  const [retentionPolicies, setRetentionPolicies] = useState<any[]>([]);
+  const [dispositionRuns, setDispositionRuns] = useState<any[]>([]);
   const [matterId, setMatterId] = useState('');
   const [title, setTitle] = useState('Inspection Report');
   const [file, setFile] = useState<File | null>(null);
   const [pdfMatterId, setPdfMatterId] = useState('');
+  const [policyName, setPolicyName] = useState('Default 7-year retention');
+  const [policyScope, setPolicyScope] = useState<'ALL_DOCUMENTS' | 'MATTER' | 'CATEGORY'>('ALL_DOCUMENTS');
+  const [policyTrigger, setPolicyTrigger] = useState<'DOCUMENT_UPLOADED' | 'MATTER_CLOSED'>('DOCUMENT_UPLOADED');
+  const [policyRetentionDays, setPolicyRetentionDays] = useState('2555');
+  const [retentionStatus, setRetentionStatus] = useState<string | null>(null);
+  const [selectedPolicyId, setSelectedPolicyId] = useState('');
 
-  async function load() {
+  async function loadDocuments() {
     const token = getSessionToken();
     const response = await fetch(`${API_BASE}/documents`, {
       headers: token ? { 'x-session-token': token } : {},
@@ -24,8 +32,32 @@ export default function DocumentsPage() {
     setDocuments(await response.json());
   }
 
+  async function loadRetentionData() {
+    const token = getSessionToken();
+    const [policiesResponse, runsResponse] = await Promise.all([
+      fetch(`${API_BASE}/documents/retention/policies`, {
+        headers: token ? { 'x-session-token': token } : {},
+        credentials: 'include',
+      }),
+      fetch(`${API_BASE}/documents/disposition/runs`, {
+        headers: token ? { 'x-session-token': token } : {},
+        credentials: 'include',
+      }),
+    ]);
+    if (policiesResponse.ok) {
+      const policies = await policiesResponse.json();
+      setRetentionPolicies(policies);
+      if (!selectedPolicyId && policies.length > 0) {
+        setSelectedPolicyId(policies[0].id);
+      }
+    }
+    if (runsResponse.ok) {
+      setDispositionRuns(await runsResponse.json());
+    }
+  }
+
   useEffect(() => {
-    load().catch(() => undefined);
+    loadDocuments().catch(() => undefined);
   }, []);
 
   async function upload(e: FormEvent) {
@@ -46,7 +78,7 @@ export default function DocumentsPage() {
     });
 
     setFile(null);
-    await load();
+    await loadDocuments();
   }
 
   async function generatePdf() {
@@ -65,7 +97,141 @@ export default function DocumentsPage() {
       }),
       credentials: 'include',
     });
-    await load();
+    await loadDocuments();
+  }
+
+  async function createRetentionPolicy(e: FormEvent) {
+    e.preventDefault();
+    const token = getSessionToken();
+    const response = await fetch(`${API_BASE}/documents/retention/policies`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({
+        name: policyName,
+        scope: policyScope,
+        trigger: policyTrigger,
+        retentionDays: Number(policyRetentionDays),
+      }),
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      setRetentionStatus('Failed to create retention policy.');
+      return;
+    }
+    const created = await response.json();
+    setRetentionStatus(`Created retention policy ${created.name}.`);
+    await loadRetentionData();
+    if (created?.id) {
+      setSelectedPolicyId(created.id);
+    }
+  }
+
+  async function assignRetentionPolicy(documentId: string) {
+    if (!selectedPolicyId) {
+      setRetentionStatus('Select a retention policy first.');
+      return;
+    }
+    const token = getSessionToken();
+    await fetch(`${API_BASE}/documents/${documentId}/retention-policy`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({ policyId: selectedPolicyId }),
+      credentials: 'include',
+    });
+    setRetentionStatus(`Assigned retention policy to ${documentId}.`);
+    await loadDocuments();
+  }
+
+  async function placeLegalHold(documentId: string) {
+    const token = getSessionToken();
+    await fetch(`${API_BASE}/documents/${documentId}/legal-hold`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({
+        reason: 'Attorney requested preservation pending dispute resolution.',
+      }),
+      credentials: 'include',
+    });
+    setRetentionStatus(`Placed legal hold on ${documentId}.`);
+    await loadDocuments();
+  }
+
+  async function releaseLegalHold(documentId: string) {
+    const token = getSessionToken();
+    await fetch(`${API_BASE}/documents/${documentId}/legal-hold/release`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({
+        reason: 'Matter hold release approved by supervising attorney.',
+      }),
+      credentials: 'include',
+    });
+    setRetentionStatus(`Released legal hold on ${documentId}.`);
+    await loadDocuments();
+  }
+
+  async function createDispositionRun() {
+    const token = getSessionToken();
+    await fetch(`${API_BASE}/documents/disposition/runs`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({
+        policyId: selectedPolicyId || undefined,
+      }),
+      credentials: 'include',
+    });
+    setRetentionStatus('Created disposition run.');
+    await loadRetentionData();
+  }
+
+  async function approveDispositionRun(runId: string) {
+    const token = getSessionToken();
+    await fetch(`${API_BASE}/documents/disposition/runs/${runId}/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({
+        notes: 'Approved by attorney.',
+      }),
+      credentials: 'include',
+    });
+    setRetentionStatus(`Approved disposition run ${runId}.`);
+    await loadRetentionData();
+  }
+
+  async function executeDispositionRun(runId: string) {
+    const token = getSessionToken();
+    await fetch(`${API_BASE}/documents/disposition/runs/${runId}/execute`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(token ? { 'x-session-token': token } : {}),
+      },
+      body: JSON.stringify({
+        notes: 'Executed after approval.',
+      }),
+      credentials: 'include',
+    });
+    setRetentionStatus(`Executed disposition run ${runId}.`);
+    await loadRetentionData();
+    await loadDocuments();
   }
 
   return (
@@ -83,6 +249,54 @@ export default function DocumentsPage() {
           <button className="button secondary" type="button" onClick={generatePdf}>Generate PDF Draft</button>
         </div>
       </div>
+      <div className="card" style={{ marginBottom: 14 }}>
+        <h3 style={{ marginTop: 0 }}>Retention + Legal Hold</h3>
+        <form
+          onSubmit={createRetentionPolicy}
+          style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 160px 180px 130px auto' }}
+        >
+          <input
+            className="input"
+            placeholder="Retention policy name"
+            value={policyName}
+            onChange={(e) => setPolicyName(e.target.value)}
+          />
+          <select className="select" aria-label="Retention Scope" value={policyScope} onChange={(e) => setPolicyScope(e.target.value as any)}>
+            <option value="ALL_DOCUMENTS">All Documents</option>
+            <option value="MATTER">Matter</option>
+            <option value="CATEGORY">Category</option>
+          </select>
+          <select className="select" aria-label="Retention Trigger" value={policyTrigger} onChange={(e) => setPolicyTrigger(e.target.value as any)}>
+            <option value="DOCUMENT_UPLOADED">Document Uploaded</option>
+            <option value="MATTER_CLOSED">Matter Closed</option>
+          </select>
+          <input
+            className="input"
+            aria-label="Retention Days"
+            placeholder="Days"
+            value={policyRetentionDays}
+            onChange={(e) => setPolicyRetentionDays(e.target.value)}
+          />
+          <button className="button" type="submit">Create Policy</button>
+        </form>
+        <div style={{ marginTop: 10, display: 'grid', gap: 10, gridTemplateColumns: '1fr auto auto' }}>
+          <select className="select" aria-label="Retention Policy Select" value={selectedPolicyId} onChange={(e) => setSelectedPolicyId(e.target.value)}>
+            <option value="">Select retention policy</option>
+            {retentionPolicies.map((policy) => (
+              <option key={policy.id} value={policy.id}>
+                {policy.name} ({policy.scope}, {policy.retentionDays}d)
+              </option>
+            ))}
+          </select>
+          <button className="button secondary" type="button" onClick={loadRetentionData}>
+            Load Retention Data
+          </button>
+          <button className="button secondary" type="button" onClick={createDispositionRun}>
+            Create Disposition Run
+          </button>
+        </div>
+        {retentionStatus ? <p style={{ marginTop: 10, color: 'var(--muted)' }}>{retentionStatus}</p> : null}
+      </div>
       <div className="card">
         <table className="table">
           <thead>
@@ -91,6 +305,10 @@ export default function DocumentsPage() {
               <th>Matter</th>
               <th>Versions</th>
               <th>Shared</th>
+              <th>Retention</th>
+              <th>Legal Hold</th>
+              <th>Disposition</th>
+              <th>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -100,6 +318,63 @@ export default function DocumentsPage() {
                 <td>{doc.matterId}</td>
                 <td>{doc.versions?.length || 0}</td>
                 <td>{doc.sharedWithClient ? 'Yes' : 'No'}</td>
+                <td>{doc.retentionPolicy?.name || 'Unassigned'}</td>
+                <td>{doc.legalHoldActive ? 'Active' : 'None'}</td>
+                <td>{doc.dispositionStatus || 'ACTIVE'}</td>
+                <td>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <button className="button secondary" type="button" onClick={() => assignRetentionPolicy(doc.id)}>
+                      Assign Policy
+                    </button>
+                    {doc.legalHoldActive ? (
+                      <button className="button secondary" type="button" onClick={() => releaseLegalHold(doc.id)}>
+                        Release Hold
+                      </button>
+                    ) : (
+                      <button className="button secondary" type="button" onClick={() => placeLegalHold(doc.id)}>
+                        Place Hold
+                      </button>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="card">
+        <h3 style={{ marginTop: 0 }}>Disposition Runs</h3>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Run</th>
+              <th>Status</th>
+              <th>Cutoff</th>
+              <th>Items</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {dispositionRuns.map((run) => (
+              <tr key={run.id}>
+                <td>{run.id}</td>
+                <td>{run.status}</td>
+                <td>{new Date(run.cutoffAt).toLocaleString()}</td>
+                <td>{run.items?.length || 0}</td>
+                <td>
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    {(run.status === 'DRAFT' || run.status === 'PENDING_APPROVAL') ? (
+                      <button className="button secondary" type="button" onClick={() => approveDispositionRun(run.id)}>
+                        Approve
+                      </button>
+                    ) : null}
+                    {run.status === 'APPROVED' ? (
+                      <button className="button secondary" type="button" onClick={() => executeDispositionRun(run.id)}>
+                        Execute
+                      </button>
+                    ) : null}
+                  </div>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/apps/web/test/documents-page.spec.tsx
+++ b/apps/web/test/documents-page.spec.tsx
@@ -129,4 +129,129 @@ describe('DocumentsPage', () => {
       expect(screen.getByRole('cell', { name: 'Yes' })).toBeInTheDocument();
     });
   });
+
+  it('manages retention policy, legal hold, and disposition run actions', async () => {
+    const policy = {
+      id: 'policy-1',
+      name: 'Default 7-year retention',
+      scope: 'ALL_DOCUMENTS',
+      retentionDays: 2555,
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 'doc-1',
+            matterId: 'matter-1',
+            title: 'Inspection Report',
+            versions: [{ id: 'v1' }],
+            sharedWithClient: false,
+            legalHoldActive: false,
+            dispositionStatus: 'ACTIVE',
+            retentionPolicy: null,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse(policy))
+      .mockResolvedValueOnce(jsonResponse([policy]))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ id: 'assign-ok' }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 'doc-1',
+            matterId: 'matter-1',
+            title: 'Inspection Report',
+            versions: [{ id: 'v1' }],
+            sharedWithClient: false,
+            legalHoldActive: false,
+            dispositionStatus: 'ACTIVE',
+            retentionPolicy: policy,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'hold-ok' }))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 'doc-1',
+            matterId: 'matter-1',
+            title: 'Inspection Report',
+            versions: [{ id: 'v1' }],
+            sharedWithClient: false,
+            legalHoldActive: true,
+            dispositionStatus: 'ACTIVE',
+            retentionPolicy: policy,
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'run-1' }))
+      .mockResolvedValueOnce(jsonResponse([policy]))
+      .mockResolvedValueOnce(jsonResponse([{ id: 'run-1', status: 'PENDING_APPROVAL', cutoffAt: '2026-02-01T00:00:00.000Z', items: [] }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<DocumentsPage />);
+
+    await screen.findByRole('cell', { name: 'Inspection Report' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load Retention Data' }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/retention/policies',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/disposition/runs',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Policy' }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/retention/policies',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'content-type': 'application/json' }),
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Assign Policy' }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/doc-1/retention-policy',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'content-type': 'application/json' }),
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Place Hold' }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/doc-1/legal-hold',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'content-type': 'application/json' }),
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Disposition Run' }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/disposition/runs',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'content-type': 'application/json' }),
+        }),
+      );
+      expect(screen.getByText('Created disposition run.')).toBeInTheDocument();
+    });
+  });
 });

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T18:55:58.248Z`
+- Snapshot Timestamp: `2026-02-17T19:55:09.359Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T18:55:56.809Z`
+- Last Successful Mirror Verify: `2026-02-17T19:55:07.212Z`
 
 ## Canonical Context Routing (Linear-First)
 

--- a/docs/parity/data-model-checklist.md
+++ b/docs/parity/data-model-checklist.md
@@ -95,9 +95,9 @@ This checklist maps prompt-required entities/capabilities to Prisma models in `a
 | Document folder | `DocumentFolder` | Complete | Nested folder hierarchy with parent/child references. | — |
 | Share link | `DocumentShareLink` | Complete | Expiring/revocable signed-share tokens. | — |
 | Evidence item | `EvidenceItem` | Complete | Evidence wrapper linking to document version. | — |
-| Document retention policy | `DocumentRetentionPolicy` | Missing | No policy table for retention trigger/period/disposition/legal hold override. | `REQ-COMM-004` |
-| Legal hold | `LegalHold` | Missing | No legal hold entity for retention freeze lifecycle yet. | `REQ-COMM-004` |
-| Retention disposition event | `RetentionDispositionEvent` | Missing | No disposition execution/audit record model yet. | `REQ-COMM-004` |
+| Document retention policy | `DocumentRetentionPolicy` | Complete | Policy supports scope (`ALL_DOCUMENTS`/`MATTER`/`CATEGORY`), trigger (`DOCUMENT_UPLOADED`/`MATTER_CLOSED`), retention period, approval gate, and assignment to documents. | — |
+| Legal hold | `DocumentLegalHold` | Complete | Active/released hold lifecycle with placed/released user attribution, hold reason, and document-level legal-hold enforcement. | — |
+| Retention disposition workflow | `DocumentDispositionRun`, `DocumentDispositionItem`, `Document.dispositionStatus` | Complete | Approval-gated disposition queue, legal-hold skip behavior, execution metadata, and document disposition status tracking with audit events. | — |
 
 ## 9) Time / Billing / Trust
 
@@ -185,7 +185,6 @@ These gaps are explicitly tracked in the parity matrix and Linear backlog:
 | Pgvector retrieval production path for AI chunks | `REQ-DATA-003` | Storage exists; retrieval ranking path still partial. |
 | Participant role workflow semantics completeness | `REQ-MAT-001` | Core schema exists; end-to-end role semantics still partial. |
 | Advanced conflict rule profiles + resolution decision logging | `REQ-MAT-004` | Missing first-class conflict profile/decision entities. |
-| Document retention/legal hold/disposition lifecycle models | `REQ-COMM-004` | Retention policy + legal hold + disposition entities missing. |
 | Trust reconciliation run + discrepancy queue | `REQ-BILL-003` | Reconciliation models missing from schema. |
 | LEDES profile/job entities | `REQ-BILL-004` | Standards-oriented profile/job data model missing. |
 | Dedupe user-confirm merge workflow | `REQ-PORT-003` | Import framework exists; user-confirm merge flow still partial. |

--- a/docs/parity/document-retention-workflows.md
+++ b/docs/parity/document-retention-workflows.md
@@ -1,0 +1,57 @@
+# REQ-COMM-004 Parity Evidence: Document Retention + Legal Hold + Disposition Workflow
+
+## Implemented
+
+- Added retention/hold/disposition data model in Prisma:
+  - enums: `DocumentDispositionStatus`, `RetentionScope`, `RetentionTrigger`, `DocumentLegalHoldStatus`, `DocumentDispositionRunStatus`, `DocumentDispositionItemStatus`
+  - models: `DocumentRetentionPolicy`, `DocumentLegalHold`, `DocumentDispositionRun`, `DocumentDispositionItem`
+  - document fields: `retentionPolicyId`, `retentionEligibleAt`, `legalHoldActive`, `dispositionStatus`, `disposedAt`
+- Added migration:
+  - `apps/api/prisma/migrations/20260217191000_document_retention_workflows/migration.sql`
+- Added document retention/legal-hold/disposition APIs:
+  - `GET /documents/retention/policies`
+  - `POST /documents/retention/policies`
+  - `POST /documents/:id/retention-policy`
+  - `POST /documents/:id/legal-hold`
+  - `POST /documents/:id/legal-hold/release`
+  - `GET /documents/disposition/runs`
+  - `POST /documents/disposition/runs`
+  - `POST /documents/disposition/runs/:id/approve`
+  - `POST /documents/disposition/runs/:id/execute`
+- Added legal-hold precedence and disposition governance behavior:
+  - legal-hold documents are skipped from pending disposition items
+  - approval state required before execution
+  - execution marks documents as disposed, revokes active share links, and records disposition item apply timestamps
+  - disposed documents are blocked from share/download/versioning actions
+- Added documents page controls for retention workflows:
+  - policy creation
+  - policy assignment
+  - place/release legal hold
+  - create/approve/execute disposition runs
+
+## Audit + Safety Controls
+
+- Audit events emitted for:
+  - policy creation/assignment
+  - legal hold placement/release
+  - disposition run creation/approval/completion
+- Legal hold requires explicit reason on placement.
+- Disposition execution requires approved run state.
+
+## Verification
+
+Executed on 2026-02-17:
+
+```bash
+pnpm --filter api prisma:generate
+pnpm --filter api test -- document-retention.spec.ts
+pnpm --filter web test -- documents-page.spec.tsx
+pnpm test
+pnpm build
+```
+
+Results:
+
+- New API retention workflow suite passed (`apps/api/test/document-retention.spec.ts`).
+- Updated documents page suite passed (`apps/web/test/documents-page.spec.tsx`).
+- Full monorepo tests and build passed.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -429,11 +429,11 @@
           "title": "Implement document retention policies with legal hold workflow",
           "requirementId": "REQ-COMM-004",
           "promptSection": "Documents / Evidence + Security controls for retention/legal hold",
-          "parityStatus": "Missing",
+          "parityStatus": "Complete",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "documents", "security", "phase-2"],
-          "problemStatement": "Document storage/versioning exists, but policy-driven retention and legal hold governance are not implemented.",
+          "problemStatement": "Retention policy lifecycle, legal hold controls, and approval-gated disposition workflows are now implemented across API + documents UI.",
           "requirementExcerpt": "Support retention policy assignment, legal hold precedence, disposition queue, and auditable retention actions.",
           "acceptanceCriteria": [
             "Create retention policy model with scope, trigger, and disposition rules.",
@@ -443,7 +443,7 @@
           "apiImpact": "Document management APIs gain retention policy assignment and disposition queue endpoints.",
           "securityImpact": "Improves defensible records governance and prevents unauthorized deletion.",
           "definitionOfDone": [
-            "Retention + legal hold lifecycle tests cover policy application, hold exclusion, and disposition approvals."
+            "Retention + legal hold + disposition lifecycle workflows are covered by API/Web tests with evidence in docs/parity/document-retention-workflows.md."
           ]
         }
       ]

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T18:55:58.248Z",
+  "generatedAt": "2026-02-17T19:55:09.359Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -24,8 +24,8 @@
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 31,
-      "Missing": 3
+      "Complete": 32,
+      "Missing": 2
     },
     "unresolvedCountsByRisk": {
       "High": 17,
@@ -33,8 +33,8 @@
     },
     "unresolvedCountsByStatusAndRisk": {
       "Complete:High": 17,
-      "Complete:Medium": 14,
-      "Missing:Medium": 3
+      "Complete:Medium": 15,
+      "Missing:Medium": 2
     }
   },
   "priority": {
@@ -137,13 +137,30 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 44,
     "stateCounts": {
-      "Backlog": 16,
-      "Done": 27,
+      "Backlog": 14,
+      "In Progress": 1,
+      "Done": 28,
       "In Review": 1
     },
-    "inProgressIssueKeys": [],
+    "inProgressIssueKeys": [
+      "KAR-46"
+    ],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-46",
+        "title": "Implement document retention policies with legal hold workflow",
+        "state": "In Progress",
+        "updatedAt": "2026-02-17T19:44:13.950Z",
+        "requirementId": "REQ-COMM-004"
+      },
+      {
+        "key": "KAR-45",
+        "title": "Implement jurisdictional deadline rules packs and rule selection flow",
+        "state": "Done",
+        "updatedAt": "2026-02-17T19:03:45.185Z",
+        "requirementId": "REQ-MAT-005"
+      },
       {
         "key": "KAR-44",
         "title": "Implement advanced conflict rule profiles and resolution workflows",
@@ -199,47 +216,34 @@
         "state": "Done",
         "updatedAt": "2026-02-17T16:44:47.650Z",
         "requirementId": "REQ-COMM-001"
-      },
-      {
-        "key": "KAR-35",
-        "title": "Implement style pack management with source document governance",
-        "state": "Done",
-        "updatedAt": "2026-02-17T16:30:16.904Z",
-        "requirementId": "REQ-AI-003"
-      },
-      {
-        "key": "KAR-30",
-        "title": "Implement secure portal attachments in message workflow",
-        "state": "Done",
-        "updatedAt": "2026-02-17T16:05:48.344Z",
-        "requirementId": "REQ-PORTAL-001"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T18:55:56.809Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T19:55:07.212Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "434be4de1014be1625d7e787c222bf5432d79333",
+    "gitHead": "8960d96417b6358c8960eeeb74381c1518de2c7f",
     "gitStatusShort": [
-      "## lin/KAR-45-jurisdictional-deadline-rules-packs",
+      "## lin/KAR-46-document-retention-legal-hold-workflow",
       " M README.md",
-      " M apps/api/src/calendar/calendar.controller.ts",
-      " M apps/api/src/calendar/calendar.service.ts",
-      " M apps/web/app/matters/[id]/page.tsx",
-      " M apps/web/test/setup.tsx",
-      " M docs/SESSION_HANDOFF.md",
+      " M apps/api/prisma/schema.prisma",
+      " M apps/api/prisma/seed.ts",
+      " M apps/api/src/documents/documents.controller.ts",
+      " M apps/api/src/documents/documents.service.ts",
+      " M apps/web/app/documents/page.tsx",
+      " M apps/web/test/documents-page.spec.tsx",
       " M docs/parity/data-model-checklist.md",
       " M tools/backlog-sync/requirements.matrix.json",
-      " M tools/backlog-sync/session.snapshot.json",
-      "?? apps/api/src/calendar/dto/apply-deadline-preview.dto.ts",
-      "?? apps/api/src/calendar/dto/create-rules-pack.dto.ts",
-      "?? apps/api/src/calendar/dto/preview-deadlines.dto.ts",
-      "?? apps/api/test/deadline-rules-packs.spec.ts",
-      "?? apps/web/test/matter-dashboard-page.spec.tsx",
-      "?? docs/parity/deadline-rules-packs.md"
+      "?? apps/api/prisma/migrations/20260217191000_document_retention_workflows/",
+      "?? apps/api/src/documents/dto/assign-retention-policy.dto.ts",
+      "?? apps/api/src/documents/dto/create-retention-policy.dto.ts",
+      "?? apps/api/src/documents/dto/disposition-run.dto.ts",
+      "?? apps/api/src/documents/dto/legal-hold.dto.ts",
+      "?? apps/api/test/document-retention.spec.ts",
+      "?? docs/parity/document-retention-workflows.md"
     ],
-    "dirtyFileCount": 15
+    "dirtyFileCount": 16
   }
 }


### PR DESCRIPTION
## Summary
- add retention/legal-hold/disposition Prisma schema and migration
- implement document retention policy CRUD/assignment plus legal hold place/release APIs
- implement approval-gated disposition run creation/approval/execution with legal-hold skip behavior and audit events
- enforce disposed-document download/share/version protections
- add documents UI controls for retention policy, legal hold, and disposition run actions
- add API/web regression coverage and parity documentation

## Linear Issue
- KAR-46

## Requirement ID
- REQ-COMM-004

## Verification
- pnpm --filter api prisma:generate
- pnpm --filter api test -- document-retention.spec.ts
- pnpm --filter web test -- documents-page.spec.tsx
- pnpm test
- pnpm build
- set -a; source .env; set +a; pnpm backlog:sync
- set -a; source .env; set +a; pnpm backlog:verify
- set -a; source .env; set +a; pnpm backlog:snapshot
- set -a; source .env; set +a; pnpm backlog:handoff:check