### PR TITLE
[KAR-47] Verify trust reconciliation workflow safeguards

### DIFF
--- a/apps/api/src/billing/billing.service.ts
+++ b/apps/api/src/billing/billing.service.ts
@@ -1245,6 +1245,12 @@ export class BillingService {
     if (!input.resolutionNote?.trim()) {
       throw new UnprocessableEntityException('resolutionNote is required');
     }
+    if (
+      input.status !== TrustReconciliationDiscrepancyStatus.RESOLVED &&
+      input.status !== TrustReconciliationDiscrepancyStatus.WAIVED
+    ) {
+      throw new UnprocessableEntityException('status must be RESOLVED or WAIVED');
+    }
 
     const discrepancy = await this.prisma.trustReconciliationDiscrepancy.findFirst({
       where: {
@@ -1258,6 +1264,9 @@ export class BillingService {
     if (!discrepancy) throw new NotFoundException('Trust reconciliation discrepancy not found');
     if (discrepancy.run.status !== TrustReconciliationRunStatus.IN_REVIEW) {
       throw new UnprocessableEntityException('Discrepancies can only be resolved while run is in review');
+    }
+    if (discrepancy.status !== TrustReconciliationDiscrepancyStatus.OPEN) {
+      throw new UnprocessableEntityException('Only open discrepancies can be resolved');
     }
 
     const resolved = await this.prisma.trustReconciliationDiscrepancy.update({

--- a/apps/api/test/billing-trust-reconciliation-verification.spec.ts
+++ b/apps/api/test/billing-trust-reconciliation-verification.spec.ts
@@ -1,0 +1,167 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { BillingService } from '../src/billing/billing.service';
+
+describe('BillingService trust reconciliation verification hardening', () => {
+  it('records negative-balance discrepancy reason codes in run creation', async () => {
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const prisma = {
+      trustAccount: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'ta-1' }),
+      },
+      matterTrustLedger: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'ledger-neg',
+            trustAccountId: 'ta-1',
+            matterId: 'matter-1',
+            balance: -20,
+            trustAccount: { name: 'IOLTA Account' },
+            matter: { name: 'Matter One' },
+          },
+        ]),
+      },
+      trustTransaction: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      trustReconciliationRun: {
+        create: jest.fn().mockResolvedValue({
+          id: 'run-neg',
+          discrepancies: [{ id: 'disc-neg-1' }],
+        }),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      audit,
+      { upload: jest.fn() } as any,
+    );
+
+    await service.createTrustReconciliationRun({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      trustAccountId: 'ta-1',
+      statementStartAt: '2026-01-01T00:00:00.000Z',
+      statementEndAt: '2026-01-31T23:59:59.999Z',
+    });
+
+    expect(prisma.trustReconciliationRun.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          summaryJson: expect.objectContaining({
+            negativeBalanceViolations: 1,
+          }),
+          discrepancies: {
+            create: [
+              expect.objectContaining({
+                reasonCode: 'NEGATIVE_BALANCE',
+                ledgerBalance: -20,
+                expectedBalance: 0,
+                difference: -20,
+                status: 'OPEN',
+              }),
+            ],
+          },
+        }),
+      }),
+    );
+  });
+
+  it('appends submission notes while transitioning run to in-review', async () => {
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const prisma = {
+      trustReconciliationRun: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'run-1',
+          organizationId: 'org-1',
+          status: 'DRAFT',
+          notes: 'Initial reconciliation summary',
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'run-1',
+          status: 'IN_REVIEW',
+          notes: 'Initial reconciliation summary\n\nAttorney review complete',
+        }),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      audit,
+      { upload: jest.fn() } as any,
+    );
+
+    await service.submitTrustReconciliationRun({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      runId: 'run-1',
+      notes: 'Attorney review complete',
+    });
+
+    expect(prisma.trustReconciliationRun.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'IN_REVIEW',
+          notes: 'Initial reconciliation summary\n\nAttorney review complete',
+        }),
+      }),
+    );
+  });
+
+  it('rejects unsupported discrepancy statuses before persistence lookup', async () => {
+    const prisma = {
+      trustReconciliationDiscrepancy: {
+        findFirst: jest.fn(),
+      },
+    } as any;
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    await expect(
+      service.resolveTrustReconciliationDiscrepancy({
+        user: { id: 'u1', organizationId: 'org-1' } as any,
+        discrepancyId: 'disc-1',
+        status: 'OPEN' as any,
+        resolutionNote: 'No action required',
+      }),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+
+    expect(prisma.trustReconciliationDiscrepancy.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects resolution for discrepancies that are already resolved', async () => {
+    const prisma = {
+      trustReconciliationDiscrepancy: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'disc-1',
+          organizationId: 'org-1',
+          runId: 'run-1',
+          status: 'RESOLVED',
+          run: {
+            id: 'run-1',
+            status: 'IN_REVIEW',
+          },
+        }),
+      },
+    } as any;
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+    );
+
+    await expect(
+      service.resolveTrustReconciliationDiscrepancy({
+        user: { id: 'u1', organizationId: 'org-1' } as any,
+        discrepancyId: 'disc-1',
+        status: 'WAIVED' as any,
+        resolutionNote: 'Already addressed',
+      }),
+    ).rejects.toThrow('Only open discrepancies can be resolved');
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T21:09:54.767Z`
+- Snapshot Timestamp: `2026-02-18T21:25:19.210Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T21:09:53.396Z`
+- Last Successful Mirror Verify: `2026-02-18T21:25:16.756Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-BILL-003` by hardening trust reconciliation service invariants (resolution status restricted to `RESOLVED|WAIVED`, non-open discrepancies cannot be re-resolved), plus regression coverage for negative-balance discrepancy reason codes, draft->in-review note append behavior, and resolution guardrails (`apps/api/test/billing-trust-reconciliation-verification.spec.ts`, `docs/parity/trust-reconciliation-workflows.md`).
 - 2026-02-18: Verified `REQ-PORTAL-002` by adding explicit e-sign verification hardening coverage for client matter-scoped envelope listing, duplicate-webhook idempotency, refresh lifecycle history persistence, invalid-signature rejection, and portal envelope status refresh UX assertions (`apps/api/test/portal-esign-verification.spec.ts`, `apps/web/test/portal-page.spec.tsx`, `docs/parity/esign-provider-abstraction.md`).
 - 2026-02-18: Verified `REQ-OPS-003` by adding executable governance checks for `.github/workflows/pr-linear-policy.yml` and `.github/pull_request_template.md`, including regex enforcement and required metadata section assertions (`apps/api/test/pr-linear-policy.spec.ts`, `docs/parity/pr-linear-policy-verification.md`).
 - 2026-02-18: Verified `REQ-OPS-002` by adding executable runbook conformance coverage for required deployment/readiness/rollback/incident sections, baseline SLO targets, and README/parity linkage integrity (`apps/api/test/ops-runbook.spec.ts`, `docs/parity/ops-runbook-slos.md`).

--- a/docs/parity/trust-reconciliation-workflows.md
+++ b/docs/parity/trust-reconciliation-workflows.md
@@ -39,6 +39,7 @@ Executed on 2026-02-17:
 ```bash
 pnpm --filter api prisma:generate
 pnpm --filter api test -- billing-trust-invariants.spec.ts
+pnpm --filter api test -- billing-trust-reconciliation-verification.spec.ts
 pnpm --filter web test -- billing-page.spec.tsx
 pnpm test
 pnpm build
@@ -47,5 +48,10 @@ pnpm build
 Results:
 
 - API trust reconciliation regression coverage passed (`apps/api/test/billing-trust-invariants.spec.ts`).
+- Verification hardening coverage passed (`apps/api/test/billing-trust-reconciliation-verification.spec.ts`) for:
+  - negative-balance discrepancy reason-code capture in run creation,
+  - submission note append behavior on draft -> in-review transition,
+  - strict discrepancy resolution status validation (`RESOLVED|WAIVED` only),
+  - prevention of re-resolving already-resolved discrepancies.
 - Web billing reconciliation coverage passed (`apps/web/test/billing-page.spec.tsx`).
 - Full monorepo tests and build passed.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -524,11 +524,11 @@
           "title": "Implement trust reconciliation workflows with discrepancy resolution",
           "requirementId": "REQ-BILL-003",
           "promptSection": "Billing & Trust / trust reconciliation workflows",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "billing", "phase-2"],
-          "problemStatement": "Trust reconciliation workflows are implemented with run lifecycle management, discrepancy resolution, and completion sign-off controls.",
+          "problemStatement": "Trust reconciliation workflows are verification-hardened with discrepancy reason-code capture, strict resolution status guards, and immutable resolution semantics for non-open discrepancies.",
           "requirementExcerpt": "Trust reconciliation should support statement-period runs, discrepancy tracking, resolution notes, and sign-off evidence.",
           "acceptanceCriteria": [
             "Create reconciliation run entities with lifecycle states (draft, in_review, completed).",
@@ -538,7 +538,8 @@
           "apiImpact": "New reconciliation run/discrepancy endpoints and reporting payload fields.",
           "securityImpact": "Improves financial controls and traceability for trust account compliance.",
           "definitionOfDone": [
-            "Reconciliation workflows are tested end-to-end with deterministic trust ledger fixtures and documented in docs/parity/trust-reconciliation-workflows.md."
+            "Reconciliation workflows are tested end-to-end with deterministic trust ledger fixtures and documented in docs/parity/trust-reconciliation-workflows.md.",
+            "Service-level validation rejects unsupported discrepancy statuses and re-resolution of non-open discrepancies."
           ]
         },
         {

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T21:09:54.767Z",
+  "generatedAt": "2026-02-18T21:25:19.210Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,36 +14,27 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 5,
+    "unresolvedRequirements": 4,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-2": 5
+      "phase-2": 4
     },
     "unresolvedCountsByStatus": {
-      "Complete": 5
+      "Complete": 4
     },
     "unresolvedCountsByRisk": {
-      "Medium": 5
+      "Medium": 4
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 5
+      "Complete:Medium": 4
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-BILL-003",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Implement trust reconciliation workflows with discrepancy resolution",
-        "component": "API",
-        "epicCode": "PARITY-06",
-        "phase": "phase-2"
-      },
       {
         "requirementId": "REQ-BILL-004",
         "parityStatus": "Complete",
@@ -93,6 +84,13 @@
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-31",
+        "title": "Replace e-sign stub with provider abstraction implementation",
+        "state": "Done",
+        "updatedAt": "2026-02-18T21:15:22.027Z",
+        "requirementId": "REQ-PORTAL-002"
+      },
       {
         "key": "KAR-43",
         "title": "Enforce Linear key branch/PR policy in CI",
@@ -155,33 +153,27 @@
         "state": "Done",
         "updatedAt": "2026-02-18T19:21:45.723Z",
         "requirementId": "REQ-PORT-002"
-      },
-      {
-        "key": "KAR-25",
-        "title": "Expand document automation coverage for merge fields and generated outputs",
-        "state": "Done",
-        "updatedAt": "2026-02-18T19:14:05.739Z",
-        "requirementId": "REQ-COMM-003"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:09:53.396Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:25:16.756Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "4ebc313d2d918b5f39b658655c017abc06226898",
+    "gitHead": "417892848dc62d9990fc8befcd91ac895e8e92b9",
     "gitStatusShort": [
-      "## lin/KAR-31-portal-esign-verification-hardening",
-      " M apps/web/test/portal-page.spec.tsx",
+      "## lin/KAR-47-bill-003-verification-hardening",
+      " M apps/api/src/billing/billing.service.ts",
       " M docs/SESSION_HANDOFF.md",
-      " M docs/parity/esign-provider-abstraction.md",
+      " M docs/parity/trust-reconciliation-workflows.md",
       " M tools/backlog-sync/requirements.matrix.json",
+      " M tools/backlog-sync/session.snapshot.json",
       "?? agents.md",
-      "?? apps/api/test/portal-esign-verification.spec.ts",
+      "?? apps/api/test/billing-trust-reconciliation-verification.spec.ts",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 8
+    "dirtyFileCount": 9
   }
 }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-47
- URL: https://linear.app/karenap/issue/KAR-47/implement-trust-reconciliation-workflows-with-discrepancy-resolution

## Requirement ID
- REQ-BILL-003

## Summary
- Added service-level trust reconciliation guardrails to enforce allowed discrepancy resolution statuses (`RESOLVED|WAIVED`) and prevent re-resolution of non-open discrepancies.
- Added dedicated verification-hardening API test coverage for negative-balance discrepancy reason coding, submission note append behavior, and resolution guardrails.
- Updated parity docs/matrix/snapshot/handoff to mark `REQ-BILL-003` as `Verified`.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- billing-trust-reconciliation-verification.spec.ts billing-trust-invariants.spec.ts`
  - `pnpm --filter web test -- billing-page.spec.tsx`
  - `pnpm test`
  - `pnpm build`
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - New API verification suite passed.
  - Existing trust reconciliation API + web workflows passed.
  - Full workspace test/build passed.
  - Backlog mirror and handoff freshness checks passed.

## Notes
- Runtime behavior is intentionally stricter for discrepancy resolution to preserve reconciliation audit integrity.
