### PR TITLE
[KAR-17] Verify full-backup export manifest integrity guardrails

### DIFF
--- a/apps/api/src/exports/full-backup-contract.ts
+++ b/apps/api/src/exports/full-backup-contract.ts
@@ -209,7 +209,10 @@ export type FullBackupValidationIssueCode =
   | 'missing_required_column'
   | 'manifest_missing_field'
   | 'manifest_invalid_path'
-  | 'manifest_missing_blob';
+  | 'manifest_missing_blob'
+  | 'manifest_duplicate_document_version'
+  | 'manifest_duplicate_path'
+  | 'manifest_placeholder_mismatch';
 
 export type FullBackupValidationIssue = {
   code: FullBackupValidationIssueCode;
@@ -233,6 +236,8 @@ export function validateFullBackupPackageConformance(input: {
 }): FullBackupValidationResult {
   const issues: FullBackupValidationIssue[] = [];
   const archivePaths = new Set(input.archivePaths);
+  const seenDocumentVersions = new Map<string, number>();
+  const seenPaths = new Map<string, number>();
 
   for (const contract of FULL_BACKUP_CSV_CONTRACT) {
     if (!archivePaths.has(contract.fileName) || !input.csvColumnsByFile[contract.fileName]) {
@@ -291,6 +296,31 @@ export function validateFullBackupPackageConformance(input: {
         });
       }
 
+      const priorPathIndex = seenPaths.get(path);
+      if (priorPathIndex !== undefined) {
+        issues.push({
+          code: 'manifest_duplicate_path',
+          file: FULL_BACKUP_MANIFEST_FILE,
+          field: 'path',
+          entryIndex,
+          message: `Manifest entry ${entryIndex} reuses path "${path}" from entry ${priorPathIndex}`,
+        });
+      } else {
+        seenPaths.set(path, entryIndex);
+      }
+
+      const placeholder = entry.placeholder === true;
+      const hasMissingSuffix = path.endsWith('.missing.txt');
+      if (placeholder !== hasMissingSuffix) {
+        issues.push({
+          code: 'manifest_placeholder_mismatch',
+          file: FULL_BACKUP_MANIFEST_FILE,
+          field: 'placeholder',
+          entryIndex,
+          message: `Manifest entry ${entryIndex} placeholder flag does not match path suffix for "${path}"`,
+        });
+      }
+
       if (!archivePaths.has(path)) {
         issues.push({
           code: 'manifest_missing_blob',
@@ -299,6 +329,21 @@ export function validateFullBackupPackageConformance(input: {
           entryIndex,
           message: `Manifest entry ${entryIndex} references missing file "${path}"`,
         });
+      }
+    }
+
+    if (typeof entry.documentVersionId === 'string' && entry.documentVersionId.trim().length > 0) {
+      const priorVersionIndex = seenDocumentVersions.get(entry.documentVersionId);
+      if (priorVersionIndex !== undefined) {
+        issues.push({
+          code: 'manifest_duplicate_document_version',
+          file: FULL_BACKUP_MANIFEST_FILE,
+          field: 'documentVersionId',
+          entryIndex,
+          message: `Manifest entry ${entryIndex} reuses documentVersionId "${entry.documentVersionId}" from entry ${priorVersionIndex}`,
+        });
+      } else {
+        seenDocumentVersions.set(entry.documentVersionId, entryIndex);
       }
     }
   });

--- a/apps/api/test/exports-conformance.spec.ts
+++ b/apps/api/test/exports-conformance.spec.ts
@@ -216,9 +216,26 @@ describe('ExportsService full backup conformance', () => {
           path: '../outside/path',
           matterId: '',
           title: '',
+          placeholder: false,
+        },
+        {
+          documentId: 'doc-2',
+          documentVersionId: 'dv-1',
+          path: 'documents/matter-1/evidence.missing.txt',
+          matterId: 'matter-1',
+          title: 'Duplicate Version',
+          placeholder: false,
+        },
+        {
+          documentId: 'doc-3',
+          documentVersionId: 'dv-3',
+          path: 'documents/matter-1/evidence.missing.txt',
+          matterId: 'matter-1',
+          title: 'Duplicate Path',
+          placeholder: true,
         },
       ],
-      archivePaths: ['contacts.csv', FULL_BACKUP_MANIFEST_FILE],
+      archivePaths: ['contacts.csv', FULL_BACKUP_MANIFEST_FILE, 'documents/matter-1/evidence.missing.txt'],
     });
 
     expect(result.valid).toBe(false);
@@ -229,6 +246,9 @@ describe('ExportsService full backup conformance', () => {
         expect.objectContaining({ code: 'manifest_missing_field' }),
         expect.objectContaining({ code: 'manifest_invalid_path' }),
         expect.objectContaining({ code: 'manifest_missing_blob' }),
+        expect.objectContaining({ code: 'manifest_duplicate_document_version' }),
+        expect.objectContaining({ code: 'manifest_duplicate_path' }),
+        expect.objectContaining({ code: 'manifest_placeholder_mismatch' }),
       ]),
     );
   });

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T19:35:44.599Z`
+- Snapshot Timestamp: `2026-02-18T20:11:19.493Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T19:35:36.987Z`
+- Last Successful Mirror Verify: `2026-02-18T20:11:15.094Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-PORT-004` by hardening full-backup manifest conformance checks with duplicate `documentVersionId`/path detection plus placeholder-flag/path-suffix consistency validation, and extending export conformance regression coverage (`docs/parity/export-conformance.md`).
 - 2026-02-18: Verified `REQ-AI-003` by hardening style-pack source detach authorization (matter-access enforced), enriching detached-source audit provenance (`documentVersionId`, `documentId`, `matterId`), and retaining artifact/execution style-pack provenance checks (`docs/parity/style-pack-verification.md`).
 - 2026-02-18: Verified `REQ-PORTAL-001` by hardening portal attachment auditability with explicit `portal.attachment.linked` and `portal.attachment.download_url_issued` events, while retaining portal upload/link/download security regression coverage (`docs/parity/portal-attachments-verification.md`).
 - 2026-02-18: Verified `REQ-PORT-003` by hardening dedupe merge safeguards (self-merge rejection), expanding contact-reference reassignment coverage before duplicate deletion, and adding web confirmation-cancel behavior validation for merge actions (`docs/parity/dedupe-merge-verification.md`).

--- a/docs/parity/export-conformance.md
+++ b/docs/parity/export-conformance.md
@@ -24,6 +24,10 @@ This artifact records full-backup export conformance checks for portability pari
   - `matterId`
   - `title`
 - Manifest paths must remain under `documents/` and resolve to an actual ZIP entry.
+- Manifest entries enforce uniqueness and placeholder consistency:
+  - each `documentVersionId` appears once in `manifest.json`
+  - each manifest `path` is unique
+  - `.missing.txt` suffix and `placeholder` flag must agree
 
 ## Runtime Behavior
 
@@ -40,6 +44,6 @@ This artifact records full-backup export conformance checks for portability pari
   - validates required file/column presence in produced ZIP
   - validates manifest-to-ZIP path linkage
   - validates placeholder-path behavior when document blob retrieval fails
-  - validates conformance error reporting for malformed packages
+  - validates conformance error reporting for malformed packages, including duplicate manifest IDs/paths and placeholder mismatch
 - `apps/api/test/roundtrip.spec.ts`
   - validates generic contacts import can be exported into canonical full backup contacts CSV (roundtrip coherence)

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -233,11 +233,11 @@
           "title": "Implement full backup export package conformance checks",
           "requirementId": "REQ-PORT-004",
           "promptSection": "Export / Exit Strategy",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "migration", "exports"],
-          "problemStatement": "Export exists but needs strict dictionary conformance and integrity validation.",
+          "problemStatement": "Full-backup export is now verification-hardened with deterministic manifest integrity checks (duplicate path/documentVersion detection and placeholder/path consistency) in addition to required file/column/schema validation.",
           "requirementExcerpt": "ZIP with CSVs per entity and docs manifest; data dictionary page.",
           "acceptanceCriteria": [
             "Export output validated against documented manifest schema.",
@@ -247,7 +247,9 @@
           "apiImpact": "Export endpoint emits validated package metadata.",
           "securityImpact": "Signed export access and audit logging maintained.",
           "definitionOfDone": [
-            "Round-trip export/import verification published."
+            "Round-trip export/import verification published.",
+            "Conformance validator rejects duplicate manifest documentVersion/path rows and placeholder/path mismatches with explicit issue codes.",
+            "Verification artifact documented at docs/parity/export-conformance.md."
           ]
         }
       ]

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T19:35:44.599Z",
+  "generatedAt": "2026-02-18T20:11:19.493Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,39 +14,28 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 13,
+    "unresolvedRequirements": 11,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-1": 8,
+      "phase-1": 6,
       "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 13
+      "Complete": 11
     },
     "unresolvedCountsByRisk": {
-      "Medium": 12,
-      "High": 1
+      "Medium": 11
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 12,
-      "Complete:High": 1
+      "Complete:Medium": 11
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-PORTAL-001",
-        "parityStatus": "Complete",
-        "risk": "High",
-        "title": "Implement secure portal attachments in message workflow",
-        "component": "Web",
-        "epicCode": "PARITY-07",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-AI-003",
         "parityStatus": "Complete",
@@ -93,15 +82,6 @@
         "phase": "phase-1"
       },
       {
-        "requirementId": "REQ-PORT-004",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Implement full backup export package conformance checks",
-        "component": "API",
-        "epicCode": "PARITY-03",
-        "phase": "phase-1"
-      },
-      {
         "requirementId": "REQ-PORTAL-002",
         "parityStatus": "Complete",
         "risk": "Medium",
@@ -127,6 +107,24 @@
         "component": "API",
         "epicCode": "PARITY-06",
         "phase": "phase-2"
+      },
+      {
+        "requirementId": "REQ-COMM-004",
+        "parityStatus": "Complete",
+        "risk": "Medium",
+        "title": "Implement document retention policies with legal hold workflow",
+        "component": "API",
+        "epicCode": "PARITY-05",
+        "phase": "phase-2"
+      },
+      {
+        "requirementId": "REQ-MAT-004",
+        "parityStatus": "Complete",
+        "risk": "Medium",
+        "title": "Implement advanced conflict rule profiles and resolution workflows",
+        "component": "API",
+        "epicCode": "PARITY-04",
+        "phase": "phase-2"
       }
     ]
   },
@@ -141,6 +139,20 @@
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-30",
+        "title": "Implement secure portal attachments in message workflow",
+        "state": "Done",
+        "updatedAt": "2026-02-18T20:03:28.782Z",
+        "requirementId": "REQ-PORTAL-001"
+      },
+      {
+        "key": "KAR-35",
+        "title": "Implement style pack management with source document governance",
+        "state": "Done",
+        "updatedAt": "2026-02-18T19:48:45.056Z",
+        "requirementId": "REQ-AI-003"
+      },
       {
         "key": "KAR-16",
         "title": "Build user-confirm merge workflow for dedupe suggestions",
@@ -177,20 +189,6 @@
         "requirementId": "REQ-COMM-001"
       },
       {
-        "key": "KAR-35",
-        "title": "Implement style pack management with source document governance",
-        "state": "Done",
-        "updatedAt": "2026-02-18T18:32:29.595Z",
-        "requirementId": "REQ-AI-003"
-      },
-      {
-        "key": "KAR-30",
-        "title": "Implement secure portal attachments in message workflow",
-        "state": "Done",
-        "updatedAt": "2026-02-18T18:16:19.891Z",
-        "requirementId": "REQ-PORTAL-001"
-      },
-      {
         "key": "KAR-14",
         "title": "Finalize MyCase ZIP importer field coverage and error mapping",
         "state": "Done",
@@ -214,17 +212,21 @@
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T19:35:36.987Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T20:11:15.094Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "bd4a0ed5b8672e620bace716f60d002f82c88133",
+    "gitHead": "0f20599191881a130d0e6e2df4a60830028fa559",
     "gitStatusShort": [
-      "## main...origin/main",
+      "## lin/KAR-17-export-conformance-verification-hardening",
+      " M apps/api/src/exports/full-backup-contract.ts",
+      " M apps/api/test/exports-conformance.spec.ts",
+      " M docs/parity/export-conformance.md",
+      " M tools/backlog-sync/requirements.matrix.json",
       "?? agents.md",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 3
+    "dirtyFileCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- harden full-backup manifest validation with duplicate documentVersion/path detection
- enforce placeholder flag/path suffix consistency checks
- add conformance regression assertions and mark REQ-PORT-004 as Verified with updated parity evidence docs/snapshot

## Linear Issue
- KAR-17

## Requirement ID
- REQ-PORT-004

## Verification Evidence
- `pnpm --filter api test -- exports-conformance.spec.ts`
- `pnpm --filter api test -- roundtrip.spec.ts`
- `pnpm --filter api test`
- `pnpm test`
- `pnpm build`
- `pnpm backlog:sync`
- `pnpm backlog:verify`
- `pnpm backlog:snapshot`
- `pnpm backlog:handoff:check`

## Risk
- Low: validation-only hardening; no endpoint shape change
