### PR TITLE
[KAR-51] Add webhook delivery observability and manual retries

### DIFF
--- a/apps/api/src/webhooks/webhooks.controller.ts
+++ b/apps/api/src/webhooks/webhooks.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Query, UseGuards } from '@nestjs/common';
 import { WebhooksService } from './webhooks.service';
 import { SessionAuthGuard } from '../common/guards/session-auth.guard';
 import { PermissionGuard } from '../common/guards/permission.guard';
@@ -29,5 +29,26 @@ export class WebhooksController {
       secret: body.secret,
       events: body.events,
     });
+  }
+
+  @Get('deliveries')
+  @RequirePermissions('webhooks:read')
+  listDeliveries(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query('endpointId') endpointId?: string,
+    @Query('status') status?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.webhooksService.listDeliveries(user.organizationId, {
+      endpointId,
+      status,
+      limit: limit ? Number(limit) : undefined,
+    });
+  }
+
+  @Post('deliveries/:deliveryId/retry')
+  @RequirePermissions('webhooks:write')
+  retryDelivery(@CurrentUser() user: AuthenticatedUser, @Param('deliveryId') deliveryId: string) {
+    return this.webhooksService.retryDelivery(user.organizationId, deliveryId);
   }
 }

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { createHash, createHmac } from 'node:crypto';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { toJsonValue } from '../common/utils/json.util';
 
@@ -31,6 +32,114 @@ export class WebhooksService {
       where: { organizationId },
       orderBy: { createdAt: 'desc' },
     });
+  }
+
+  async listDeliveries(
+    organizationId: string,
+    options?: {
+      endpointId?: string;
+      status?: string;
+      limit?: number;
+    },
+  ) {
+    const where: Prisma.WebhookDeliveryWhereInput = {
+      webhookEndpoint: {
+        organizationId,
+      },
+    };
+    if (options?.endpointId) {
+      where.webhookEndpointId = options.endpointId;
+    }
+    if (options?.status) {
+      where.status = options.status;
+    }
+
+    return this.prisma.webhookDelivery.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }],
+      take: this.normalizeListLimit(options?.limit),
+      include: {
+        webhookEndpoint: {
+          select: {
+            id: true,
+            url: true,
+            isActive: true,
+          },
+        },
+      },
+    });
+  }
+
+  async retryDelivery(organizationId: string, deliveryId: string) {
+    const delivery = await this.prisma.webhookDelivery.findFirst({
+      where: {
+        id: deliveryId,
+        webhookEndpoint: {
+          organizationId,
+        },
+      },
+      include: {
+        webhookEndpoint: {
+          select: {
+            id: true,
+            url: true,
+            secret: true,
+            isActive: true,
+          },
+        },
+      },
+    });
+
+    if (!delivery) {
+      throw new NotFoundException('Webhook delivery not found');
+    }
+    if (!delivery.webhookEndpoint.isActive) {
+      throw new BadRequestException('Webhook endpoint is inactive');
+    }
+    if (!this.isRetryableStatus(delivery.status)) {
+      throw new BadRequestException('Only FAILED or RETRYING deliveries can be retried');
+    }
+
+    await this.prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: {
+        status: 'PENDING',
+        attemptCount: 0,
+        responseCode: null,
+        lastAttemptAt: null,
+      },
+    });
+
+    await this.deliverWithRetries({
+      deliveryId: delivery.id,
+      endpoint: {
+        id: delivery.webhookEndpoint.id,
+        url: delivery.webhookEndpoint.url,
+        secret: delivery.webhookEndpoint.secret,
+      },
+      eventType: delivery.eventType,
+      idempotencyKey: delivery.idempotencyKey,
+      payload: this.readPayload(delivery.payloadJson),
+    });
+
+    const refreshed = await this.prisma.webhookDelivery.findUnique({
+      where: { id: delivery.id },
+      include: {
+        webhookEndpoint: {
+          select: {
+            id: true,
+            url: true,
+            isActive: true,
+          },
+        },
+      },
+    });
+
+    if (!refreshed) {
+      throw new NotFoundException('Webhook delivery not found');
+    }
+
+    return refreshed;
   }
 
   async emit(
@@ -162,6 +271,24 @@ export class WebhooksService {
   private computePayloadFingerprint(eventType: string, payload: Record<string, unknown>) {
     const serialized = JSON.stringify(payload);
     return createHash('sha256').update(`${eventType}:${serialized}`).digest('hex');
+  }
+
+  private readPayload(payloadJson: unknown): Record<string, unknown> {
+    if (!payloadJson || typeof payloadJson !== 'object' || Array.isArray(payloadJson)) {
+      throw new BadRequestException('Webhook delivery payload is invalid');
+    }
+    return payloadJson as Record<string, unknown>;
+  }
+
+  private isRetryableStatus(status: string) {
+    return status === 'FAILED' || status === 'RETRYING';
+  }
+
+  private normalizeListLimit(limit?: number) {
+    if (!Number.isFinite(limit) || !limit || limit <= 0) {
+      return 50;
+    }
+    return Math.min(limit, 200);
   }
 
   private signPayload(secret: string, timestamp: string, body: string) {

--- a/apps/api/test/tenant-isolation.spec.ts
+++ b/apps/api/test/tenant-isolation.spec.ts
@@ -236,6 +236,7 @@ describe('Tenant isolation', () => {
       matterStage: { findMany: jest.fn().mockResolvedValue([]) },
       auditLogEvent: { findMany: jest.fn().mockResolvedValue([]) },
       webhookEndpoint: { findMany: jest.fn().mockResolvedValue([]) },
+      webhookDelivery: { findMany: jest.fn().mockResolvedValue([]) },
     } as any;
 
     const admin = new AdminService(prisma, { appendEvent: jest.fn() } as any);
@@ -247,6 +248,7 @@ describe('Tenant isolation', () => {
     await admin.listStages('org-isolated', 'Construction Litigation');
     await audit.listByOrganization('org-isolated', 50);
     await webhooks.listEndpoints('org-isolated');
+    await webhooks.listDeliveries('org-isolated', { status: 'FAILED', limit: 10 });
 
     expect(prisma.membership.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { organizationId: 'org-isolated' } }));
     expect(prisma.role.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { organizationId: 'org-isolated' } }));
@@ -257,6 +259,14 @@ describe('Tenant isolation', () => {
     );
     expect(prisma.auditLogEvent.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { organizationId: 'org-isolated' } }));
     expect(prisma.webhookEndpoint.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { organizationId: 'org-isolated' } }));
+    expect(prisma.webhookDelivery.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          webhookEndpoint: expect.objectContaining({ organizationId: 'org-isolated' }),
+          status: 'FAILED',
+        }),
+      }),
+    );
   });
 
   it('queries organization-scoped custom fields/sections and reporting data', async () => {

--- a/apps/api/test/webhooks-delivery.spec.ts
+++ b/apps/api/test/webhooks-delivery.spec.ts
@@ -128,4 +128,130 @@ describe('WebhooksService delivery hardening', () => {
     expect(headers['x-karen-event-type']).toBe('record.updated');
     expect(signature).toBe(expectedSignature);
   });
+
+  it('lists deliveries scoped to organization with optional filters', async () => {
+    const prisma = {
+      webhookDelivery: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    } as any;
+
+    const service = new WebhooksService(prisma);
+    await service.listDeliveries('org-1', {
+      endpointId: 'endpoint-1',
+      status: 'FAILED',
+      limit: 25,
+    });
+
+    expect(prisma.webhookDelivery.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          webhookEndpoint: expect.objectContaining({
+            organizationId: 'org-1',
+          }),
+          webhookEndpointId: 'endpoint-1',
+          status: 'FAILED',
+        }),
+        take: 25,
+      }),
+    );
+  });
+
+  it('retries a failed delivery and returns refreshed delivery details', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    (global as any).fetch = fetchMock;
+
+    const delivery = {
+      id: 'delivery-1',
+      status: 'FAILED',
+      eventType: 'record.updated',
+      idempotencyKey: 'record.updated:endpoint-1:evt-1',
+      payloadJson: { entityType: 'matter', entityId: 'matter-1' },
+      webhookEndpoint: {
+        id: 'endpoint-1',
+        url: 'https://webhook.test/receive',
+        secret: 'retry-secret',
+        isActive: true,
+      },
+    };
+    const prisma = {
+      webhookDelivery: {
+        findFirst: jest.fn().mockResolvedValue(delivery),
+        update: jest.fn().mockResolvedValue({ id: 'delivery-1' }),
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'delivery-1',
+          status: 'DELIVERED',
+          attemptCount: 1,
+          responseCode: 200,
+          webhookEndpoint: {
+            id: 'endpoint-1',
+            url: 'https://webhook.test/receive',
+            isActive: true,
+          },
+        }),
+      },
+    } as any;
+
+    const service = new WebhooksService(prisma);
+    const result = await service.retryDelivery('org-1', 'delivery-1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(prisma.webhookDelivery.update.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        where: { id: 'delivery-1' },
+        data: expect.objectContaining({
+          status: 'PENDING',
+          attemptCount: 0,
+        }),
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'delivery-1',
+        status: 'DELIVERED',
+      }),
+    );
+  });
+
+  it('rejects manual retry for non-retryable delivery status', async () => {
+    const prisma = {
+      webhookDelivery: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'delivery-1',
+          status: 'DELIVERED',
+          eventType: 'record.updated',
+          idempotencyKey: 'record.updated:endpoint-1:evt-1',
+          payloadJson: { entityType: 'matter', entityId: 'matter-1' },
+          webhookEndpoint: {
+            id: 'endpoint-1',
+            url: 'https://webhook.test/receive',
+            secret: 'retry-secret',
+            isActive: true,
+          },
+        }),
+        update: jest.fn(),
+        findUnique: jest.fn(),
+      },
+    } as any;
+
+    const service = new WebhooksService(prisma);
+    await expect(service.retryDelivery('org-1', 'delivery-1')).rejects.toThrow(
+      'Only FAILED or RETRYING deliveries can be retried',
+    );
+    expect(prisma.webhookDelivery.update).not.toHaveBeenCalled();
+  });
+
+  it('enforces organization isolation for manual retry', async () => {
+    const prisma = {
+      webhookDelivery: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        update: jest.fn(),
+        findUnique: jest.fn(),
+      },
+    } as any;
+
+    const service = new WebhooksService(prisma);
+    await expect(service.retryDelivery('org-1', 'delivery-foreign')).rejects.toThrow('Webhook delivery not found');
+    expect(prisma.webhookDelivery.update).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -5,6 +5,28 @@ import { AppShell } from '../../components/app-shell';
 import { PageHeader } from '../../components/page-header';
 import { apiFetch } from '../../lib/api';
 
+type WebhookEndpointSummary = {
+  id: string;
+  url: string;
+  isActive: boolean;
+  events: string[];
+};
+
+type WebhookDeliverySummary = {
+  id: string;
+  eventType: string;
+  status: string;
+  attemptCount: number;
+  responseCode?: number | null;
+  createdAt: string;
+  lastAttemptAt?: string | null;
+  webhookEndpoint: {
+    id: string;
+    url: string;
+    isActive: boolean;
+  };
+};
+
 export default function AdminPage() {
   const [org, setOrg] = useState<{ name: string; slug: string } | null>(null);
   const [users, setUsers] = useState<Array<{ id: string; user: { email: string }; role?: { name: string } }>>([]);
@@ -31,6 +53,8 @@ export default function AdminPage() {
       };
     }>
   >([]);
+  const [webhookEndpoints, setWebhookEndpoints] = useState<WebhookEndpointSummary[]>([]);
+  const [webhookDeliveries, setWebhookDeliveries] = useState<WebhookDeliverySummary[]>([]);
   const [customFieldKey, setCustomFieldKey] = useState('project_address');
   const [customFieldLabel, setCustomFieldLabel] = useState('Project Address');
   const [sectionName, setSectionName] = useState('Defect Summary');
@@ -44,6 +68,9 @@ export default function AdminPage() {
   const [selectedConflictProfileId, setSelectedConflictProfileId] = useState('');
   const [resolutionDecision, setResolutionDecision] = useState<'CLEAR' | 'WAIVE' | 'BLOCK'>('WAIVE');
   const [resolutionRationale, setResolutionRationale] = useState('Attorney override after review of unrelated prior engagement.');
+  const [webhookStatusFilter, setWebhookStatusFilter] = useState<'ALL' | 'PENDING' | 'RETRYING' | 'FAILED' | 'DELIVERED'>('FAILED');
+  const [webhookError, setWebhookError] = useState<string | null>(null);
+  const [retryingDeliveryId, setRetryingDeliveryId] = useState<string | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -72,8 +99,10 @@ export default function AdminPage() {
           };
         }>
       >('/admin/conflict-checks?limit=15'),
+      apiFetch<WebhookEndpointSummary[]>('/webhooks/endpoints'),
+      apiFetch<WebhookDeliverySummary[]>('/webhooks/deliveries?status=FAILED&limit=25'),
     ])
-      .then(([o, u, r, s, pr, a, cf, sec, cProfiles, cChecks]) => {
+      .then(([o, u, r, s, pr, a, cf, sec, cProfiles, cChecks, wEndpoints, wDeliveries]) => {
         setOrg(o);
         setUsers(u);
         setRoles(r);
@@ -84,6 +113,8 @@ export default function AdminPage() {
         setSections(sec);
         setConflictProfiles(cProfiles);
         setConflictChecks(cChecks);
+        setWebhookEndpoints(wEndpoints);
+        setWebhookDeliveries(wDeliveries);
         if (cProfiles.length > 0) {
           setSelectedConflictProfileId(cProfiles[0].id);
         }
@@ -203,6 +234,38 @@ export default function AdminPage() {
         }>
       >('/admin/conflict-checks?limit=15'),
     );
+  }
+
+  async function refreshWebhookDeliveries(nextFilter = webhookStatusFilter) {
+    const params = new URLSearchParams({ limit: '25' });
+    if (nextFilter !== 'ALL') {
+      params.set('status', nextFilter);
+    }
+    setWebhookDeliveries(await apiFetch<WebhookDeliverySummary[]>(`/webhooks/deliveries?${params.toString()}`));
+  }
+
+  async function updateWebhookFilter(nextFilter: 'ALL' | 'PENDING' | 'RETRYING' | 'FAILED' | 'DELIVERED') {
+    setWebhookStatusFilter(nextFilter);
+    setWebhookError(null);
+    await refreshWebhookDeliveries(nextFilter);
+  }
+
+  async function retryWebhookDelivery(deliveryId: string) {
+    setWebhookError(null);
+    setRetryingDeliveryId(deliveryId);
+    try {
+      await apiFetch(`/webhooks/deliveries/${deliveryId}/retry`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+      const endpoints = await apiFetch<WebhookEndpointSummary[]>('/webhooks/endpoints');
+      setWebhookEndpoints(endpoints);
+      await refreshWebhookDeliveries();
+    } catch (error) {
+      setWebhookError(error instanceof Error ? error.message : 'Failed to retry webhook delivery');
+    } finally {
+      setRetryingDeliveryId(null);
+    }
   }
 
   return (
@@ -470,6 +533,82 @@ export default function AdminPage() {
                   </td>
                 </tr>
               ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="card" style={{ gridColumn: '1 / -1' }}>
+          <h3 style={{ marginTop: 0 }}>Webhook Delivery Monitor</h3>
+          <p style={{ color: 'var(--muted)', marginTop: 0 }}>
+            Track endpoint health and retry failed deliveries with full server-side organization scoping.
+          </p>
+
+          <div style={{ display: 'grid', gap: 8, gridTemplateColumns: '220px 1fr', marginBottom: 12 }}>
+            <select
+              className="select"
+              value={webhookStatusFilter}
+              onChange={(e) => updateWebhookFilter(e.target.value as 'ALL' | 'PENDING' | 'RETRYING' | 'FAILED' | 'DELIVERED')}
+            >
+              <option value="ALL">ALL</option>
+              <option value="PENDING">PENDING</option>
+              <option value="RETRYING">RETRYING</option>
+              <option value="FAILED">FAILED</option>
+              <option value="DELIVERED">DELIVERED</option>
+            </select>
+            <span style={{ alignSelf: 'center', color: 'var(--muted)' }}>
+              Active endpoints: {webhookEndpoints.filter((endpoint) => endpoint.isActive).length} / {webhookEndpoints.length}
+            </span>
+          </div>
+
+          {webhookError ? (
+            <p style={{ color: '#c62828', marginTop: 0 }}>
+              {webhookError}
+            </p>
+          ) : null}
+
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Endpoint</th>
+                <th>Event</th>
+                <th>Status</th>
+                <th>Attempts</th>
+                <th>Response</th>
+                <th>Last Attempt</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {webhookDeliveries.map((delivery) => {
+                const retryable = delivery.status === 'FAILED' || delivery.status === 'RETRYING';
+                return (
+                  <tr key={delivery.id}>
+                    <td>{delivery.webhookEndpoint.url}</td>
+                    <td>{delivery.eventType}</td>
+                    <td>{delivery.status}</td>
+                    <td>{delivery.attemptCount}</td>
+                    <td>{delivery.responseCode ?? '-'}</td>
+                    <td>{delivery.lastAttemptAt ? new Date(delivery.lastAttemptAt).toLocaleString() : '-'}</td>
+                    <td>
+                      <button
+                        className="button ghost"
+                        type="button"
+                        disabled={!retryable || retryingDeliveryId === delivery.id}
+                        onClick={() => retryWebhookDelivery(delivery.id)}
+                      >
+                        {retryingDeliveryId === delivery.id ? 'Retrying...' : 'Retry'}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+              {webhookDeliveries.length === 0 ? (
+                <tr>
+                  <td colSpan={7} style={{ color: 'var(--muted)' }}>
+                    No deliveries for current filter.
+                  </td>
+                </tr>
+              ) : null}
             </tbody>
           </table>
         </div>

--- a/apps/web/test/admin-page.spec.tsx
+++ b/apps/web/test/admin-page.spec.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import AdminPage from '../app/admin/page';
+
+function jsonResponse<T>(payload: T, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}
+
+describe('AdminPage webhook delivery monitor', () => {
+  it('filters and retries webhook deliveries', async () => {
+    const endpoints = [
+      {
+        id: 'endpoint-1',
+        url: 'https://hooks.example/receiver',
+        isActive: true,
+        events: ['record.updated'],
+      },
+    ];
+
+    let failedDeliveries = [
+      {
+        id: 'delivery-1',
+        eventType: 'record.updated',
+        status: 'FAILED',
+        attemptCount: 3,
+        responseCode: 500,
+        createdAt: '2026-02-17T20:00:00.000Z',
+        lastAttemptAt: '2026-02-17T20:05:00.000Z',
+        webhookEndpoint: {
+          id: 'endpoint-1',
+          url: 'https://hooks.example/receiver',
+          isActive: true,
+        },
+      },
+    ];
+
+    const allDeliveries = [
+      {
+        id: 'delivery-2',
+        eventType: 'record.created',
+        status: 'DELIVERED',
+        attemptCount: 1,
+        responseCode: 200,
+        createdAt: '2026-02-17T20:10:00.000Z',
+        lastAttemptAt: '2026-02-17T20:10:02.000Z',
+        webhookEndpoint: {
+          id: 'endpoint-1',
+          url: 'https://hooks.example/receiver',
+          isActive: true,
+        },
+      },
+    ];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method || 'GET';
+
+      if (url.endsWith('/admin/organization')) return jsonResponse({ name: 'Karen Legal', slug: 'karen' });
+      if (url.endsWith('/admin/users')) return jsonResponse([]);
+      if (url.endsWith('/admin/roles')) return jsonResponse([]);
+      if (url.endsWith('/admin/stages')) return jsonResponse([]);
+      if (url.endsWith('/admin/participant-roles')) return jsonResponse([]);
+      if (url.endsWith('/audit?limit=25')) return jsonResponse([]);
+      if (url.endsWith('/config/custom-fields')) return jsonResponse([]);
+      if (url.endsWith('/config/sections')) return jsonResponse([]);
+      if (url.endsWith('/admin/conflict-rule-profiles')) return jsonResponse([]);
+      if (url.endsWith('/admin/conflict-checks?limit=15')) return jsonResponse([]);
+      if (url.endsWith('/webhooks/endpoints')) return jsonResponse(endpoints);
+
+      if (url.includes('/webhooks/deliveries?') && method === 'GET') {
+        const query = url.split('?')[1] || '';
+        const params = new URLSearchParams(query);
+        if (params.get('status') === 'FAILED' && params.get('limit') === '25') {
+          return jsonResponse(failedDeliveries);
+        }
+        if (!params.has('status') && params.get('limit') === '25') {
+          return jsonResponse(allDeliveries);
+        }
+      }
+      if (url.endsWith('/webhooks/deliveries/delivery-1/retry') && method === 'POST') {
+        failedDeliveries = [];
+        return jsonResponse({ id: 'delivery-1', status: 'DELIVERED' });
+      }
+
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<AdminPage />);
+
+    await screen.findByText('Webhook Delivery Monitor');
+    await screen.findByText('https://hooks.example/receiver');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/webhooks/deliveries/delivery-1/retry',
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      );
+      expect(screen.getByText('No deliveries for current filter.')).toBeInTheDocument();
+    });
+
+    const filterSelect = screen
+      .getAllByRole('combobox')
+      .find(
+        (node) =>
+          node instanceof HTMLSelectElement &&
+          Array.from(node.options).some((option) => option.value === 'FAILED') &&
+          Array.from(node.options).some((option) => option.value === 'DELIVERED'),
+      ) as HTMLSelectElement;
+
+    fireEvent.change(filterSelect, { target: { value: 'ALL' } });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/webhooks/deliveries?limit=25',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+      expect(screen.getByText('record.created')).toBeInTheDocument();
+      expect(screen.getAllByText('DELIVERED').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Added webhook delivery observability + manual retry controls with org-scoped delivery list/retry API endpoints, admin monitor/filter/retry UI, and regression coverage (`docs/parity/webhook-delivery-observability.md`).
 - 2026-02-17: Completed `REQ-BILL-004` by adding LEDES export profile/job schema, profile-driven UTBMS validation, billing endpoints for profile/job/list/download flow, checksum + artifact metadata persistence, billing-page LEDES workflow controls, and API/Web regression coverage (`docs/parity/ledes-export-workflows.md`).
 - 2026-02-17: Completed `REQ-BILL-003` by adding trust reconciliation run/discrepancy schema, statement-period run lifecycle endpoints (`create/submit/resolve/complete`), sign-off gating requiring all discrepancies to be resolved/waived, billing UI reconciliation actions, and API/Web regression coverage (`docs/parity/trust-reconciliation-workflows.md`).
 - 2026-02-17: Completed `REQ-MAT-005` by adding jurisdiction/court/procedure deadline rules packs with effective-date versioning, deadline preview/apply endpoints, business-day offset logic, required override-reason governance, matter-dashboard rules-pack preview/apply UI, and API/Web regression coverage (`docs/parity/deadline-rules-packs.md`).

--- a/docs/parity/webhook-delivery-observability.md
+++ b/docs/parity/webhook-delivery-observability.md
@@ -1,0 +1,38 @@
+# Webhook Delivery Observability + Manual Retry
+
+Requirement: `REQ-INT-003` (post-completion hardening follow-on)  
+Scope: expose delivery observability and scoped manual retry controls for webhook events.
+
+## Artifact
+
+- API:
+  - `GET /webhooks/deliveries`
+  - `POST /webhooks/deliveries/:deliveryId/retry`
+- Web admin monitor:
+  - `apps/web/app/admin/page.tsx` (`Webhook Delivery Monitor`)
+
+## Coverage Mapping
+
+- Delivery observability:
+  - org-scoped list endpoint with optional `status`, `endpointId`, and `limit` filters
+  - response includes endpoint URL + active state, event type, attempts, response code, timestamps
+- Manual retry governance:
+  - retries limited to `FAILED` and `RETRYING` deliveries
+  - rejects inactive endpoints
+  - strict organization scoping on retry lookup
+  - retry resets delivery state to `PENDING` then reuses signed delivery pipeline
+- UI operations:
+  - status-filtered delivery table in Admin
+  - retry action button for retryable rows only
+  - inline error display for retry failures
+
+## Verification
+
+- API tests:
+  - `apps/api/test/webhooks-delivery.spec.ts`
+  - `apps/api/test/tenant-isolation.spec.ts`
+- Web test:
+  - `apps/web/test/admin-page.spec.tsx`
+- Validation commands:
+  - `pnpm test`
+  - `pnpm build`


### PR DESCRIPTION
## Linear Issue
- Key: KAR-51
- URL: https://linear.app/karenap/issue/KAR-51/add-webhook-delivery-observability-and-manual-retry-controls

## Requirement ID
- REQ-INT-003

## Summary
- Added org-scoped webhook delivery observability API (`GET /webhooks/deliveries`) with filter support (`status`, `endpointId`, `limit`).
- Added manual webhook retry API (`POST /webhooks/deliveries/:deliveryId/retry`) with guardrails for retryable states and active endpoints only.
- Added Admin UI "Webhook Delivery Monitor" with status filters, active endpoint health summary, and retry action for retryable deliveries.
- Added regression coverage for webhook delivery list/retry behavior, tenant scoping, and admin UI monitor/retry flow.
- Added parity artifact doc for this slice.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm build`
  - `pnpm test`
- Output summary:
  - Build passed for both `apps/api` and `apps/web`.
  - Test suites passed: API `34/34`, Web `12/12`.
  - Added targeted tests:
    - `apps/api/test/webhooks-delivery.spec.ts`
    - `apps/api/test/tenant-isolation.spec.ts`
    - `apps/web/test/admin-page.spec.tsx`

## Notes
- This is a post-completion hardening/operability slice for integration webhook reliability.
- No DB schema migration required.
