### PR TITLE
[KAR-51] Refresh backlog snapshot and handoff metadata

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T20:45:16.255Z`
+- Snapshot Timestamp: `2026-02-17T21:25:30.157Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T20:45:15.063Z`
+- Last Successful Mirror Verify: `2026-02-17T21:25:27.581Z`
 
 ## Canonical Context Routing (Linear-First)
 

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T20:45:16.255Z",
+  "generatedAt": "2026-02-17T21:25:30.157Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -135,8 +135,8 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 44,
     "stateCounts": {
-      "In Review": 2,
-      "Done": 30,
+      "Done": 31,
+      "In Review": 1,
       "Backlog": 12
     },
     "inProgressIssueKeys": [],
@@ -145,8 +145,8 @@
       {
         "key": "KAR-48",
         "title": "Implement LEDES/UTBMS export jobs with validation profiles",
-        "state": "In Review",
-        "updatedAt": "2026-02-17T20:44:48.911Z",
+        "state": "Done",
+        "updatedAt": "2026-02-17T20:54:23.712Z",
         "requirementId": "REQ-BILL-004"
       },
       {
@@ -215,13 +215,13 @@
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T20:45:15.063Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T21:25:27.581Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "19d67695ce17ed68fe35041e83bd1e11ebf5dd55",
+    "gitHead": "3208d8874c5583f3857ad42f54e81c66f1b89d42",
     "gitStatusShort": [
-      "## lin/KAR-48-ledes-export-jobs...origin/lin/KAR-48-ledes-export-jobs"
+      "## main...origin/main"
     ],
     "dirtyFileCount": 0
   }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-51
- URL: https://linear.app/karenap/issue/KAR-51/add-webhook-delivery-observability-and-manual-retry-controls

## Requirement ID
- REQ-OPS-003

## Summary
- Refreshed `tools/backlog-sync/session.snapshot.json` after merging KAR-51.
- Updated snapshot metadata in `docs/SESSION_HANDOFF.md` to match latest generated snapshot and mirror verify timestamp.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - Mirror sync updated parity mirrors without duplicates.
  - Verify reported zero missing/orphan issues.
  - Snapshot regenerated and handoff freshness check passed.

## Notes
- Housekeeping-only change; no runtime code, schema, or API behavior changes.
