### PR TITLE
[KAR-31] Verify portal e-sign provider lifecycle safeguards

### DIFF
--- a/apps/api/test/portal-esign-verification.spec.ts
+++ b/apps/api/test/portal-esign-verification.spec.ts
@@ -1,0 +1,243 @@
+import { createHmac } from 'node:crypto';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { PortalService } from '../src/portal/portal.service';
+
+function buildClientUser() {
+  return {
+    id: 'user-client-1',
+    organizationId: 'org-1',
+    membership: {
+      contactId: 'contact-1',
+      role: {
+        name: 'Client',
+      },
+    },
+  } as any;
+}
+
+describe('PortalService e-sign verification hardening', () => {
+  afterEach(() => {
+    delete process.env.ESIGN_PROVIDER;
+    delete process.env.ESIGN_STUB_WEBHOOK_SECRET;
+    delete process.env.ESIGN_SANDBOX_WEBHOOK_SECRET;
+  });
+
+  it('scopes envelope listing to client-visible matters and rejects out-of-scope filters', async () => {
+    const prisma = {
+      matterParticipant: {
+        findMany: jest.fn().mockResolvedValue([{ matterId: 'matter-1' }]),
+      },
+      eSignEnvelope: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'env-1',
+            matterId: 'matter-1',
+            status: 'SENT',
+            provider: 'sandbox',
+          },
+        ]),
+      },
+    } as any;
+
+    const service = new PortalService(
+      prisma,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    const listed = await service.listPortalEsignEnvelopes({
+      user: buildClientUser(),
+    });
+    expect(listed).toHaveLength(1);
+    expect(prisma.eSignEnvelope.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          matterId: { in: ['matter-1'] },
+        }),
+      }),
+    );
+
+    await expect(
+      service.listPortalEsignEnvelopes({
+        user: buildClientUser(),
+        matterId: 'matter-2',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(prisma.eSignEnvelope.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats duplicate webhook event ids as idempotent updates', async () => {
+    process.env.ESIGN_SANDBOX_WEBHOOK_SECRET = 'sandbox-secret';
+
+    const payload = {
+      externalId: 'sandbox-ext-dup',
+      status: 'SIGNED',
+      eventId: 'evt-dup',
+    };
+    const signature = createHmac('sha256', process.env.ESIGN_SANDBOX_WEBHOOK_SECRET)
+      .update(JSON.stringify(payload))
+      .digest('hex');
+
+    const prisma = {
+      eSignEnvelope: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'env-dup',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          status: 'SIGNED',
+          provider: 'sandbox',
+          externalId: 'sandbox-ext-dup',
+          payloadJson: {
+            statusHistory: [{ from: 'SENT', to: 'SIGNED', source: 'provider_webhook' }],
+            webhookEvents: ['evt-dup'],
+          },
+        }),
+        update: jest.fn(),
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new PortalService(
+      prisma,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      audit,
+    );
+
+    const result = await service.handleEsignWebhook({
+      providerKey: 'sandbox',
+      headers: {
+        'x-esign-signature': signature,
+      },
+      payload,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      envelopeId: 'env-dup',
+      status: 'SIGNED',
+    });
+    expect(prisma.eSignEnvelope.update).not.toHaveBeenCalled();
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'portal.esign.webhook.processed',
+        entityType: 'e_sign_envelope',
+        entityId: 'env-dup',
+      }),
+    );
+  });
+
+  it('captures status history and provider poll metadata during refresh', async () => {
+    const prisma = {
+      matterParticipant: {
+        findMany: jest.fn().mockResolvedValue([{ matterId: 'matter-1' }]),
+      },
+      eSignEnvelope: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'env-refresh-1',
+            organizationId: 'org-1',
+            matterId: 'matter-1',
+            status: 'SENT',
+            provider: 'sandbox',
+            externalId: 'sandbox-refresh-1',
+            payloadJson: {
+              sandboxStatus: 'SIGNED',
+              statusHistory: [{ from: 'DRAFT', to: 'SENT', source: 'provider_create' }],
+              webhookEvents: [],
+            },
+          })
+          .mockResolvedValueOnce({
+            id: 'env-refresh-1',
+            organizationId: 'org-1',
+            matterId: 'matter-1',
+            status: 'SENT',
+            provider: 'sandbox',
+            externalId: 'sandbox-refresh-1',
+            payloadJson: {
+              sandboxStatus: 'SIGNED',
+              statusHistory: [{ from: 'DRAFT', to: 'SENT', source: 'provider_create' }],
+              webhookEvents: [],
+            },
+          }),
+        update: jest.fn().mockResolvedValue({
+          id: 'env-refresh-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          status: 'SIGNED',
+          provider: 'sandbox',
+          externalId: 'sandbox-refresh-1',
+          payloadJson: {},
+        }),
+      },
+    } as any;
+
+    const service = new PortalService(
+      prisma,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    const refreshed = await service.refreshPortalEsignEnvelope({
+      user: buildClientUser(),
+      envelopeId: 'env-refresh-1',
+    });
+    expect(refreshed.status).toBe('SIGNED');
+
+    const updateArgs = prisma.eSignEnvelope.update.mock.calls[0]?.[0];
+    const payloadJson = updateArgs?.data?.payloadJson as Record<string, unknown>;
+    const statusHistory = Array.isArray(payloadJson?.statusHistory) ? payloadJson.statusHistory : [];
+
+    expect(statusHistory).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'SENT',
+          to: 'SIGNED',
+          source: 'provider_poll',
+        }),
+      ]),
+    );
+    expect(payloadJson.providerPoll).toEqual(
+      expect.objectContaining({
+        mode: 'sandbox',
+        at: expect.any(String),
+      }),
+    );
+  });
+
+  it('rejects sandbox webhooks with invalid signatures', async () => {
+    process.env.ESIGN_SANDBOX_WEBHOOK_SECRET = 'sandbox-secret';
+
+    const prisma = {
+      eSignEnvelope: {
+        findFirst: jest.fn(),
+      },
+    } as any;
+    const service = new PortalService(
+      prisma,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    await expect(
+      service.handleEsignWebhook({
+        providerKey: 'sandbox',
+        headers: {
+          'x-esign-signature': 'bad-signature',
+        },
+        payload: {
+          externalId: 'sandbox-ext-bad',
+          status: 'SIGNED',
+          eventId: 'evt-bad',
+        },
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.eSignEnvelope.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/portal-page.spec.tsx
+++ b/apps/web/test/portal-page.spec.tsx
@@ -147,6 +147,64 @@ describe('PortalPage', () => {
     });
   });
 
+  it('refreshes an e-sign envelope status from the portal list', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          matters: [{ id: 'matter-9' }],
+          keyDates: [],
+          invoices: [],
+          messages: [],
+          documents: [],
+          eSignEnvelopes: [
+            {
+              id: 'env-9',
+              status: 'SENT',
+              provider: 'sandbox',
+              engagementLetterTemplate: { id: 'tpl-9', name: 'Engagement Letter v9' },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 'env-9', status: 'SIGNED', provider: 'sandbox' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          matters: [{ id: 'matter-9' }],
+          keyDates: [],
+          invoices: [],
+          messages: [],
+          documents: [],
+          eSignEnvelopes: [
+            {
+              id: 'env-9',
+              status: 'SIGNED',
+              provider: 'sandbox',
+              engagementLetterTemplate: { id: 'tpl-9', name: 'Engagement Letter v9' },
+            },
+          ],
+        }),
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+    render(<PortalPage />);
+
+    await screen.findByText('Status: SENT | Provider: sandbox');
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh Status' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/portal/esign/env-9/refresh',
+        expect.objectContaining({
+          method: 'POST',
+          credentials: 'include',
+        }),
+      );
+    });
+
+    await screen.findByText('Status: SIGNED | Provider: sandbox');
+  });
+
   it('uploads a portal attachment, links it to message, and downloads securely', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const fetchMock = vi

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T20:59:15.135Z`
+- Snapshot Timestamp: `2026-02-18T21:09:54.767Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T20:59:13.599Z`
+- Last Successful Mirror Verify: `2026-02-18T21:09:53.396Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-PORTAL-002` by adding explicit e-sign verification hardening coverage for client matter-scoped envelope listing, duplicate-webhook idempotency, refresh lifecycle history persistence, invalid-signature rejection, and portal envelope status refresh UX assertions (`apps/api/test/portal-esign-verification.spec.ts`, `apps/web/test/portal-page.spec.tsx`, `docs/parity/esign-provider-abstraction.md`).
 - 2026-02-18: Verified `REQ-OPS-003` by adding executable governance checks for `.github/workflows/pr-linear-policy.yml` and `.github/pull_request_template.md`, including regex enforcement and required metadata section assertions (`apps/api/test/pr-linear-policy.spec.ts`, `docs/parity/pr-linear-policy-verification.md`).
 - 2026-02-18: Verified `REQ-OPS-002` by adding executable runbook conformance coverage for required deployment/readiness/rollback/incident sections, baseline SLO targets, and README/parity linkage integrity (`apps/api/test/ops-runbook.spec.ts`, `docs/parity/ops-runbook-slos.md`).
 - 2026-02-18: Verified `REQ-MAT-002` by hardening contacts filter/graph query parsing to support both CSV and repeated query params (`includeTags`, `excludeTags`, `relationshipTypes`), adding controller-level regression coverage for parsing and tag-mode fallback, and updating parity evidence (`docs/parity/contacts-graph-filtering.md`).

--- a/docs/parity/esign-provider-abstraction.md
+++ b/docs/parity/esign-provider-abstraction.md
@@ -47,10 +47,21 @@ Scope: replace portal e-sign stub-only flow with provider abstraction, lifecycle
 
 - API:
   - `apps/api/test/portal.spec.ts`
+  - `apps/api/test/portal-esign-verification.spec.ts`
   - coverage includes:
     - envelope creation with provider abstraction + stub fallback
     - sandbox status polling transitions
     - signed sandbox webhook processing
+    - envelope list scope enforcement for client-visible matters
+    - webhook idempotency for duplicate provider event IDs
+    - refresh lifecycle persistence (`statusHistory` + `providerPoll` metadata)
+    - invalid signature rejection before envelope lookup
 - Web:
   - `apps/web/test/portal-page.spec.tsx`
   - verifies portal action flow for intake + e-sign envelope creation payload including provider.
+  - verifies envelope status refresh calls provider refresh endpoint and updates surfaced status.
+
+## Verification Command
+
+- `pnpm --filter api test -- portal.spec.ts portal-esign-verification.spec.ts`
+- `pnpm --filter web test -- portal-page.spec.tsx`

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -598,11 +598,11 @@
           "title": "Replace e-sign stub with provider abstraction implementation",
           "requirementId": "REQ-PORTAL-002",
           "promptSection": "Client Portal / e-sign stub flow",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "portal"],
-          "problemStatement": "Portal e-sign flow now uses provider abstraction with signed webhook processing, provider polling, lifecycle transition history, and fallback stub support.",
+          "problemStatement": "Portal e-sign flow is verification-hardened with provider abstraction lifecycle coverage, idempotent webhook handling, invalid-signature rejection, and portal-side status refresh assertions.",
           "requirementExcerpt": "E-sign interface required; stub acceptable for MVP but parity backlog needs production-ready integration path.",
           "acceptanceCriteria": [
             "Provider abstraction supports create envelope, status polling, webhook callback.",
@@ -612,7 +612,9 @@
           "apiImpact": "Portal endpoints now include envelope list/status refresh and provider-specific webhook callback processing.",
           "securityImpact": "Signature payload integrity and webhook auth required.",
           "definitionOfDone": [
-            "Sandbox provider flow and signed webhook lifecycle tests are passing, with evidence in docs/parity/esign-provider-abstraction.md."
+            "Sandbox provider flow and signed webhook lifecycle tests are passing with idempotency + invalid-signature verification coverage.",
+            "Portal UI tests confirm envelope refresh updates surfaced lifecycle status.",
+            "Verification artifact is documented at docs/parity/esign-provider-abstraction.md."
           ]
         }
       ]

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T20:59:15.135Z",
+  "generatedAt": "2026-02-18T21:09:54.767Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,37 +14,27 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 6,
+    "unresolvedRequirements": 5,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-2": 5,
-      "phase-1": 1
+      "phase-2": 5
     },
     "unresolvedCountsByStatus": {
-      "Complete": 6
+      "Complete": 5
     },
     "unresolvedCountsByRisk": {
-      "Medium": 6
+      "Medium": 5
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 6
+      "Complete:Medium": 5
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-PORTAL-002",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Replace e-sign stub with provider abstraction implementation",
-        "component": "API",
-        "epicCode": "PARITY-07",
-        "phase": "phase-1"
-      },
       {
         "requirementId": "REQ-BILL-003",
         "parityStatus": "Complete",
@@ -103,6 +93,13 @@
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-43",
+        "title": "Enforce Linear key branch/PR policy in CI",
+        "state": "Done",
+        "updatedAt": "2026-02-18T21:03:00.059Z",
+        "requirementId": "REQ-OPS-003"
+      },
       {
         "key": "KAR-42",
         "title": "Document deployment runbook and operational SLOs",
@@ -165,31 +162,26 @@
         "state": "Done",
         "updatedAt": "2026-02-18T19:14:05.739Z",
         "requirementId": "REQ-COMM-003"
-      },
-      {
-        "key": "KAR-24",
-        "title": "Complete communication search relevance and indexing strategy",
-        "state": "Done",
-        "updatedAt": "2026-02-18T19:06:10.494Z",
-        "requirementId": "REQ-COMM-002"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T20:59:13.599Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:09:53.396Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "2ed6df801e9a6487147d262e0243f00e664531f2",
+    "gitHead": "4ebc313d2d918b5f39b658655c017abc06226898",
     "gitStatusShort": [
-      "## lin/KAR-43-pr-policy-verification-hardening",
+      "## lin/KAR-31-portal-esign-verification-hardening",
+      " M apps/web/test/portal-page.spec.tsx",
+      " M docs/SESSION_HANDOFF.md",
+      " M docs/parity/esign-provider-abstraction.md",
       " M tools/backlog-sync/requirements.matrix.json",
       "?? agents.md",
-      "?? apps/api/test/pr-linear-policy.spec.ts",
+      "?? apps/api/test/portal-esign-verification.spec.ts",
       "?? brand/",
-      "?? docs/parity/pr-linear-policy-verification.md",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 6
+    "dirtyFileCount": 8
   }
 }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-31
- URL: https://linear.app/karenap/issue/KAR-31/replace-e-sign-stub-with-provider-abstraction-implementation

## Requirement ID
- REQ-PORTAL-002

## Summary
- Added focused API verification coverage for portal e-sign listing scope, webhook idempotency, refresh lifecycle metadata, and invalid signature rejection.
- Added web regression coverage for portal e-sign status refresh rendering.
- Updated parity artifact, requirement matrix status (`Verified`), and session handoff/snapshot metadata.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- portal-esign-verification.spec.ts portal.spec.ts`
  - `pnpm --filter web test -- portal-page.spec.tsx`
  - `pnpm test`
  - `pnpm build`
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - Targeted portal API/Web suites passed.
  - Full workspace tests/build passed.
  - Backlog mirror verify/snapshot/handoff checks passed.

## Notes
- No runtime API contract changes; this slice is verification hardening and parity status progression only.
