### PR TITLE
[KAR-61] Verify Stripe reconciliation idempotency and webhook signature flow

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -324,6 +324,7 @@ export class BillingService {
           organizationId,
           invoiceId,
           stripeEventId: event.id,
+          stripeEventType: event.type,
           stripeCheckoutSessionId: session.id,
           stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : undefined,
           amount: typeof session.amount_total === 'number' ? Number((session.amount_total / 100).toFixed(2)) : undefined,
@@ -359,6 +360,7 @@ export class BillingService {
           organizationId,
           invoiceId,
           stripeEventId: event.id,
+          stripeEventType: event.type,
           stripePaymentIntentId: paymentIntent.id,
           amount: Number((amountInCents / 100).toFixed(2)),
         })),
@@ -1521,6 +1523,12 @@ export class BillingService {
 
   private parseStripeWebhookEvent(input: { payload: unknown; signature?: string; rawBody?: Buffer }): Stripe.Event {
     const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (webhookSecret && !this.stripe) {
+      throw new Error(
+        'Stripe webhook verification requires STRIPE_SECRET_KEY when STRIPE_WEBHOOK_SECRET is configured',
+      );
+    }
+
     if (this.stripe && webhookSecret) {
       if (!input.signature || !input.rawBody) {
         throw new Error('Stripe webhook signature verification failed: missing stripe-signature header or raw body');
@@ -1551,6 +1559,7 @@ export class BillingService {
     organizationId: string;
     invoiceId: string;
     stripeEventId: string;
+    stripeEventType?: string;
     amount?: number;
     stripePaymentIntentId?: string;
     stripeCheckoutSessionId?: string;
@@ -1563,6 +1572,17 @@ export class BillingService {
     });
     if (!invoice) {
       return { status: 'ignored', reason: 'invoice_not_found' };
+    }
+
+    const existingByEvent = await this.prisma.payment.findFirst({
+      where: {
+        organizationId: input.organizationId,
+        invoiceId: invoice.id,
+        reference: `stripe_event:${input.stripeEventId}`,
+      },
+    });
+    if (existingByEvent) {
+      return { status: 'duplicate', paymentId: existingByEvent.id };
     }
 
     if (input.stripePaymentIntentId) {
@@ -1593,6 +1613,7 @@ export class BillingService {
         reference: `stripe_event:${input.stripeEventId}`,
         rawSourcePayload: toJsonValue({
           stripeEventId: input.stripeEventId,
+          stripeEventType: input.stripeEventType ?? null,
           stripeCheckoutSessionId: input.stripeCheckoutSessionId,
         }),
       },

--- a/apps/api/test/billing-stripe-reconciliation.spec.ts
+++ b/apps/api/test/billing-stripe-reconciliation.spec.ts
@@ -83,6 +83,7 @@ describe('BillingService Stripe lifecycle + reconciliation', () => {
         findFirst: jest
           .fn()
           .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce(null)
           .mockResolvedValueOnce({
             id: 'pay-existing',
             organizationId: 'org-1',
@@ -145,6 +146,13 @@ describe('BillingService Stripe lifecycle + reconciliation', () => {
     );
 
     expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          reference: 'stripe_event:evt_1',
+        }),
+      }),
+    );
     expect(prisma.invoice.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'inv-1' },
@@ -159,6 +167,142 @@ describe('BillingService Stripe lifecycle + reconciliation', () => {
         action: 'invoice.payment.reconciled',
         entityType: 'invoice',
         entityId: 'inv-1',
+      }),
+    );
+  });
+
+  it('dedupes duplicate checkout webhook by stripe event id when payment intent is absent', async () => {
+    const prisma = {
+      invoice: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'inv-2',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          balanceDue: 175,
+          status: 'SENT',
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'inv-2' }),
+      },
+      payment: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            id: 'pay-evt-existing',
+            organizationId: 'org-1',
+            invoiceId: 'inv-2',
+            reference: 'stripe_event:evt_no_pi',
+          }),
+        create: jest.fn().mockResolvedValue({ id: 'pay-evt-created' }),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    (service as any).stripe = null;
+
+    const eventPayload = {
+      id: 'evt_no_pi',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_no_pi',
+          payment_intent: null,
+          amount_total: 17500,
+          metadata: {
+            invoiceId: 'inv-2',
+            organizationId: 'org-1',
+          },
+        },
+      },
+    };
+
+    const first = await service.handleStripeWebhook({ payload: eventPayload });
+    const second = await service.handleStripeWebhook({ payload: eventPayload });
+
+    expect(first).toEqual(
+      expect.objectContaining({
+        eventId: 'evt_no_pi',
+        status: 'recorded',
+        paymentId: 'pay-evt-created',
+      }),
+    );
+    expect(second).toEqual(
+      expect.objectContaining({
+        eventId: 'evt_no_pi',
+        status: 'duplicate',
+        paymentId: 'pay-evt-existing',
+      }),
+    );
+    expect(prisma.payment.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('reconciles payment_intent.succeeded to PAID status when amount satisfies remaining balance', async () => {
+    const prisma = {
+      invoice: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'inv-3',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          balanceDue: 100,
+          status: 'SENT',
+        }),
+        update: jest.fn().mockResolvedValue({ id: 'inv-3' }),
+      },
+      payment: {
+        findFirst: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(null),
+        create: jest.fn().mockResolvedValue({ id: 'pay-3' }),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    (service as any).stripe = null;
+
+    const result = await service.handleStripeWebhook({
+      payload: {
+        id: 'evt_pi_paid',
+        type: 'payment_intent.succeeded',
+        data: {
+          object: {
+            id: 'pi_paid',
+            amount: 10000,
+            amount_received: 10000,
+            metadata: {
+              invoiceId: 'inv-3',
+              organizationId: 'org-1',
+            },
+          },
+        },
+      },
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        received: true,
+        eventId: 'evt_pi_paid',
+        type: 'payment_intent.succeeded',
+        status: 'recorded',
+        paymentId: 'pay-3',
+      }),
+    );
+    expect(prisma.invoice.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'inv-3' },
+        data: expect.objectContaining({
+          balanceDue: 0,
+          status: 'PAID',
+        }),
       }),
     );
   });
@@ -207,5 +351,58 @@ describe('BillingService Stripe lifecycle + reconciliation', () => {
       }),
     );
   });
-});
 
+  it('verifies webhook signature when STRIPE_WEBHOOK_SECRET is configured', async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test';
+
+    const service = new BillingService(
+      {
+        invoice: {
+          findFirst: jest.fn(),
+          update: jest.fn(),
+        },
+        payment: {
+          findFirst: jest.fn(),
+          create: jest.fn(),
+        },
+      } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    const constructEvent = jest.fn().mockReturnValue({
+      id: 'evt_sig',
+      type: 'customer.created',
+      data: { object: {} },
+    });
+    (service as any).stripe = {
+      webhooks: {
+        constructEvent,
+      },
+    };
+
+    await expect(
+      service.handleStripeWebhook({
+        payload: { any: 'payload' },
+      }),
+    ).rejects.toThrow('Stripe webhook signature verification failed');
+
+    const result = await service.handleStripeWebhook({
+      payload: { any: 'payload' },
+      signature: 'sig_test',
+      rawBody: Buffer.from('{}'),
+    });
+
+    expect(constructEvent).toHaveBeenCalledWith(Buffer.from('{}'), 'sig_test', 'whsec_test');
+    expect(result).toEqual(
+      expect.objectContaining({
+        received: true,
+        eventId: 'evt_sig',
+        type: 'customer.created',
+        status: 'ignored',
+        reason: 'event_type_not_handled',
+      }),
+    );
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T22:29:36.614Z`
+- Snapshot Timestamp: `2026-02-17T22:43:53.695Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T22:29:35.336Z`
+- Last Successful Mirror Verify: `2026-02-17T22:43:52.533Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Verified `REQ-BILL-001` by hardening Stripe reconciliation idempotency with event-level dedupe (`stripe_event:<eventId>`), preserving payment-intent dedupe, adding deterministic `payment_intent.succeeded` paid-transition coverage, and verifying signature-enforced webhook parsing when `STRIPE_WEBHOOK_SECRET` is configured (`docs/parity/billing-stripe-reconciliation-verification.md`).
 - 2026-02-17: Verified `REQ-AI-002` by hardening ingestion/generation governance with explicit `quarantinedFromContext` metadata, citation-policy enforcement that appends trusted chunk citations when missing, `policyCompliance` artifact metadata, `ai.output.citation_policy_enforced` audit events, and expanded adversarial API coverage (`docs/parity/ai-ingestion-security-verification.md`).
 - 2026-02-17: Verified `REQ-AI-001` by hardening deadline-confirmation server validation (non-empty selections, valid dates, at-least-one output), adding explicit `ai.deadlines.confirmed` audit events with selection/created-record metadata, and extending API/Web regression coverage (`docs/parity/ai-deadline-confirmation-verification.md`).
 - 2026-02-17: Verified `REQ-OPS-001` with a new cross-module web smoke journey test (`login -> dashboard -> matter create -> portal message`) plus full-suite test/build validation, documented at `docs/parity/web-smoke-journey-coverage.md`.

--- a/docs/parity/billing-stripe-reconciliation-verification.md
+++ b/docs/parity/billing-stripe-reconciliation-verification.md
@@ -1,0 +1,33 @@
+# Billing Stripe Reconciliation Verification
+
+Requirement: `REQ-BILL-001`  
+Scope: verify Stripe checkout payment lifecycle reconciliation, idempotency controls, and invoice balance/status transitions.
+
+## Artifact
+
+- API hardening: `apps/api/src/billing/billing.service.ts`
+- API tests: `apps/api/test/billing-stripe-reconciliation.spec.ts`
+
+## Coverage Mapping
+
+- Checkout metadata propagation:
+  - checkout session and payment intent metadata include `invoiceId` + `organizationId` for reconciliation routing.
+- Webhook reconciliation lifecycle:
+  - `checkout.session.completed` and `payment_intent.succeeded` both reconcile payments against invoices.
+  - payment amount is clamped to remaining balance, with deterministic invoice status transitions (`PARTIAL` / `PAID`).
+- Idempotency hardening:
+  - duplicate deliveries are deduped by Stripe event ID (`reference=stripe_event:<eventId>`).
+  - payment-intent dedupe remains in place for repeated events with the same `stripePaymentIntentId`.
+- Signature verification governance:
+  - when `STRIPE_WEBHOOK_SECRET` is configured, missing signature/raw body is rejected.
+  - signature path is verified by regression test via Stripe webhook constructor mock.
+
+## Verification
+
+- `pnpm --filter api test -- billing-stripe-reconciliation.spec.ts`
+- `pnpm test`
+- `pnpm build`
+- `pnpm backlog:sync`
+- `pnpm backlog:verify`
+- `pnpm backlog:snapshot`
+- `pnpm backlog:handoff:check`

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -458,11 +458,11 @@
           "title": "Finalize Stripe payment flow lifecycle and webhook reconciliation",
           "requirementId": "REQ-BILL-001",
           "promptSection": "Billing & Trust / Stripe Checkout pay link",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "High",
           "labels": ["parity", "billing"],
-          "problemStatement": "Checkout link generation exists but full payment lifecycle reconciliation is incomplete.",
+          "problemStatement": "Stripe checkout + reconciliation is now verified with event-level idempotency, signature-path coverage, and deterministic invoice status transition tests.",
           "requirementExcerpt": "Stripe Checkout pay link required with payments tracking.",
           "acceptanceCriteria": [
             "Webhook handling reconciles checkout completion and payment state.",
@@ -472,7 +472,8 @@
           "apiImpact": "Webhook endpoint and payment status updates expanded.",
           "securityImpact": "Webhook signature verification required.",
           "definitionOfDone": [
-            "Stripe test-mode flow fully documented and tested."
+            "Stripe lifecycle tests cover checkout metadata propagation, duplicate webhook behavior by payment intent and event ID, payment_intent.succeeded paid transitions, and webhook signature verification.",
+            "Verification artifact documented at docs/parity/billing-stripe-reconciliation-verification.md."
           ]
         },
         {

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T22:29:36.614Z",
+  "generatedAt": "2026-02-17T22:43:53.695Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,39 +14,30 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 31,
+    "unresolvedRequirements": 30,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-1": 26,
+      "phase-1": 25,
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 31
+      "Complete": 30
     },
     "unresolvedCountsByRisk": {
-      "High": 14,
+      "High": 13,
       "Medium": 17
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:High": 14,
+      "Complete:High": 13,
       "Complete:Medium": 17
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-BILL-001",
-        "parityStatus": "Complete",
-        "risk": "High",
-        "title": "Finalize Stripe payment flow lifecycle and webhook reconciliation",
-        "component": "API",
-        "epicCode": "PARITY-06",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-BILL-002",
         "parityStatus": "Complete",
@@ -127,26 +118,52 @@
         "component": "Web",
         "epicCode": "PARITY-03",
         "phase": "phase-1"
+      },
+      {
+        "requirementId": "REQ-PORTAL-001",
+        "parityStatus": "Complete",
+        "risk": "High",
+        "title": "Implement secure portal attachments in message workflow",
+        "component": "Web",
+        "epicCode": "PARITY-07",
+        "phase": "phase-1"
       }
     ]
   },
   "linearSummary": {
     "projectName": "Prompt Parity - Karen Legal Suite",
     "scopeLabel": "parity",
-    "scopedIssueCount": 46,
+    "scopedIssueCount": 47,
     "stateCounts": {
-      "Done": 32,
-      "In Review": 2,
+      "In Progress": 1,
+      "Done": 33,
+      "In Review": 1,
       "Backlog": 12
     },
-    "inProgressIssueKeys": [],
+    "inProgressIssueKeys": [
+      "KAR-61"
+    ],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
       {
+        "key": "KAR-61",
+        "title": "Harden REQ-BILL-001 Stripe reconciliation idempotency + verification coverage",
+        "state": "In Progress",
+        "updatedAt": "2026-02-17T22:43:34.521Z",
+        "requirementId": "REQ-BILL-001"
+      },
+      {
+        "key": "KAR-26",
+        "title": "PARITY-06 Billing + Trust + Payments",
+        "state": "Backlog",
+        "updatedAt": "2026-02-17T22:39:55.432Z",
+        "requirementId": "PARITY-06"
+      },
+      {
         "key": "KAR-34",
         "title": "Implement prompt injection defense hardening for ingestion pipeline",
-        "state": "In Review",
-        "updatedAt": "2026-02-17T22:29:16.066Z",
+        "state": "Done",
+        "updatedAt": "2026-02-17T22:33:44.856Z",
         "requirementId": "REQ-AI-002"
       },
       {
@@ -197,37 +214,30 @@
         "state": "Done",
         "updatedAt": "2026-02-17T18:38:27.887Z",
         "requirementId": "REQ-MAT-004"
-      },
-      {
-        "key": "KAR-42",
-        "title": "Document deployment runbook and operational SLOs",
-        "state": "Done",
-        "updatedAt": "2026-02-17T18:18:44.891Z",
-        "requirementId": "REQ-OPS-002"
-      },
-      {
-        "key": "KAR-31",
-        "title": "Replace e-sign stub with provider abstraction implementation",
-        "state": "Done",
-        "updatedAt": "2026-02-17T18:12:32.131Z",
-        "requirementId": "REQ-PORTAL-002"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T22:29:35.336Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-17T22:43:52.533Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "4b25cccb5b739c915d984e3ab54031380701bfbf",
+    "gitHead": "f1dc8d3ba85f9f412096e1c154944945e0f62e48",
     "gitStatusShort": [
-      "## lin/KAR-34-ai-ingestion-verification-hardening...origin/lin/KAR-34-ai-ingestion-verification-hardening",
+      "## lin/KAR-61-billing-stripe-verification-hardening",
+      " M apps/api/src/billing/billing.service.ts",
+      " M apps/api/test/billing-stripe-reconciliation.spec.ts",
+      " M docs/SESSION_HANDOFF.md",
+      " M tools/backlog-sync/requirements.matrix.json",
+      " M tools/backlog-sync/session.snapshot.json",
       "?? Brandguide.md",
+      "?? Brandguideprompt.md",
       "?? agents.md",
       "?? brand/",
       "?? brandguidetailwindsnipped.js",
+      "?? docs/parity/billing-stripe-reconciliation-verification.md",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 5
+    "dirtyFileCount": 12
   }
 }


### PR DESCRIPTION
## Linear Issue
- KAR-61
- https://linear.app/karenap/issue/KAR-61

## Requirement
- Requirement ID: REQ-BILL-001

## What changed
- Added Stripe reconciliation idempotency by event ID (`reference = stripe_event:<eventId>`), including cases where `payment_intent` is absent.
- Preserved payment-intent idempotency checks and expanded reconciliation metadata (`stripeEventType`).
- Hardened webhook verification behavior so configured webhook secrets require Stripe client/signature verification path.
- Expanded Stripe lifecycle regression tests:
  - duplicate event id handling without payment intent
  - `payment_intent.succeeded` full-balance transition to `PAID`
  - signature-enforced webhook parsing path
- Added parity verification artifact and updated parity matrix/handoff metadata.

## Verification evidence
- `pnpm --filter api test -- billing-stripe-reconciliation.spec.ts`
- `pnpm test`
- `pnpm build`
- `pnpm backlog:sync`
- `pnpm backlog:verify`
- `pnpm backlog:snapshot`
- `pnpm backlog:handoff:check`
