### PR TITLE
[KAR-15] Verify Clio import lineage diagnostics

### DIFF
--- a/apps/api/src/imports/plugins/clio-template.plugin.ts
+++ b/apps/api/src/imports/plugins/clio-template.plugin.ts
@@ -431,12 +431,14 @@ function attachSource(
   canonical: Prisma.InputJsonObject,
   sourceFile: string,
   sourceEntity: string,
+  sourceRowNumber: number,
 ): Prisma.InputJsonObject {
   return {
     ...rawInput,
     ...canonical,
     __source_file: sourceFile,
     __source_entity: sourceEntity,
+    __source_row_number: sourceRowNumber,
   } as Prisma.InputJsonObject;
 }
 
@@ -470,7 +472,7 @@ export class ClioTemplateImportPlugin implements ImportPlugin {
         {
           entityType: definition.entityType,
           rowNumber: index + 1,
-          rawJson: attachSource(rawInput, transformed.rawJson, sourceFilename, sourceEntity),
+          rawJson: attachSource(rawInput, transformed.rawJson, sourceFilename, sourceEntity, index + 1),
           warnings,
         },
       ];
@@ -495,7 +497,13 @@ export class ClioTemplateImportPlugin implements ImportPlugin {
         rows.push({
           entityType: definition.entityType,
           rowNumber: index + 1,
-          rawJson: attachSource(rawInput, transformed.rawJson, `${sourceFilename}#${sheetName}`, sourceEntity),
+          rawJson: attachSource(
+            rawInput,
+            transformed.rawJson,
+            `${sourceFilename}#${sheetName}`,
+            sourceEntity,
+            index + 1,
+          ),
           warnings,
         });
       });

--- a/apps/api/test/imports.spec.ts
+++ b/apps/api/test/imports.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import AdmZip from 'adm-zip';
+import XLSX from 'xlsx';
 import { ImportsService } from '../src/imports/imports.service';
 import { ClioTemplateImportPlugin } from '../src/imports/plugins/clio-template.plugin';
 import { MyCaseZipImportPlugin } from '../src/imports/plugins/mycase-zip.plugin';
@@ -500,14 +501,17 @@ describe('ImportsService', () => {
     expect(noteRow?.rawJson).toMatchObject({
       __source_file: 'clio-template-full.csv',
       __source_entity: 'notes',
+      __source_row_number: 6,
     });
     expect(phoneRow?.rawJson).toMatchObject({
       __source_file: 'clio-template-full.csv',
       __source_entity: 'phone_logs',
+      __source_row_number: 7,
     });
     expect(emailRow?.rawJson).toMatchObject({
       __source_file: 'clio-template-full.csv',
       __source_entity: 'emails',
+      __source_row_number: 8,
     });
   });
 
@@ -554,6 +558,68 @@ describe('ImportsService', () => {
           sourceFile: 'clio-missing-matter.csv',
           sourceEntity: 'tasks',
           externalId: 't99',
+        }),
+      }),
+    );
+  });
+
+  it('captures XLSX row-level Clio error context for unresolved matter references', async () => {
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(
+      workbook,
+      XLSX.utils.json_to_sheet([
+        {
+          id: 'tx1',
+          title: 'Missing Matter Task',
+          due_date: '2026-05-10',
+          legacy_column: 'legacy-task',
+        },
+      ]),
+      'Tasks',
+    );
+    const workbookBuffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+
+    const { prisma, state } = buildImportPrismaMock();
+    const service = new ImportsService(prisma, { appendEvent: jest.fn() } as any);
+    service.registerPlugin(new ClioTemplateImportPlugin());
+
+    const batch = await service.runImport({
+      user: { id: 'u1', organizationId: 'org1' } as any,
+      sourceSystem: 'clio_template',
+      file: {
+        buffer: workbookBuffer,
+        originalname: 'clio-missing-matter.xlsx',
+        mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        size: workbookBuffer.length,
+        fieldname: 'file',
+        encoding: '7bit',
+      } as any,
+    });
+
+    expect(batch?.summaryJson).toMatchObject({
+      total: 1,
+      imported: 0,
+      failed: 1,
+      warnings: 2,
+    });
+
+    expect(state.importItems).toHaveLength(1);
+    expect(state.importItems[0].status).toBe('FAILED');
+    expect(state.importItems[0].warningsJson).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing_matter_reference' }),
+        expect.objectContaining({ code: 'unmapped_columns' }),
+      ]),
+    );
+    expect(state.importItems[0].errorsJson).toEqual(
+      expect.objectContaining({
+        message: 'Task row missing resolvable matter reference',
+        rowContext: expect.objectContaining({
+          entityType: 'task',
+          rowNumber: 1,
+          sourceFile: 'clio-missing-matter.xlsx#Tasks',
+          sourceEntity: 'tasks',
+          externalId: 'tx1',
         }),
       }),
     );
@@ -611,6 +677,7 @@ describe('ImportsService', () => {
       rawSourcePayload: expect.objectContaining({
         __source_file: 'clio-template.xlsx#Notes',
         __source_entity: 'notes',
+        __source_row_number: 1,
       }),
     });
     expect(phoneRef).toMatchObject({
@@ -619,6 +686,7 @@ describe('ImportsService', () => {
       rawSourcePayload: expect.objectContaining({
         __source_file: 'clio-template.xlsx#Phone_Logs',
         __source_entity: 'phone_logs',
+        __source_row_number: 1,
       }),
     });
     expect(emailRef).toMatchObject({
@@ -627,6 +695,7 @@ describe('ImportsService', () => {
       rawSourcePayload: expect.objectContaining({
         __source_file: 'clio-template.xlsx#Emails',
         __source_entity: 'emails',
+        __source_row_number: 1,
       }),
     });
   });

--- a/docs/parity/clio-import-verification.md
+++ b/docs/parity/clio-import-verification.md
@@ -7,9 +7,10 @@ Scope: verify Clio CSV/XLSX importer parity for mapping coverage, diagnostics qu
 
 - Regression suite: `apps/api/test/imports.spec.ts`
 - Hardened assertions include:
-  - CSV parsing maps all documented entity groups and preserves per-row source entity lineage (`notes`, `phone_logs`, `emails`) in `rawSourcePayload.__source_entity`.
+  - CSV parsing maps all documented entity groups and preserves per-row source lineage (`__source_entity`, `__source_file`, `__source_row_number`) for communications rows.
   - Row-level unresolved-reference failures include detailed error context (`entityType`, `sourceFile`, `sourceEntity`, `externalId`) for deterministic remediation.
-  - XLSX import coverage verifies external-reference payload lineage across communication sheets (`Notes`, `Phone_Logs`, `Emails`) with `externalParentId` linkage and source metadata integrity.
+  - XLSX unresolved-reference diagnostics preserve workbook sheet context (`sourceFile: <workbook>#<sheet>`) and row number.
+  - XLSX import coverage verifies external-reference payload lineage across communication sheets (`Notes`, `Phone_Logs`, `Emails`) with `externalParentId` linkage and source metadata integrity, including source row numbers.
   - Import summary diagnostics continue to report `warningCodeCounts` and `unmappedColumnsBySource` for template drift visibility.
 
 ## Commands

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -186,7 +186,7 @@
           "title": "Finalize Clio CSV/XLSX template importer coverage",
           "requirementId": "REQ-PORT-002",
           "promptSection": "MVP Importers / Clio Migration Template Import",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "High",
           "labels": ["parity", "migration", "imports"],
@@ -201,7 +201,8 @@
           "securityImpact": "No material security impact.",
           "definitionOfDone": [
             "Importer acceptance tests cover complete template spectrum with row-level error/warning context.",
-            "Communication source-entity lineage is preserved for CSV and XLSX sources.",
+            "Communication source lineage is preserved for CSV/XLSX with source file, source entity, and source row number metadata.",
+            "XLSX unresolved-reference diagnostics include workbook-sheet source context and row numbers.",
             "Verification artifact published at docs/parity/clio-import-verification.md."
           ]
         },


### PR DESCRIPTION
## Linear Issue
- KAR-15

## Requirement ID
- REQ-PORT-002

## Summary
- preserve per-row Clio source lineage metadata via `__source_row_number` for CSV and XLSX parsing paths
- add XLSX unresolved-reference diagnostic regression coverage with sheet-qualified source context
- expand Clio parity evidence and promote REQ-PORT-002 to Verified

## Acceptance Criteria
- [x] Clio CSV/XLSX entity mappings remain intact
- [x] unresolved reference diagnostics include deterministic row-level workbook/csv source context
- [x] importer lineage payload includes file/entity/row metadata for remediation and audit traceability

## Validation
- pnpm --filter api test -- imports.spec.ts
- pnpm --filter api test
- pnpm test
- pnpm build
