### PR TITLE
[KAR-42] Verify deployment runbook and SLO coverage

### DIFF
--- a/apps/api/test/ops-runbook.spec.ts
+++ b/apps/api/test/ops-runbook.spec.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('Operations runbook verification', () => {
+  const runbookPath = join(__dirname, '../../../docs/DEPLOYMENT_RUNBOOK.md');
+  const parityArtifactPath = join(__dirname, '../../../docs/parity/ops-runbook-slos.md');
+  const readmePath = join(__dirname, '../../../README.md');
+
+  it('documents required deployment and incident response sections', () => {
+    const runbook = readFileSync(runbookPath, 'utf8');
+
+    const requiredSections = [
+      '## 2) Pre-Deployment Checklist',
+      '## 3) Deployment Procedure',
+      '## 4) Startup Readiness Checks',
+      '## 5) Rollback Procedure',
+      '## 6) Incident Response',
+      '## 7) Baseline SLOs and Metrics',
+    ];
+
+    for (const section of requiredSections) {
+      expect(runbook).toContain(section);
+    }
+  });
+
+  it('captures baseline SLO targets in the runbook', () => {
+    const runbook = readFileSync(runbookPath, 'utf8');
+
+    const requiredSlos = [
+      'API availability: `99.9%` monthly',
+      'Web availability: `99.9%` monthly',
+      'P95 API latency (core CRUD): `< 500ms`',
+      'P99 API latency (core CRUD): `< 1200ms`',
+      'Queue job success rate (AI/import/export jobs): `>= 99%`',
+      'Critical webhook delivery success (with retries): `>= 99%`',
+      'RPO: `< 15 minutes`',
+      'RTO: `< 60 minutes`',
+    ];
+
+    for (const target of requiredSlos) {
+      expect(runbook).toContain(target);
+    }
+  });
+
+  it('keeps runbook and parity artifact linked from README', () => {
+    const parityArtifact = readFileSync(parityArtifactPath, 'utf8');
+    const readme = readFileSync(readmePath, 'utf8');
+
+    expect(parityArtifact).toContain('`docs/DEPLOYMENT_RUNBOOK.md`');
+    expect(readme).toContain('`docs/DEPLOYMENT_RUNBOOK.md`');
+    expect(readme).toContain('`docs/parity/ops-runbook-slos.md`');
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T20:43:42.540Z`
+- Snapshot Timestamp: `2026-02-18T20:51:25.492Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T20:43:41.127Z`
+- Last Successful Mirror Verify: `2026-02-18T20:51:23.862Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-OPS-002` by adding executable runbook conformance coverage for required deployment/readiness/rollback/incident sections, baseline SLO targets, and README/parity linkage integrity (`apps/api/test/ops-runbook.spec.ts`, `docs/parity/ops-runbook-slos.md`).
 - 2026-02-18: Verified `REQ-MAT-002` by hardening contacts filter/graph query parsing to support both CSV and repeated query params (`includeTags`, `excludeTags`, `relationshipTypes`), adding controller-level regression coverage for parsing and tag-mode fallback, and updating parity evidence (`docs/parity/contacts-graph-filtering.md`).
 - 2026-02-18: Verified `REQ-INT-003` by hardening Filevine/PracticePanther connectors with live webhook registration URL support (env/config override), strict provider error surfacing, external subscription ID extraction, and expanded connector regression coverage (`docs/parity/filevine-practicepanther-connector-verification.md`).
 - 2026-02-18: Finalized `REQ-AI-003` parity status to `Verified` in the requirements matrix and snapshot after reconfirming API/Web style-pack verification suites and provenance artifact coverage (`docs/parity/style-pack-verification.md`).

--- a/docs/parity/ops-runbook-slos.md
+++ b/docs/parity/ops-runbook-slos.md
@@ -29,3 +29,10 @@ Scope: deployment runbook, rollback + incident procedures, startup readiness gui
 ## README Linkage
 
 - `README.md` includes an "Operations Runbook" section linking to `docs/DEPLOYMENT_RUNBOOK.md`.
+
+## Test Evidence
+
+- `apps/api/test/ops-runbook.spec.ts` verifies:
+  - required deploy/readiness/rollback/incident/SLO section presence in `docs/DEPLOYMENT_RUNBOOK.md`
+  - required baseline SLO target lines
+  - README linkage to runbook + parity artifact

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -801,11 +801,11 @@
           "title": "Document deployment runbook and operational SLOs",
           "requirementId": "REQ-OPS-002",
           "promptSection": "Production-ready expectation",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "Infra",
           "risk": "Medium",
           "labels": ["parity", "ops"],
-          "problemStatement": "Deployment, rollback, readiness, incident response, and SLO baselines are now documented in a production runbook and linked from README.",
+          "problemStatement": "Operations documentation is now verification-hardened with executable checks that enforce required runbook sections, baseline SLO targets, and README/parity linkage integrity.",
           "requirementExcerpt": "Production-ready system requires clear operational playbooks.",
           "acceptanceCriteria": [
             "Create runbook for deploy, rollback, migrations, and incident response.",
@@ -815,7 +815,8 @@
           "apiImpact": "No endpoint changes.",
           "securityImpact": "Improves incident response posture.",
           "definitionOfDone": [
-            "Runbook committed at docs/DEPLOYMENT_RUNBOOK.md, linked from README, and evidenced in docs/parity/ops-runbook-slos.md."
+            "Runbook committed at docs/DEPLOYMENT_RUNBOOK.md, linked from README, and evidenced in docs/parity/ops-runbook-slos.md.",
+            "Automated regression test validates required runbook sections, baseline SLO targets, and README/parity linkage."
           ]
         },
         {

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T20:43:42.540Z",
+  "generatedAt": "2026-02-18T20:51:25.492Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,37 +14,28 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 8,
+    "unresolvedRequirements": 7,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
       "phase-2": 5,
-      "phase-1": 3
+      "phase-1": 2
     },
     "unresolvedCountsByStatus": {
-      "Complete": 8
+      "Complete": 7
     },
     "unresolvedCountsByRisk": {
-      "Medium": 8
+      "Medium": 7
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 8
+      "Complete:Medium": 7
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-OPS-002",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Document deployment runbook and operational SLOs",
-        "component": "Infra",
-        "epicCode": "PARITY-10",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-OPS-003",
         "parityStatus": "Complete",
@@ -122,6 +113,13 @@
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
       {
+        "key": "KAR-20",
+        "title": "Enhance contact relationship graph visualization and filtering",
+        "state": "Done",
+        "updatedAt": "2026-02-18T20:47:12.236Z",
+        "requirementId": "REQ-MAT-002"
+      },
+      {
         "key": "KAR-39",
         "title": "Implement Filevine and PracticePanther connector production adapters",
         "state": "Done",
@@ -183,32 +181,24 @@
         "state": "Done",
         "updatedAt": "2026-02-18T18:58:44.368Z",
         "requirementId": "REQ-COMM-001"
-      },
-      {
-        "key": "KAR-14",
-        "title": "Finalize MyCase ZIP importer field coverage and error mapping",
-        "state": "Done",
-        "updatedAt": "2026-02-18T16:15:08.852Z",
-        "requirementId": "REQ-PORT-001"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T20:43:41.127Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T20:51:23.862Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "3d192a7d37973e0afc21e88bbb02839cdaac1afd",
+    "gitHead": "763ba1b41f327ce8c14518f876b6ebbb23a4767e",
     "gitStatusShort": [
-      "## lin/KAR-20-contacts-graph-verification-hardening",
-      " M apps/api/src/contacts/contacts.controller.ts",
-      " M docs/parity/contacts-graph-filtering.md",
+      "## lin/KAR-42-ops-runbook-verification-hardening",
+      " M docs/parity/ops-runbook-slos.md",
       " M tools/backlog-sync/requirements.matrix.json",
       "?? agents.md",
-      "?? apps/api/test/contacts-controller.spec.ts",
+      "?? apps/api/test/ops-runbook.spec.ts",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 7
+    "dirtyFileCount": 6
   }
 }


### PR DESCRIPTION
## Summary
- add executable ops runbook verification coverage (`apps/api/test/ops-runbook.spec.ts`)
- enforce required runbook sections, baseline SLO target lines, and README/parity linkage integrity
- mark REQ-OPS-002 as Verified with updated parity artifact and snapshot/handoff metadata

## Linear Issue
- KAR-42

## Requirement ID
- REQ-OPS-002

## Verification Evidence
- `pnpm --filter api test -- ops-runbook.spec.ts`
- `pnpm --filter api test`
- `pnpm test`
- `pnpm build`
- `pnpm backlog:sync`
- `pnpm backlog:verify`
- `pnpm backlog:snapshot`
- `pnpm backlog:handoff:check`

## Notes
- No runtime API behavior change; this is verification hardening for operational readiness documentation.
