### PR TITLE
[KAR-16] Verify dedupe merge relationship cleanup

### DIFF
--- a/apps/api/src/contacts/contacts.service.ts
+++ b/apps/api/src/contacts/contacts.service.ts
@@ -441,6 +441,14 @@ export class ContactsService {
         data: { toContactId: primary.id },
       });
 
+      await tx.contactRelationship.deleteMany({
+        where: {
+          organizationId: input.organizationId,
+          fromContactId: primary.id,
+          toContactId: primary.id,
+        },
+      });
+
       await tx.externalReference.updateMany({
         where: {
           organizationId: input.organizationId,

--- a/apps/api/test/contacts-dedupe.spec.ts
+++ b/apps/api/test/contacts-dedupe.spec.ts
@@ -210,7 +210,10 @@ describe('ContactsService dedupe workflow', () => {
     const tx = {
       matterParticipant: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       contactMethod: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
-      contactRelationship: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
+      contactRelationship: {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
       externalReference: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       communicationThread: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
       communicationParticipant: { updateMany: jest.fn().mockResolvedValue({ count: 1 }) },
@@ -275,6 +278,13 @@ describe('ContactsService dedupe workflow', () => {
       data: { contactId: 'c1' },
     });
     expect(tx.contactRelationship.updateMany).toHaveBeenCalledTimes(2);
+    expect(tx.contactRelationship.deleteMany).toHaveBeenCalledWith({
+      where: {
+        organizationId: 'org1',
+        fromContactId: 'c1',
+        toContactId: 'c1',
+      },
+    });
     expect(tx.externalReference.updateMany).toHaveBeenCalledWith({
       where: { organizationId: 'org1', entityType: 'contact', entityId: 'c2' },
       data: { entityId: 'c1' },

--- a/docs/parity/dedupe-merge-verification.md
+++ b/docs/parity/dedupe-merge-verification.md
@@ -24,6 +24,7 @@ Scope: verify dedupe candidate review and merge-confirmation workflow integrity 
   - `InsuranceClaim.adjusterContactId`
   - `InsuranceClaim.insurerContactId`
   - `ExpertEngagement.expertContactId`
+- Merge workflow now prunes self-referential contact relationships created by ID consolidation (`fromContactId == toContactId` after reassignment).
 - Audit log emission remains enforced for merge and decision actions.
 
 ### Web hardening checks

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -210,7 +210,7 @@
           "title": "Build user-confirm merge workflow for dedupe suggestions",
           "requirementId": "REQ-PORT-003",
           "promptSection": "Import Framework / Dedupe engine + user-confirm merge UI",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "Web",
           "risk": "High",
           "labels": ["parity", "migration", "imports", "contacts"],
@@ -225,7 +225,7 @@
           "securityImpact": "Audit log and change traceability required.",
           "definitionOfDone": [
             "Dedupe confirmation flow includes explicit reviewer confirmation gate and cancel-safe behavior.",
-            "Merge service rejects self-referential merges/decisions and reassigns all high-risk contact references.",
+            "Merge service rejects self-referential merges/decisions, reassigns all high-risk contact references, and prunes self-referential relationship rows created during reassignment.",
             "Verification artifact published at docs/parity/dedupe-merge-verification.md."
           ]
         },


### PR DESCRIPTION
## Linear Issue
- KAR-16

## Requirement ID
- REQ-PORT-003

## Summary
- add merge-time cleanup for self-referential `ContactRelationship` rows created when duplicate IDs are remapped to the primary contact
- expand dedupe merge regression coverage to assert cleanup query execution
- update parity evidence/matrix and promote REQ-PORT-003 to Verified

## Acceptance Criteria
- [x] reviewer-confirmed merge flow remains unchanged
- [x] high-risk contact references continue to be reassigned safely
- [x] post-merge relationship graph no longer retains self-link artifacts

## Validation
- pnpm --filter api test -- contacts-dedupe.spec.ts
- pnpm --filter web test -- contacts-page.spec.tsx
- pnpm --filter api test
- pnpm test
- pnpm build
