### PR TITLE
[KAR-62] Verify trust ledger invariants and transfer reconciliation

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -481,104 +481,114 @@ export class BillingService {
     const amount = Number(Math.abs(input.amount).toFixed(2));
     if (amount <= 0) throw new Error('Transfer amount must be greater than zero');
 
-    const sourceLedger = await this.prisma.matterTrustLedger.findFirst({
-      where: {
-        organizationId: input.user.organizationId,
-        matterId: input.fromMatterId,
-        trustAccountId: input.trustAccountId,
-      },
-    });
-    const sourceBalance = sourceLedger?.balance || 0;
-    const nextSourceBalance = Number((sourceBalance - amount).toFixed(2));
-    this.assertTrustBalanceInvariant(nextSourceBalance);
-
-    const destinationLedger = await this.prisma.matterTrustLedger.findFirst({
-      where: {
-        organizationId: input.user.organizationId,
-        matterId: input.toMatterId,
-        trustAccountId: input.trustAccountId,
-      },
-    });
-    const nextDestinationBalance = Number(((destinationLedger?.balance || 0) + amount).toFixed(2));
-
     const transferId = `transfer:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`;
-
-    const [withdrawalTx, depositTx] = await this.prisma.$transaction([
-      this.prisma.trustTransaction.create({
-        data: {
-          organizationId: input.user.organizationId,
-          trustAccountId: input.trustAccountId,
-          matterId: input.fromMatterId,
-          type: TrustTransactionType.TRANSFER,
-          amount,
-          description: `${input.description || 'Trust transfer'} | ${transferId} | out`,
-        },
-      }),
-      this.prisma.trustTransaction.create({
-        data: {
-          organizationId: input.user.organizationId,
-          trustAccountId: input.trustAccountId,
-          matterId: input.toMatterId,
-          type: TrustTransactionType.TRANSFER,
-          amount,
-          description: `${input.description || 'Trust transfer'} | ${transferId} | in`,
-        },
-      }),
-    ]);
-
-    if (!sourceLedger) {
-      await this.prisma.matterTrustLedger.create({
-        data: {
+    const transferResult = await this.prisma.$transaction(async (tx) => {
+      const sourceLedger = await tx.matterTrustLedger.findFirst({
+        where: {
           organizationId: input.user.organizationId,
           matterId: input.fromMatterId,
           trustAccountId: input.trustAccountId,
-          balance: nextSourceBalance,
         },
       });
-    } else {
-      await this.prisma.matterTrustLedger.update({
-        where: { id: sourceLedger.id },
-        data: { balance: nextSourceBalance },
-      });
-    }
+      const sourceBalance = sourceLedger?.balance || 0;
+      const nextSourceBalance = Number((sourceBalance - amount).toFixed(2));
+      this.assertTrustBalanceInvariant(nextSourceBalance);
 
-    if (!destinationLedger) {
-      await this.prisma.matterTrustLedger.create({
-        data: {
+      const destinationLedger = await tx.matterTrustLedger.findFirst({
+        where: {
           organizationId: input.user.organizationId,
           matterId: input.toMatterId,
           trustAccountId: input.trustAccountId,
-          balance: nextDestinationBalance,
         },
       });
-    } else {
-      await this.prisma.matterTrustLedger.update({
-        where: { id: destinationLedger.id },
-        data: { balance: nextDestinationBalance },
-      });
-    }
+      const nextDestinationBalance = Number(((destinationLedger?.balance || 0) + amount).toFixed(2));
+
+      const [withdrawalTx, depositTx] = await Promise.all([
+        tx.trustTransaction.create({
+          data: {
+            organizationId: input.user.organizationId,
+            trustAccountId: input.trustAccountId,
+            matterId: input.fromMatterId,
+            type: TrustTransactionType.TRANSFER,
+            amount,
+            description: `${input.description || 'Trust transfer'} | ${transferId} | out`,
+          },
+        }),
+        tx.trustTransaction.create({
+          data: {
+            organizationId: input.user.organizationId,
+            trustAccountId: input.trustAccountId,
+            matterId: input.toMatterId,
+            type: TrustTransactionType.TRANSFER,
+            amount,
+            description: `${input.description || 'Trust transfer'} | ${transferId} | in`,
+          },
+        }),
+      ]);
+
+      if (!sourceLedger) {
+        await tx.matterTrustLedger.create({
+          data: {
+            organizationId: input.user.organizationId,
+            matterId: input.fromMatterId,
+            trustAccountId: input.trustAccountId,
+            balance: nextSourceBalance,
+          },
+        });
+      } else {
+        await tx.matterTrustLedger.update({
+          where: { id: sourceLedger.id },
+          data: { balance: nextSourceBalance },
+        });
+      }
+
+      if (!destinationLedger) {
+        await tx.matterTrustLedger.create({
+          data: {
+            organizationId: input.user.organizationId,
+            matterId: input.toMatterId,
+            trustAccountId: input.trustAccountId,
+            balance: nextDestinationBalance,
+          },
+        });
+      } else {
+        await tx.matterTrustLedger.update({
+          where: { id: destinationLedger.id },
+          data: { balance: nextDestinationBalance },
+        });
+      }
+
+      return {
+        withdrawalTx,
+        depositTx,
+        nextSourceBalance,
+        nextDestinationBalance,
+      };
+    });
 
     await this.audit.appendEvent({
       organizationId: input.user.organizationId,
       actorUserId: input.user.id,
       action: 'trust.transfer.completed',
       entityType: 'trustTransaction',
-      entityId: withdrawalTx.id,
+      entityId: transferResult.withdrawalTx.id,
       metadata: {
         transferId,
         trustAccountId: input.trustAccountId,
         fromMatterId: input.fromMatterId,
         toMatterId: input.toMatterId,
         amount,
+        sourceBalance: transferResult.nextSourceBalance,
+        destinationBalance: transferResult.nextDestinationBalance,
       },
     });
 
     return {
       transferId,
-      withdrawalTransactionId: withdrawalTx.id,
-      depositTransactionId: depositTx.id,
-      sourceBalance: nextSourceBalance,
-      destinationBalance: nextDestinationBalance,
+      withdrawalTransactionId: transferResult.withdrawalTx.id,
+      depositTransactionId: transferResult.depositTx.id,
+      sourceBalance: transferResult.nextSourceBalance,
+      destinationBalance: transferResult.nextDestinationBalance,
     };
   }
 
@@ -660,7 +670,7 @@ export class BillingService {
     for (const tx of transactions) {
       const key = `${tx.trustAccountId}:${tx.matterId}`;
       const current = expectedByKey.get(key) || 0;
-      const delta = this.computeTrustDelta(tx.type, tx.amount);
+      const delta = this.computeTrustReconciliationDelta(tx);
       expectedByKey.set(key, Number((current + delta).toFixed(2)));
     }
 
@@ -1086,7 +1096,7 @@ export class BillingService {
     for (const tx of transactions) {
       const key = `${tx.trustAccountId}:${tx.matterId}`;
       const current = expectedByKey.get(key) || 0;
-      const delta = this.computeTrustDelta(tx.type, tx.amount);
+      const delta = this.computeTrustReconciliationDelta(tx);
       expectedByKey.set(key, Number((current + delta).toFixed(2)));
     }
 
@@ -1664,6 +1674,26 @@ export class BillingService {
       default:
         throw new Error(`Unsupported trust transaction type: ${type}`);
     }
+  }
+
+  private computeTrustReconciliationDelta(tx: {
+    type: TrustTransactionType;
+    amount: number;
+    description?: string | null;
+  }): number {
+    if (tx.type !== TrustTransactionType.TRANSFER) {
+      return this.computeTrustDelta(tx.type, tx.amount);
+    }
+
+    const descriptor = String(tx.description || '').toLowerCase();
+    if (/\|\s*in\s*$/.test(descriptor)) {
+      return Number(Math.abs(tx.amount).toFixed(2));
+    }
+    if (/\|\s*out\s*$/.test(descriptor)) {
+      return Number((-Math.abs(tx.amount)).toFixed(2));
+    }
+
+    return this.computeTrustDelta(tx.type, tx.amount);
   }
 
   private assertTrustBalanceInvariant(nextBalance: number) {

--- a/apps/api/test/billing-trust-invariants.spec.ts
+++ b/apps/api/test/billing-trust-invariants.spec.ts
@@ -81,6 +81,78 @@ describe('BillingService trust invariants + reports', () => {
     );
   });
 
+  it('creates paired transfer entries and updates both ledgers atomically', async () => {
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const txClient = {
+      matterTrustLedger: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce({ id: 'ledger-src', balance: 300 })
+          .mockResolvedValueOnce({ id: 'ledger-dst', balance: 50 }),
+        update: jest.fn().mockResolvedValue({}),
+        create: jest.fn(),
+      },
+      trustTransaction: {
+        create: jest
+          .fn()
+          .mockResolvedValueOnce({ id: 'tx-out' })
+          .mockResolvedValueOnce({ id: 'tx-in' }),
+      },
+    } as any;
+    const prisma = {
+      trustAccount: { findFirst: jest.fn().mockResolvedValue({ id: 'ta-1' }) },
+      $transaction: jest.fn().mockImplementation(async (handler: (client: typeof txClient) => Promise<unknown>) => handler(txClient)),
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      audit,
+      { upload: jest.fn() } as any,
+    );
+
+    const result = await service.transferTrust({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      trustAccountId: 'ta-1',
+      fromMatterId: 'matter-src',
+      toMatterId: 'matter-dst',
+      amount: 75,
+      description: 'Reallocate trust retainer',
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(txClient.trustTransaction.create).toHaveBeenCalledTimes(2);
+    expect(txClient.matterTrustLedger.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'ledger-src' },
+        data: { balance: 225 },
+      }),
+    );
+    expect(txClient.matterTrustLedger.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'ledger-dst' },
+        data: { balance: 125 },
+      }),
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        withdrawalTransactionId: 'tx-out',
+        depositTransactionId: 'tx-in',
+        sourceBalance: 225,
+        destinationBalance: 125,
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'trust.transfer.completed',
+        metadata: expect.objectContaining({
+          sourceBalance: 225,
+          destinationBalance: 125,
+        }),
+      }),
+    );
+  });
+
   it('returns account and matter level trust summaries', async () => {
     const service = new BillingService(
       {
@@ -184,6 +256,65 @@ describe('BillingService trust invariants + reports', () => {
         difference: -50,
       }),
     );
+  });
+
+  it('treats transfer in/out descriptors as opposite reconciliation deltas', async () => {
+    const service = new BillingService(
+      {
+        matterTrustLedger: {
+          findMany: jest.fn().mockResolvedValue([
+            {
+              id: 'l1',
+              trustAccountId: 'ta-1',
+              matterId: 'm-src',
+              balance: 200,
+              trustAccount: { name: 'IOLTA Account' },
+              matter: { name: 'Matter Source' },
+            },
+            {
+              id: 'l2',
+              trustAccountId: 'ta-1',
+              matterId: 'm-dst',
+              balance: 100,
+              trustAccount: { name: 'IOLTA Account' },
+              matter: { name: 'Matter Dest' },
+            },
+          ]),
+        },
+        trustTransaction: {
+          findMany: jest.fn().mockResolvedValue([
+            { trustAccountId: 'ta-1', matterId: 'm-src', type: 'DEPOSIT', amount: 300 },
+            {
+              trustAccountId: 'ta-1',
+              matterId: 'm-src',
+              type: 'TRANSFER',
+              amount: 100,
+              description: 'Trust transfer | transfer:abc123 | out',
+            },
+            {
+              trustAccountId: 'ta-1',
+              matterId: 'm-dst',
+              type: 'TRANSFER',
+              amount: 100,
+              description: 'Trust transfer | transfer:abc123 | in',
+            },
+          ]),
+        },
+      } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn() } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    const report = await service.trustReconciliation({ organizationId: 'org-1' } as any);
+    expect(report).toEqual(
+      expect.objectContaining({
+        checkedLedgers: 2,
+        checkedTransactions: 3,
+        mismatchCount: 0,
+      }),
+    );
+    expect(report.mismatches).toEqual([]);
   });
 
   it('creates trust reconciliation run with discrepancy records', async () => {

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-17T22:43:53.695Z`
+- Snapshot Timestamp: `2026-02-18T00:52:39.300Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-17T22:43:52.533Z`
+- Last Successful Mirror Verify: `2026-02-18T00:52:38.003Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-17: Verified `REQ-BILL-002` by hardening trust-transfer atomicity (paired transfer entries + ledger updates inside one DB transaction), adding transfer balance metadata to audit events, and fixing reconciliation transfer-delta logic to interpret `| out`/`| in` directions with expanded regression coverage (`docs/parity/billing-trust-ledger-verification.md`).
 - 2026-02-17: Verified `REQ-BILL-001` by hardening Stripe reconciliation idempotency with event-level dedupe (`stripe_event:<eventId>`), preserving payment-intent dedupe, adding deterministic `payment_intent.succeeded` paid-transition coverage, and verifying signature-enforced webhook parsing when `STRIPE_WEBHOOK_SECRET` is configured (`docs/parity/billing-stripe-reconciliation-verification.md`).
 - 2026-02-17: Verified `REQ-AI-002` by hardening ingestion/generation governance with explicit `quarantinedFromContext` metadata, citation-policy enforcement that appends trusted chunk citations when missing, `policyCompliance` artifact metadata, `ai.output.citation_policy_enforced` audit events, and expanded adversarial API coverage (`docs/parity/ai-ingestion-security-verification.md`).
 - 2026-02-17: Verified `REQ-AI-001` by hardening deadline-confirmation server validation (non-empty selections, valid dates, at-least-one output), adding explicit `ai.deadlines.confirmed` audit events with selection/created-record metadata, and extending API/Web regression coverage (`docs/parity/ai-deadline-confirmation-verification.md`).

--- a/docs/parity/billing-trust-ledger-verification.md
+++ b/docs/parity/billing-trust-ledger-verification.md
@@ -1,0 +1,33 @@
+# Billing Trust Ledger Verification
+
+Requirement: `REQ-BILL-002`  
+Scope: verify trust ledger invariants and reporting correctness with transfer-safe reconciliation behavior.
+
+## Artifact
+
+- API hardening: `apps/api/src/billing/billing.service.ts`
+- API tests: `apps/api/test/billing-trust-invariants.spec.ts`
+
+## Coverage Mapping
+
+- Trust balance invariants:
+  - negative-balance guardrails continue to block violating withdrawals.
+  - adjustment/transaction audit events include resulting-balance metadata.
+- Transfer consistency hardening:
+  - trust transfer now performs transaction entries + ledger updates in one DB transaction boundary.
+  - transfer audit metadata includes resulting source/destination balances.
+- Reporting and reconciliation correctness:
+  - account/matter trust summary totals remain covered.
+  - reconciliation now interprets transfer direction markers (`| out` / `| in`) to apply correct deltas and avoid false mismatches.
+- Regression protection:
+  - tests validate transfer atomic flow, mismatch detection path, and transfer-direction reconciliation behavior.
+
+## Verification
+
+- `pnpm --filter api test -- billing-trust-invariants.spec.ts`
+- `pnpm test`
+- `pnpm build`
+- `pnpm backlog:sync`
+- `pnpm backlog:verify`
+- `pnpm backlog:snapshot`
+- `pnpm backlog:handoff:check`

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -480,11 +480,11 @@
           "title": "Complete trust accounting reports and ledger invariants",
           "requirementId": "REQ-BILL-002",
           "promptSection": "Billing & Trust / Trust ledger entries and basic trust reporting",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "High",
           "labels": ["parity", "billing"],
-          "problemStatement": "Trust tables exist but reconciliation and report completeness need hardening.",
+          "problemStatement": "Trust invariants and reporting are now verified with atomic transfer updates, transfer-aware reconciliation delta logic, and expanded regression coverage.",
           "requirementExcerpt": "Trust ledger and basic trust reporting required.",
           "acceptanceCriteria": [
             "Matter and account-level trust balance reports implemented.",
@@ -494,7 +494,8 @@
           "apiImpact": "Trust report endpoints expanded.",
           "securityImpact": "Financial data integrity improved.",
           "definitionOfDone": [
-            "Trust accounting regression tests pass."
+            "Trust regression tests cover transfer atomicity, reconciliation mismatch detection, and transfer in/out delta correctness.",
+            "Verification artifact documented at docs/parity/billing-trust-ledger-verification.md."
           ]
         },
         {

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-17T22:43:53.695Z",
+  "generatedAt": "2026-02-18T00:52:39.300Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,39 +14,30 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 30,
+    "unresolvedRequirements": 29,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-1": 25,
+      "phase-1": 24,
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 30
+      "Complete": 29
     },
     "unresolvedCountsByRisk": {
-      "High": 13,
+      "High": 12,
       "Medium": 17
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:High": 13,
+      "Complete:High": 12,
       "Complete:Medium": 17
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-BILL-002",
-        "parityStatus": "Complete",
-        "risk": "High",
-        "title": "Complete trust accounting reports and ledger invariants",
-        "component": "API",
-        "epicCode": "PARITY-06",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-DATA-001",
         "parityStatus": "Complete",
@@ -127,37 +118,53 @@
         "component": "Web",
         "epicCode": "PARITY-07",
         "phase": "phase-1"
+      },
+      {
+        "requirementId": "REQ-SEC-001",
+        "parityStatus": "Complete",
+        "risk": "High",
+        "title": "Harden tenant isolation test coverage across all core entities",
+        "component": "API",
+        "epicCode": "PARITY-01",
+        "phase": "phase-1"
       }
     ]
   },
   "linearSummary": {
     "projectName": "Prompt Parity - Karen Legal Suite",
     "scopeLabel": "parity",
-    "scopedIssueCount": 47,
+    "scopedIssueCount": 48,
     "stateCounts": {
       "In Progress": 1,
-      "Done": 33,
+      "Done": 34,
       "In Review": 1,
       "Backlog": 12
     },
     "inProgressIssueKeys": [
-      "KAR-61"
+      "KAR-62"
     ],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
       {
-        "key": "KAR-61",
-        "title": "Harden REQ-BILL-001 Stripe reconciliation idempotency + verification coverage",
+        "key": "KAR-62",
+        "title": "Harden REQ-BILL-002 trust invariants + reconciliation verification coverage",
         "state": "In Progress",
-        "updatedAt": "2026-02-17T22:43:34.521Z",
-        "requirementId": "REQ-BILL-001"
+        "updatedAt": "2026-02-18T00:52:11.882Z",
+        "requirementId": "REQ-BILL-002"
       },
       {
         "key": "KAR-26",
         "title": "PARITY-06 Billing + Trust + Payments",
         "state": "Backlog",
-        "updatedAt": "2026-02-17T22:39:55.432Z",
+        "updatedAt": "2026-02-18T00:52:11.882Z",
         "requirementId": "PARITY-06"
+      },
+      {
+        "key": "KAR-61",
+        "title": "Harden REQ-BILL-001 Stripe reconciliation idempotency + verification coverage",
+        "state": "Done",
+        "updatedAt": "2026-02-18T00:37:07.780Z",
+        "requirementId": "REQ-BILL-001"
       },
       {
         "key": "KAR-34",
@@ -207,37 +214,29 @@
         "state": "Done",
         "updatedAt": "2026-02-17T19:03:45.185Z",
         "requirementId": "REQ-MAT-005"
-      },
-      {
-        "key": "KAR-44",
-        "title": "Implement advanced conflict rule profiles and resolution workflows",
-        "state": "Done",
-        "updatedAt": "2026-02-17T18:38:27.887Z",
-        "requirementId": "REQ-MAT-004"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-17T22:43:52.533Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T00:52:38.003Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "f1dc8d3ba85f9f412096e1c154944945e0f62e48",
+    "gitHead": "8a00fafe44fa2f6102f8f598d1dcf0e6579e0bce",
     "gitStatusShort": [
-      "## lin/KAR-61-billing-stripe-verification-hardening",
+      "## lin/KAR-62-billing-trust-verification-hardening",
       " M apps/api/src/billing/billing.service.ts",
-      " M apps/api/test/billing-stripe-reconciliation.spec.ts",
+      " M apps/api/test/billing-trust-invariants.spec.ts",
       " M docs/SESSION_HANDOFF.md",
       " M tools/backlog-sync/requirements.matrix.json",
-      " M tools/backlog-sync/session.snapshot.json",
       "?? Brandguide.md",
       "?? Brandguideprompt.md",
       "?? agents.md",
       "?? brand/",
       "?? brandguidetailwindsnipped.js",
-      "?? docs/parity/billing-stripe-reconciliation-verification.md",
+      "?? docs/parity/billing-trust-ledger-verification.md",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 12
+    "dirtyFileCount": 11
   }
 }


### PR DESCRIPTION
## Linear Issue
- KAR-62
- https://linear.app/karenap/issue/KAR-62

## Requirement
- Requirement ID: REQ-BILL-002

## What changed
- Hardened trust transfer workflow to run paired transfer entries and ledger updates inside one DB transaction.
- Added transfer-result balances into transfer audit metadata.
- Fixed reconciliation delta calculation for transfer pairs by honoring transfer direction markers (`| out` / `| in`).
- Added regression tests for transfer atomic flow and transfer-direction reconciliation correctness.
- Added parity verification artifact and updated parity matrix/handoff metadata.

## Verification evidence
- `pnpm --filter api test -- billing-trust-invariants.spec.ts`
- `pnpm test`
- `pnpm build`
- `pnpm backlog:sync`
- `pnpm backlog:verify`
- `pnpm backlog:snapshot`
- `pnpm backlog:handoff:check`
