### PR TITLE
[KAR-20] Verify contacts graph and filter query parsing

### DIFF
--- a/apps/api/src/contacts/contacts.controller.ts
+++ b/apps/api/src/contacts/contacts.controller.ts
@@ -18,8 +18,8 @@ export class ContactsController {
   list(
     @CurrentUser() user: AuthenticatedUser,
     @Query('search') search?: string,
-    @Query('includeTags') includeTags?: string,
-    @Query('excludeTags') excludeTags?: string,
+    @Query('includeTags') includeTags?: string | string[],
+    @Query('excludeTags') excludeTags?: string | string[],
     @Query('tagMode') tagMode?: 'any' | 'all',
   ) {
     return this.contactsService.list(user.organizationId, {
@@ -46,7 +46,7 @@ export class ContactsController {
     @CurrentUser() user: AuthenticatedUser,
     @Param('id') id: string,
     @Query('search') search?: string,
-    @Query('relationshipTypes') relationshipTypes?: string,
+    @Query('relationshipTypes') relationshipTypes?: string | string[],
   ) {
     return this.contactsService.graph(user.organizationId, id, {
       search,
@@ -96,9 +96,10 @@ export class ContactsController {
     });
   }
 
-  private parseCsv(value?: string) {
-    return String(value || '')
-      .split(',')
+  private parseCsv(value?: string | string[]) {
+    const values = Array.isArray(value) ? value : value ? [value] : [];
+    return values
+      .flatMap((entry) => String(entry).split(','))
       .map((item) => item.trim())
       .filter(Boolean);
   }

--- a/apps/api/test/contacts-controller.spec.ts
+++ b/apps/api/test/contacts-controller.spec.ts
@@ -1,0 +1,57 @@
+import { ContactsController } from '../src/contacts/contacts.controller';
+
+describe('ContactsController query parsing', () => {
+  const user = { id: 'user-1', organizationId: 'org-1' } as any;
+
+  it('parses include/exclude tags from repeated query params and csv values', async () => {
+    const contactsService = {
+      list: jest.fn().mockResolvedValue([]),
+    } as any;
+    const controller = new ContactsController(contactsService);
+
+    await controller.list(
+      user,
+      'jane',
+      ['client,vip', ' priority '],
+      ['blocked', ' archived,closed '],
+      'all',
+    );
+
+    expect(contactsService.list).toHaveBeenCalledWith('org-1', {
+      search: 'jane',
+      includeTags: ['client', 'vip', 'priority'],
+      excludeTags: ['blocked', 'archived', 'closed'],
+      tagMode: 'all',
+    });
+  });
+
+  it('defaults tagMode to any when query value is invalid', async () => {
+    const contactsService = {
+      list: jest.fn().mockResolvedValue([]),
+    } as any;
+    const controller = new ContactsController(contactsService);
+
+    await controller.list(user, undefined, 'client', undefined, 'invalid' as any);
+
+    expect(contactsService.list).toHaveBeenCalledWith('org-1', {
+      search: undefined,
+      includeTags: ['client'],
+      excludeTags: [],
+      tagMode: 'any',
+    });
+  });
+
+  it('parses graph relationshipTypes from repeated query params and csv values', async () => {
+    const contactsService = {
+      graph: jest.fn().mockResolvedValue({}),
+    } as any;
+    const controller = new ContactsController(contactsService);
+
+    await controller.graph(user, 'contact-1', 'defense', ['opposing_counsel,insurer', ' expert ']);
+
+    expect(contactsService.graph).toHaveBeenCalledWith('org-1', 'contact-1', {
+      search: 'defense',
+      relationshipTypes: ['opposing_counsel', 'insurer', 'expert'],
+    });
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T20:33:46.800Z`
+- Snapshot Timestamp: `2026-02-18T20:43:42.540Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T20:33:44.797Z`
+- Last Successful Mirror Verify: `2026-02-18T20:43:41.127Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-MAT-002` by hardening contacts filter/graph query parsing to support both CSV and repeated query params (`includeTags`, `excludeTags`, `relationshipTypes`), adding controller-level regression coverage for parsing and tag-mode fallback, and updating parity evidence (`docs/parity/contacts-graph-filtering.md`).
 - 2026-02-18: Verified `REQ-INT-003` by hardening Filevine/PracticePanther connectors with live webhook registration URL support (env/config override), strict provider error surfacing, external subscription ID extraction, and expanded connector regression coverage (`docs/parity/filevine-practicepanther-connector-verification.md`).
 - 2026-02-18: Finalized `REQ-AI-003` parity status to `Verified` in the requirements matrix and snapshot after reconfirming API/Web style-pack verification suites and provenance artifact coverage (`docs/parity/style-pack-verification.md`).
 - 2026-02-18: Verified `REQ-PORT-004` by hardening full-backup manifest conformance checks with duplicate `documentVersionId`/path detection plus placeholder-flag/path-suffix consistency validation, and extending export conformance regression coverage (`docs/parity/export-conformance.md`).

--- a/docs/parity/contacts-graph-filtering.md
+++ b/docs/parity/contacts-graph-filtering.md
@@ -31,6 +31,9 @@ Scope: contact relationship graph filtering + compound contact filters + inline 
 ## Test Evidence
 
 - API:
+  - `apps/api/test/contacts-controller.spec.ts` validates:
+    - repeated-query and CSV parsing for `includeTags`, `excludeTags`, and `relationshipTypes`.
+    - invalid `tagMode` coercion to `any`.
   - `apps/api/test/contacts-dedupe.spec.ts` validates:
     - list query shape for compound tag filters.
     - graph response shape and filter propagation.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -287,11 +287,11 @@
           "title": "Enhance contact relationship graph visualization and filtering",
           "requirementId": "REQ-MAT-002",
           "promptSection": "Contacts / relationship graph + tags + filters",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "Web",
           "risk": "Medium",
           "labels": ["parity", "contacts"],
-          "problemStatement": "Contacts graph and filter workflows now support compound tag filters, graph relationship-type/search filters, and inline dedupe indicators in the main table.",
+          "problemStatement": "Contacts graph/filter workflows are verification-hardened with explicit controller parsing support for both CSV and repeated query parameters (include/exclude tags + relationship types), while preserving compound filters and inline dedupe indicators.",
           "requirementExcerpt": "People/org contacts with relationship graph and tags/filters.",
           "acceptanceCriteria": [
             "Graph view supports relationship-type filters and search.",
@@ -301,6 +301,7 @@
           "apiImpact": "Contacts list/graph endpoints now support compound filter params (include/exclude tags, tag mode, relationship type, search).",
           "securityImpact": "Tenant and permission checks enforced for graph API.",
           "definitionOfDone": [
+            "Contacts controller regression suite verifies CSV + repeated-query parsing for include/exclude tags and relationship types, plus invalid tag-mode fallback behavior.",
             "Contacts graph and filtering UI/API path is covered by API + web regression tests and documented in docs/parity/contacts-graph-filtering.md."
           ]
         },

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T20:33:46.800Z",
+  "generatedAt": "2026-02-18T20:43:42.540Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,37 +14,28 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 9,
+    "unresolvedRequirements": 8,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-1": 4,
-      "phase-2": 5
+      "phase-2": 5,
+      "phase-1": 3
     },
     "unresolvedCountsByStatus": {
-      "Complete": 9
+      "Complete": 8
     },
     "unresolvedCountsByRisk": {
-      "Medium": 9
+      "Medium": 8
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 9
+      "Complete:Medium": 8
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-MAT-002",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Enhance contact relationship graph visualization and filtering",
-        "component": "Web",
-        "epicCode": "PARITY-04",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-OPS-002",
         "parityStatus": "Complete",
@@ -134,7 +125,7 @@
         "key": "KAR-39",
         "title": "Implement Filevine and PracticePanther connector production adapters",
         "state": "Done",
-        "updatedAt": "2026-02-18T20:33:04.451Z",
+        "updatedAt": "2026-02-18T20:37:48.463Z",
         "requirementId": "REQ-INT-003"
       },
       {
@@ -203,17 +194,21 @@
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T20:33:44.797Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T20:43:41.127Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "36d10670c4198c15e8ed7a15abc078c99e62985a",
+    "gitHead": "3d192a7d37973e0afc21e88bbb02839cdaac1afd",
     "gitStatusShort": [
-      "## main...origin/main",
+      "## lin/KAR-20-contacts-graph-verification-hardening",
+      " M apps/api/src/contacts/contacts.controller.ts",
+      " M docs/parity/contacts-graph-filtering.md",
+      " M tools/backlog-sync/requirements.matrix.json",
       "?? agents.md",
+      "?? apps/api/test/contacts-controller.spec.ts",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 3
+    "dirtyFileCount": 7
   }
 }


### PR DESCRIPTION
## Summary
- harden contacts query parsing for list/graph endpoints to support both CSV and repeated query params
- add controller regression tests for include/exclude tags, relationship types, and invalid tagMode fallback
- mark REQ-MAT-002 as Verified and refresh parity snapshot/handoff metadata

## Linear Issue
- KAR-20

## Requirement ID
- REQ-MAT-002

## Verification Evidence
- `pnpm --filter api test -- contacts-controller.spec.ts contacts-dedupe.spec.ts`
- `pnpm --filter api test`
- `pnpm test`
- `pnpm build`
- `pnpm backlog:sync`
- `pnpm backlog:verify`
- `pnpm backlog:snapshot`
- `pnpm backlog:handoff:check`

## Notes
- Backward compatible: existing CSV query behavior remains; repeated query params now parse deterministically.
