### PR TITLE
[KAR-48] Verify LEDES export workflow safeguards

### DIFF
--- a/apps/api/test/billing-ledes-verification.spec.ts
+++ b/apps/api/test/billing-ledes-verification.spec.ts
@@ -1,0 +1,190 @@
+import { NotFoundException } from '@nestjs/common';
+import { BillingService } from '../src/billing/billing.service';
+
+describe('BillingService LEDES verification hardening', () => {
+  it('resets prior defaults when creating a new default export profile', async () => {
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const tx = {
+      lEDESExportProfile: {
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        create: jest.fn().mockResolvedValue({
+          id: 'profile-new-default',
+          organizationId: 'org-1',
+          name: 'Default 1998B',
+          format: 'LEDES98B',
+          isDefault: true,
+        }),
+      },
+    } as any;
+    const prisma = {
+      $transaction: jest.fn().mockImplementation(async (handler: (client: typeof tx) => Promise<unknown>) => handler(tx)),
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      audit,
+      { upload: jest.fn() } as any,
+    );
+
+    const profile = await service.createLedesExportProfile({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      name: 'Default 1998B',
+      isDefault: true,
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.lEDESExportProfile.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { organizationId: 'org-1', isDefault: true },
+        data: { isDefault: false },
+      }),
+    );
+    expect(tx.lEDESExportProfile.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          organizationId: 'org-1',
+          name: 'Default 1998B',
+          isDefault: true,
+        }),
+      }),
+    );
+    expect(profile).toEqual(expect.objectContaining({ id: 'profile-new-default', isDefault: true }));
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'billing.ledes.profile.created',
+        entityType: 'ledesExportProfile',
+        entityId: 'profile-new-default',
+      }),
+    );
+  });
+
+  it('rejects explicit invoice export when any requested invoice id is missing', async () => {
+    const prisma = {
+      lEDESExportProfile: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'profile-1',
+          organizationId: 'org-1',
+          format: 'LEDES98B',
+          requireUtbmsPhaseCode: false,
+          requireUtbmsTaskCode: false,
+          includeExpenseLineItems: true,
+        }),
+      },
+      invoice: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'inv-1',
+            invoiceNumber: 'INV-0001',
+            issuedAt: new Date('2026-01-10T00:00:00.000Z'),
+            matter: { id: 'matter-1', name: 'Matter One', matterNumber: 'MAT-1' },
+            lineItems: [],
+          },
+        ]),
+      },
+      lEDESExportJob: {
+        create: jest.fn(),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn() } as any,
+    );
+
+    await expect(
+      service.createLedesExportJob({
+        user: { id: 'u1', organizationId: 'org-1' } as any,
+        profileId: 'profile-1',
+        invoiceIds: ['inv-1', 'inv-2', ' inv-2 '],
+      }),
+    ).rejects.toEqual(new NotFoundException('Invoice(s) not found for export: inv-2'));
+
+    expect(prisma.invoice.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['inv-1', 'inv-2'] },
+        }),
+      }),
+    );
+    expect(prisma.lEDESExportJob.create).not.toHaveBeenCalled();
+  });
+
+  it('excludes expense lines when profile opts out of expense line items', async () => {
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const s3 = {
+      upload: jest.fn().mockResolvedValue({ key: 'org/org-1/exports/ledes/job-1.1998b' }),
+      signedDownloadUrl: jest.fn().mockResolvedValue('https://download.local/job-1.1998b'),
+    } as any;
+    const prisma = {
+      lEDESExportProfile: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'profile-1',
+          organizationId: 'org-1',
+          format: 'LEDES98B',
+          requireUtbmsPhaseCode: true,
+          requireUtbmsTaskCode: true,
+          includeExpenseLineItems: false,
+        }),
+      },
+      invoice: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'inv-1',
+            invoiceNumber: 'INV-0001',
+            issuedAt: new Date('2026-01-10T00:00:00.000Z'),
+            matter: { id: 'matter-1', name: 'Matter One', matterNumber: 'MAT-1' },
+            lineItems: [
+              {
+                id: 'line-expense',
+                quantity: 1,
+                amount: 300,
+                description: 'Expert invoice pass-through',
+                expenseId: 'expense-1',
+                utbmsPhaseCode: null,
+                utbmsTaskCode: null,
+              },
+              {
+                id: 'line-fee',
+                quantity: 2,
+                amount: 500,
+                description: 'Draft complaint',
+                expenseId: null,
+                utbmsPhaseCode: 'L100',
+                utbmsTaskCode: 'L110',
+              },
+            ],
+          },
+        ]),
+      },
+      lEDESExportJob: {
+        create: jest.fn().mockResolvedValue({ id: 'job-1' }),
+        update: jest.fn().mockImplementation(async ({ where, data }: any) => ({ id: where.id, ...data })),
+      },
+    } as any;
+
+    const service = new BillingService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      audit,
+      s3,
+    );
+
+    const result = await service.createLedesExportJob({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      profileId: 'profile-1',
+    });
+
+    expect(result.status).toBe('COMPLETED');
+    expect(result.validationStatus).toBe('PASSED');
+    expect(result.lineCount).toBe(1);
+    expect(result.totalAmount).toBe(500);
+    expect(s3.upload).toHaveBeenCalledTimes(1);
+    const uploadedBody = String(s3.upload.mock.calls[0][0]);
+    expect(uploadedBody).toContain('INV-0001');
+    expect(uploadedBody).toContain('Draft complaint');
+    expect(uploadedBody).not.toContain('Expert invoice pass-through');
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T21:25:19.210Z`
+- Snapshot Timestamp: `2026-02-18T21:34:51.981Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T21:25:16.756Z`
+- Last Successful Mirror Verify: `2026-02-18T21:34:50.737Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-BILL-004` by adding LEDES verification-hardening coverage for default-profile rotation (`isDefault` swap), explicit invoice-id export integrity (dedupe + missing-id rejection), and `includeExpenseLineItems=false` line filtering conformance, with parity evidence in `docs/parity/ledes-export-workflows.md` (`apps/api/test/billing-ledes-verification.spec.ts`).
 - 2026-02-18: Verified `REQ-BILL-003` by hardening trust reconciliation service invariants (resolution status restricted to `RESOLVED|WAIVED`, non-open discrepancies cannot be re-resolved), plus regression coverage for negative-balance discrepancy reason codes, draft->in-review note append behavior, and resolution guardrails (`apps/api/test/billing-trust-reconciliation-verification.spec.ts`, `docs/parity/trust-reconciliation-workflows.md`).
 - 2026-02-18: Verified `REQ-PORTAL-002` by adding explicit e-sign verification hardening coverage for client matter-scoped envelope listing, duplicate-webhook idempotency, refresh lifecycle history persistence, invalid-signature rejection, and portal envelope status refresh UX assertions (`apps/api/test/portal-esign-verification.spec.ts`, `apps/web/test/portal-page.spec.tsx`, `docs/parity/esign-provider-abstraction.md`).
 - 2026-02-18: Verified `REQ-OPS-003` by adding executable governance checks for `.github/workflows/pr-linear-policy.yml` and `.github/pull_request_template.md`, including regex enforcement and required metadata section assertions (`apps/api/test/pr-linear-policy.spec.ts`, `docs/parity/pr-linear-policy-verification.md`).

--- a/docs/parity/ledes-export-workflows.md
+++ b/docs/parity/ledes-export-workflows.md
@@ -36,6 +36,7 @@ Executed on 2026-02-17:
 ```bash
 pnpm --filter api prisma:generate
 pnpm --filter api test -- billing-ledes-export.spec.ts
+pnpm --filter api test -- billing-ledes-verification.spec.ts
 pnpm --filter web test -- billing-page.spec.tsx
 pnpm test
 pnpm build
@@ -44,5 +45,9 @@ pnpm build
 Results:
 
 - API LEDES service coverage passed (`apps/api/test/billing-ledes-export.spec.ts`).
+- Verification hardening coverage passed (`apps/api/test/billing-ledes-verification.spec.ts`) for:
+  - default-profile rotation behavior (`isDefault=true` resets prior defaults atomically),
+  - explicit invoice-id export integrity (dedupe + missing-id rejection with deterministic error),
+  - expense-line exclusion behavior for `includeExpenseLineItems=false` without false validation failures.
 - Web billing LEDES workflow coverage passed (`apps/web/test/billing-page.spec.tsx`).
 - Full monorepo tests and build passed.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -546,11 +546,11 @@
           "title": "Implement LEDES/UTBMS export jobs with validation profiles",
           "requirementId": "REQ-BILL-004",
           "promptSection": "Billing / LEDES export expectations",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "billing", "exports", "phase-2"],
-          "problemStatement": "LEDES export profiles and jobs are implemented with profile-based validation, checksum metadata, and signed artifact download flow.",
+          "problemStatement": "LEDES export workflows are verification-hardened with default-profile rotation checks, explicit invoice-id selection integrity assertions, and expense-line filtering conformance coverage.",
           "requirementExcerpt": "Provide executable LEDES export jobs, validation statuses, and downloadable LEDES outputs.",
           "acceptanceCriteria": [
             "Add LEDES export profile and export job entities with format selection and validation status.",
@@ -560,7 +560,8 @@
           "apiImpact": "Billing APIs gain LEDES export job create/status/download endpoints.",
           "securityImpact": "Billing exports remain tenant-scoped and audit logged.",
           "definitionOfDone": [
-            "LEDES profile/job workflows are covered by API/Web tests and documented in docs/parity/ledes-export-workflows.md."
+            "LEDES profile/job workflows are covered by API/Web tests and documented in docs/parity/ledes-export-workflows.md.",
+            "Verification suite asserts default-profile switching, invoice selection integrity, and expense-line filtering behavior."
           ]
         }
       ]

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T21:25:19.210Z",
+  "generatedAt": "2026-02-18T21:34:51.981Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,36 +14,27 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 4,
+    "unresolvedRequirements": 3,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-2": 4
+      "phase-2": 3
     },
     "unresolvedCountsByStatus": {
-      "Complete": 4
+      "Complete": 3
     },
     "unresolvedCountsByRisk": {
-      "Medium": 4
+      "Medium": 3
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 4
+      "Complete:Medium": 3
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-BILL-004",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Implement LEDES/UTBMS export jobs with validation profiles",
-        "component": "API",
-        "epicCode": "PARITY-06",
-        "phase": "phase-2"
-      },
       {
         "requirementId": "REQ-COMM-004",
         "parityStatus": "Complete",
@@ -84,6 +75,13 @@
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-47",
+        "title": "Implement trust reconciliation workflows with discrepancy resolution",
+        "state": "Done",
+        "updatedAt": "2026-02-18T21:29:32.488Z",
+        "requirementId": "REQ-BILL-003"
+      },
       {
         "key": "KAR-31",
         "title": "Replace e-sign stub with provider abstraction implementation",
@@ -146,34 +144,26 @@
         "state": "Done",
         "updatedAt": "2026-02-18T19:28:43.473Z",
         "requirementId": "REQ-PORT-003"
-      },
-      {
-        "key": "KAR-15",
-        "title": "Finalize Clio CSV/XLSX template importer coverage",
-        "state": "Done",
-        "updatedAt": "2026-02-18T19:21:45.723Z",
-        "requirementId": "REQ-PORT-002"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:25:16.756Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:34:50.737Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "417892848dc62d9990fc8befcd91ac895e8e92b9",
+    "gitHead": "f402b34dc865cb34383060248ad6e7c0d2efcd75",
     "gitStatusShort": [
-      "## lin/KAR-47-bill-003-verification-hardening",
-      " M apps/api/src/billing/billing.service.ts",
+      "## lin/KAR-48-bill-004-verification-hardening",
       " M docs/SESSION_HANDOFF.md",
-      " M docs/parity/trust-reconciliation-workflows.md",
+      " M docs/parity/ledes-export-workflows.md",
       " M tools/backlog-sync/requirements.matrix.json",
       " M tools/backlog-sync/session.snapshot.json",
       "?? agents.md",
-      "?? apps/api/test/billing-trust-reconciliation-verification.spec.ts",
+      "?? apps/api/test/billing-ledes-verification.spec.ts",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 9
+    "dirtyFileCount": 8
   }
 }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-48
- URL: https://linear.app/karenap/issue/KAR-48/implement-ledesutbms-export-jobs-with-validation-profiles

## Requirement ID
- REQ-BILL-004

## Summary
- Added dedicated LEDES verification-hardening API coverage for:
  - default-profile rotation (`isDefault=true` resets prior defaults),
  - invoice selection integrity for explicit `invoiceIds` (dedupe + missing-id rejection),
  - `includeExpenseLineItems=false` export-line filtering behavior.
- Updated parity artifact and requirements matrix to mark `REQ-BILL-004` as `Verified`.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- billing-ledes-verification.spec.ts billing-ledes-export.spec.ts`
  - `pnpm --filter web test -- billing-page.spec.tsx`
  - `pnpm test`
  - `pnpm build`
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - New LEDES verification suite passed.
  - Existing LEDES export and billing workflow tests passed.
  - Full workspace tests/build passed.
  - Backlog mirror + handoff checks passed.

## Notes
- No runtime route changes; this slice adds verification-hardening coverage and parity evidence.
