### PR TITLE
[KAR-25] Verify document automation hardening controls

### DIFF
--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -926,10 +926,14 @@ export class DocumentsService {
     if (!template) {
       throw new NotFoundException('Template document version not found');
     }
+    if (!this.isDocxTemplateMimeType(template.mimeType)) {
+      throw new UnprocessableEntityException('Template document version must be a DOCX file');
+    }
 
     const strictValidation = input.strictValidation ?? true;
     const baseMergeContext = await this.buildTemplateMergeContext(input.user, input.matterId);
-    const mergeContext = this.deepMergeRecords(baseMergeContext, input.mergeData ?? {});
+    const mergeData = this.sanitizeMergePatch(input.mergeData ?? {});
+    const mergeContext = this.deepMergeRecords(baseMergeContext, mergeData);
 
     const templateBuffer = await this.s3.getObjectBuffer(template.storageKey);
     const zip = new PizZip(templateBuffer);
@@ -969,7 +973,7 @@ export class DocumentsService {
       templateVersionId: template.id,
       strictValidation,
       unresolvedMergeFields,
-      providedMergeDataKeys: Object.keys(input.mergeData ?? {}),
+      providedMergeDataKeys: Object.keys(mergeData),
       mergeContextSummary: {
         participantCount: baseMergeContext.participants.length,
         matterCustomFieldCount: Object.keys(baseMergeContext.customFields.matter).length,
@@ -1377,6 +1381,9 @@ export class DocumentsService {
   private deepMergeRecords<T extends Record<string, unknown>>(base: T, patch: Record<string, unknown>): T {
     const merged: Record<string, unknown> = { ...base };
     for (const [key, value] of Object.entries(patch)) {
+      if (this.isUnsafeMergeKey(key)) {
+        continue;
+      }
       if (this.isRecord(value) && this.isRecord(merged[key])) {
         merged[key] = this.deepMergeRecords(
           merged[key] as Record<string, unknown>,
@@ -1391,6 +1398,32 @@ export class DocumentsService {
 
   private isRecord(value: unknown): value is Record<string, unknown> {
     return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  private sanitizeMergePatch(patch: Record<string, unknown>) {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(patch)) {
+      if (this.isUnsafeMergeKey(key)) {
+        continue;
+      }
+      if (this.isRecord(value)) {
+        sanitized[key] = this.sanitizeMergePatch(value);
+        continue;
+      }
+      sanitized[key] = value;
+    }
+    return sanitized;
+  }
+
+  private isUnsafeMergeKey(key: string) {
+    return key === '__proto__' || key === 'prototype' || key === 'constructor';
+  }
+
+  private isDocxTemplateMimeType(mimeType: string | null | undefined) {
+    return (
+      mimeType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+      mimeType === 'application/vnd.ms-word.document.macroEnabled.12'
+    );
   }
 
   private async auditBlockedUpload(

--- a/apps/api/test/documents-template-merge.spec.ts
+++ b/apps/api/test/documents-template-merge.spec.ts
@@ -1,6 +1,8 @@
 import PizZip from 'pizzip';
 import { DocumentsService } from '../src/documents/documents.service';
 
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
 function createDocxTemplateBuffer(tags: string[]) {
   const zip = new PizZip();
   zip.file(
@@ -141,6 +143,7 @@ describe('DocumentsService mergeDocxTemplate', () => {
         findFirst: jest.fn().mockResolvedValue({
           id: 'template-version-1',
           storageKey: 'templates/1.docx',
+          mimeType: DOCX_MIME,
           document: {
             id: 'template-document-1',
             sharedWithClient: true,
@@ -247,6 +250,7 @@ describe('DocumentsService mergeDocxTemplate', () => {
         findFirst: jest.fn().mockResolvedValue({
           id: 'template-version-1',
           storageKey: 'templates/1.docx',
+          mimeType: DOCX_MIME,
           document: {
             id: 'template-document-1',
             sharedWithClient: false,
@@ -295,6 +299,7 @@ describe('DocumentsService mergeDocxTemplate', () => {
         findFirst: jest.fn().mockResolvedValue({
           id: 'template-version-1',
           storageKey: 'templates/1.docx',
+          mimeType: DOCX_MIME,
           document: {
             id: 'template-document-1',
             sharedWithClient: false,
@@ -342,6 +347,171 @@ describe('DocumentsService mergeDocxTemplate', () => {
               unresolvedMergeFields: expect.arrayContaining(['customFields.matter.optionalField']),
             }),
           }),
+        }),
+      }),
+    );
+  });
+
+  it('rejects non-docx template versions before render', async () => {
+    const prisma = {
+      documentVersion: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'template-version-1',
+          storageKey: 'templates/1.pdf',
+          mimeType: 'application/pdf',
+          document: {
+            id: 'template-document-1',
+            sharedWithClient: false,
+            confidentialityLevel: 'CONFIDENTIAL',
+          },
+        }),
+      },
+      matter: {
+        findFirst: jest.fn().mockResolvedValue(buildMatterFixture()),
+      },
+      customFieldValue: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      document: {
+        create: jest.fn(),
+      },
+    } as any;
+
+    const s3 = {
+      getObjectBuffer: jest.fn(),
+      upload: jest.fn(),
+    } as any;
+
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      s3,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent: jest.fn() } as any,
+    );
+
+    await expect(
+      service.mergeDocxTemplate({
+        user: { id: 'user-1', organizationId: 'org-1' } as any,
+        templateVersionId: 'template-version-1',
+        matterId: 'matter-1',
+        title: 'Demand Letter Draft',
+      }),
+    ).rejects.toThrow('Template document version must be a DOCX file');
+
+    expect(s3.getObjectBuffer).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes unsafe merge keys before provenance and context merge', async () => {
+    const templateBuffer = createDocxTemplateBuffer(['{matter.name}']);
+    const prisma = {
+      documentVersion: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'template-version-1',
+          storageKey: 'templates/1.docx',
+          mimeType: DOCX_MIME,
+          document: {
+            id: 'template-document-1',
+            sharedWithClient: true,
+            confidentialityLevel: 'CONFIDENTIAL',
+          },
+        }),
+        create: jest.fn().mockResolvedValue({ id: 'generated-version-1' }),
+      },
+      matter: {
+        findFirst: jest.fn().mockResolvedValue(buildMatterFixture()),
+      },
+      customFieldValue: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      document: {
+        create: jest.fn().mockResolvedValue({ id: 'generated-document-1' }),
+      },
+    } as any;
+
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      {
+        getObjectBuffer: jest.fn().mockResolvedValue(templateBuffer),
+        upload: jest.fn().mockResolvedValue({ key: 'org/org-1/matter/matter-1/generated.docx' }),
+      } as any,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent: jest.fn() } as any,
+    );
+
+    const pollutedInput = JSON.parse('{"matter":{"name":"Sanitized Override"},"__proto__":{"polluted":"yes"}}');
+    const result = await service.mergeDocxTemplate({
+      user: { id: 'user-1', organizationId: 'org-1' } as any,
+      templateVersionId: 'template-version-1',
+      matterId: 'matter-1',
+      title: 'Demand Letter Draft',
+      mergeData: pollutedInput,
+    });
+
+    expect(result.mergeSummary.unresolvedMergeFields).toEqual([]);
+    expect(prisma.document.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          rawSourcePayload: expect.objectContaining({
+            provenance: expect.objectContaining({
+              providedMergeDataKeys: ['matter'],
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('records provenance and audit metadata for generated pdf outputs', async () => {
+    const prisma = {
+      document: {
+        create: jest.fn().mockResolvedValue({ id: 'generated-pdf-document-1' }),
+      },
+      documentVersion: {
+        create: jest.fn().mockResolvedValue({ id: 'generated-pdf-version-1' }),
+      },
+    } as any;
+
+    const appendEvent = jest.fn().mockResolvedValue(undefined);
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      {
+        upload: jest.fn().mockResolvedValue({ key: 'org/org-1/matter/matter-1/generated.pdf' }),
+      } as any,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent } as any,
+    );
+
+    await service.generateSimplePdf({
+      user: { id: 'user-1', organizationId: 'org-1' } as any,
+      matterId: 'matter-1',
+      title: 'Client Status Letter',
+      lines: ['Line 1', 'Line 2'],
+    });
+
+    expect(prisma.document.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          rawSourcePayload: expect.objectContaining({
+            source: 'simple-pdf',
+            provenance: expect.objectContaining({
+              lineCount: 2,
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.pdf.generated',
+        entityType: 'document',
+        entityId: 'generated-pdf-document-1',
+        metadata: expect.objectContaining({
+          lineCount: 2,
         }),
       }),
     );

--- a/docs/parity/document-automation-coverage.md
+++ b/docs/parity/document-automation-coverage.md
@@ -1,41 +1,40 @@
-# REQ-COMM-003 Parity Evidence: Document Automation Merge Coverage
+# Document Automation Verification
 
 Requirement: `REQ-COMM-003`  
-Prompt section: `Document Management + Automation`
+Scope: verify DOCX template merge + generated PDF automation with strict validation, provenance tracking, and hardened merge controls.
 
-## Implemented
+## Verification Coverage
 
-- Expanded DOCX merge context generation in `DocumentsService.mergeDocxTemplate`:
-  - matter graph (`matter` + stage + matter type)
-  - participant/contact graph (`participants`, `contacts.primaryClient`, side-grouped contacts)
-  - custom field graph (`customFields.matter`, `customFields.contacts`)
-- Enabled nested template expressions (`matter.name`, `contacts.primaryClient.displayName`, etc.) using Docxtemplater expression parsing.
-- Added strict placeholder validation before artifact creation:
-  - unresolved merge fields are collected during render
-  - `strictValidation` defaults to `true`
-  - unresolved placeholders now fail with `422` before upload
-  - optional bypass for deliberate partial drafts: `strictValidation=false`
-- Added generated artifact provenance metadata:
-  - persisted in `Document.rawSourcePayload` for DOCX/PDF generated outputs
-  - includes template source ids, strict mode, unresolved fields, merge-data keys, context summary, timestamp
-- Added generation audit events:
-  - `document.template.generated`
-  - `document.pdf.generated`
-
-## Verification
-
-- API tests:
+- API regression suites:
   - `apps/api/test/documents-template-merge.spec.ts`
-  - existing compatibility tests retained:
-    - `apps/api/test/documents.spec.ts`
-- Full API + web test pass:
-  - `pnpm test`
-- Build pass:
-  - `pnpm build`
+  - `apps/api/test/documents.spec.ts`
 
-## Notes
+### Merge/generation hardening checks
 
-- Generated DOCX documents now inherit confidentiality/share defaults from the source template document.
-- Endpoint `POST /documents/template-merge` now supports:
-  - optional `mergeData`
-  - optional `strictValidation` (default `true`)
+- DOCX merge context coverage remains in place:
+  - matter, participants, contact graph, and custom field graph
+  - nested expressions via Docxtemplater parser
+- Strict merge validation remains enforced by default:
+  - unresolved placeholders fail with `422`
+  - explicit `strictValidation=false` supports controlled partial drafts
+- Template ingestion hardening now blocks unsupported template source types:
+  - non-DOCX template versions are rejected before render
+- Merge patch hardening now sanitizes unsafe keys:
+  - reserved keys (`__proto__`, `prototype`, `constructor`) are stripped before merge
+  - provenance reflects sanitized top-level merge-data keys
+- Provenance + audit coverage verified for generated artifacts:
+  - DOCX template generation logs `document.template.generated`
+  - PDF generation logs `document.pdf.generated`
+  - `rawSourcePayload` persists generation provenance metadata for both output types
+
+## Commands
+
+- `pnpm --filter api test -- documents-template-merge.spec.ts`
+- `pnpm --filter api test -- documents.spec.ts`
+- `pnpm --filter api test`
+- `pnpm test`
+- `pnpm build`
+
+## Result
+
+`REQ-COMM-003` is verified with hardened template input controls, sanitized merge patch behavior, strict placeholder governance, and audited provenance for generated DOCX/PDF outputs.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -424,11 +424,11 @@
           "title": "Expand document automation coverage for merge fields and generated outputs",
           "requirementId": "REQ-COMM-003",
           "promptSection": "Document Management + Automation",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "documents"],
-          "problemStatement": "DOCX/PDF generation exists but merge-source breadth and template governance are limited.",
+          "problemStatement": "Document automation is now verified with strict template governance, merge patch sanitization, and generated artifact provenance/audit coverage.",
           "requirementExcerpt": "DOCX template merge from matter/contact/custom fields and PDF generation for invoices/finalized letters.",
           "acceptanceCriteria": [
             "Merge context supports matter/contact/custom field graph.",
@@ -438,7 +438,9 @@
           "apiImpact": "Template merge endpoint payload/response enriched.",
           "securityImpact": "Generated docs inherit confidentiality controls.",
           "definitionOfDone": [
-            "Template merge acceptance suite passes."
+            "Template merge tests verify strict validation behavior, unsupported template-type rejection, and merge patch sanitization controls.",
+            "Generated PDF coverage verifies provenance metadata and document.pdf.generated audit events.",
+            "Verification artifact documented at docs/parity/document-automation-coverage.md."
           ]
         },
         {


### PR DESCRIPTION
## Linear Issue
- KAR-25

## Requirement ID
- REQ-COMM-003

## Summary
- enforce DOCX-only template versions before docxtemplater render
- sanitize unsafe merge patch keys and keep provenance mergeData keys sanitized
- add regression coverage for non-docx template rejection, merge key sanitization, and generated PDF provenance/audit events
- promote REQ-COMM-003 parity evidence and matrix status to Verified

## Acceptance Criteria
- [x] merge context supports matter/contact/custom field graph with strict placeholder validation
- [x] unsupported template file types are rejected before render
- [x] generated DOCX/PDF outputs persist provenance and emit audit events

## Validation
- pnpm --filter api test -- documents-template-merge.spec.ts
- pnpm --filter api test
- pnpm test
- pnpm build