### PR TITLE
[KAR-46] Verify retention legal-hold execution safeguards

### DIFF
--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -624,42 +624,99 @@ export class DocumentsService {
     const now = new Date();
     const pendingItems = run.items.filter((item) => item.status === DocumentDispositionItemStatus.PENDING);
     const pendingDocumentIds = pendingItems.map((item) => item.documentId);
+    const executableDocumentIds: string[] = [];
+    const blockedByLegalHoldIds: string[] = [];
 
     if (pendingDocumentIds.length > 0) {
-      await this.prisma.document.updateMany({
+      const pendingDocuments = await this.prisma.document.findMany({
         where: {
+          organizationId: input.user.organizationId,
           id: { in: pendingDocumentIds },
-          organizationId: input.user.organizationId,
         },
-        data: {
-          dispositionStatus: DocumentDispositionStatus.DISPOSED,
-          disposedAt: now,
-          sharedWithClient: false,
+        select: {
+          id: true,
+          legalHoldActive: true,
+          dispositionStatus: true,
         },
       });
+      const pendingDocumentById = new Map(pendingDocuments.map((document) => [document.id, document]));
+      for (const pendingItem of pendingItems) {
+        const document = pendingDocumentById.get(pendingItem.documentId);
+        if (!document) {
+          continue;
+        }
+        if (document.legalHoldActive) {
+          blockedByLegalHoldIds.push(document.id);
+          continue;
+        }
+        executableDocumentIds.push(document.id);
+      }
 
-      await this.prisma.documentShareLink.updateMany({
-        where: {
-          organizationId: input.user.organizationId,
-          documentId: { in: pendingDocumentIds },
-          revokedAt: null,
-        },
-        data: {
-          revokedAt: now,
-        },
-      });
+      if (executableDocumentIds.length > 0) {
+        await this.prisma.document.updateMany({
+          where: {
+            id: { in: executableDocumentIds },
+            organizationId: input.user.organizationId,
+          },
+          data: {
+            dispositionStatus: DocumentDispositionStatus.DISPOSED,
+            disposedAt: now,
+            sharedWithClient: false,
+          },
+        });
 
-      await this.prisma.documentDispositionItem.updateMany({
-        where: {
-          runId: run.id,
-          organizationId: input.user.organizationId,
-          status: DocumentDispositionItemStatus.PENDING,
-        },
-        data: {
-          status: DocumentDispositionItemStatus.DISPOSED,
-          appliedAt: now,
-        },
-      });
+        await this.prisma.documentShareLink.updateMany({
+          where: {
+            organizationId: input.user.organizationId,
+            documentId: { in: executableDocumentIds },
+            revokedAt: null,
+          },
+          data: {
+            revokedAt: now,
+          },
+        });
+
+        await this.prisma.documentDispositionItem.updateMany({
+          where: {
+            runId: run.id,
+            organizationId: input.user.organizationId,
+            documentId: { in: executableDocumentIds },
+            status: DocumentDispositionItemStatus.PENDING,
+          },
+          data: {
+            status: DocumentDispositionItemStatus.DISPOSED,
+            appliedAt: now,
+          },
+        });
+      }
+
+      if (blockedByLegalHoldIds.length > 0) {
+        await this.prisma.document.updateMany({
+          where: {
+            id: { in: blockedByLegalHoldIds },
+            organizationId: input.user.organizationId,
+            dispositionStatus: DocumentDispositionStatus.PENDING_DISPOSITION,
+          },
+          data: {
+            dispositionStatus: DocumentDispositionStatus.ACTIVE,
+          },
+        });
+
+        await this.prisma.documentDispositionItem.updateMany({
+          where: {
+            runId: run.id,
+            organizationId: input.user.organizationId,
+            documentId: { in: blockedByLegalHoldIds },
+            status: DocumentDispositionItemStatus.PENDING,
+          },
+          data: {
+            status: DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD,
+            note: 'Skipped at execution because legal hold is active.',
+            appliedAt: now,
+          },
+        });
+      }
+
     }
 
     const completed = await this.prisma.documentDispositionRun.update({
@@ -680,13 +737,15 @@ export class DocumentsService {
       entityId: completed.id,
       metadata: {
         executedAt: now.toISOString(),
-        disposedCount: pendingDocumentIds.length,
+        disposedCount: executableDocumentIds.length,
+        skippedForLegalHoldAtExecution: blockedByLegalHoldIds.length,
       },
     });
 
     return {
       ...completed,
-      disposedDocumentCount: pendingDocumentIds.length,
+      disposedDocumentCount: executableDocumentIds.length,
+      skippedForLegalHoldCount: blockedByLegalHoldIds.length,
     };
   }
 

--- a/apps/api/test/document-retention-verification.spec.ts
+++ b/apps/api/test/document-retention-verification.spec.ts
@@ -1,0 +1,154 @@
+import {
+  DocumentDispositionItemStatus,
+  DocumentDispositionRunStatus,
+  DocumentDispositionStatus,
+} from '@prisma/client';
+import { DocumentsService } from '../src/documents/documents.service';
+
+const baseUser = {
+  id: 'user-1',
+  organizationId: 'org-1',
+} as any;
+
+describe('DocumentsService retention verification hardening', () => {
+  it('re-checks legal hold at execution and skips newly-held pending documents', async () => {
+    const documentUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const shareLinkUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const dispositionItemUpdateMany = jest.fn().mockResolvedValue({ count: 1 });
+    const runUpdate = jest.fn().mockResolvedValue({
+      id: 'run-1',
+      organizationId: 'org-1',
+      status: DocumentDispositionRunStatus.COMPLETED,
+      executedAt: new Date('2026-02-01T02:00:00.000Z'),
+    });
+
+    const prisma = {
+      documentDispositionRun: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'run-1',
+          organizationId: 'org-1',
+          status: DocumentDispositionRunStatus.APPROVED,
+          notes: null,
+          items: [
+            {
+              id: 'item-dispose',
+              documentId: 'doc-1',
+              status: DocumentDispositionItemStatus.PENDING,
+            },
+            {
+              id: 'item-skip',
+              documentId: 'doc-2',
+              status: DocumentDispositionItemStatus.PENDING,
+            },
+            {
+              id: 'item-existing-skip',
+              documentId: 'doc-3',
+              status: DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD,
+            },
+          ],
+        }),
+        update: runUpdate,
+      },
+      document: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'doc-1',
+            legalHoldActive: false,
+            dispositionStatus: DocumentDispositionStatus.PENDING_DISPOSITION,
+          },
+          {
+            id: 'doc-2',
+            legalHoldActive: true,
+            dispositionStatus: DocumentDispositionStatus.PENDING_DISPOSITION,
+          },
+        ]),
+        updateMany: documentUpdateMany,
+      },
+      documentShareLink: {
+        updateMany: shareLinkUpdateMany,
+      },
+      documentDispositionItem: {
+        updateMany: dispositionItemUpdateMany,
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn(), getObjectBuffer: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      audit,
+    );
+
+    const result = await service.executeDispositionRun({
+      user: baseUser,
+      runId: 'run-1',
+      notes: 'Execute with hold re-check',
+    });
+
+    expect(result.disposedDocumentCount).toBe(1);
+    expect(result.skippedForLegalHoldCount).toBe(1);
+
+    expect(documentUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['doc-1'] },
+        }),
+        data: expect.objectContaining({
+          dispositionStatus: DocumentDispositionStatus.DISPOSED,
+        }),
+      }),
+    );
+    expect(documentUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { in: ['doc-2'] },
+          dispositionStatus: DocumentDispositionStatus.PENDING_DISPOSITION,
+        }),
+        data: {
+          dispositionStatus: DocumentDispositionStatus.ACTIVE,
+        },
+      }),
+    );
+    expect(shareLinkUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          documentId: { in: ['doc-1'] },
+        }),
+      }),
+    );
+    expect(dispositionItemUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          documentId: { in: ['doc-1'] },
+          status: DocumentDispositionItemStatus.PENDING,
+        }),
+        data: expect.objectContaining({
+          status: DocumentDispositionItemStatus.DISPOSED,
+        }),
+      }),
+    );
+    expect(dispositionItemUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          documentId: { in: ['doc-2'] },
+          status: DocumentDispositionItemStatus.PENDING,
+        }),
+        data: expect.objectContaining({
+          status: DocumentDispositionItemStatus.SKIPPED_LEGAL_HOLD,
+          note: 'Skipped at execution because legal hold is active.',
+        }),
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.disposition_run.completed',
+        metadata: expect.objectContaining({
+          disposedCount: 1,
+          skippedForLegalHoldAtExecution: 1,
+        }),
+      }),
+    );
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T21:34:51.981Z`
+- Snapshot Timestamp: `2026-02-18T21:44:31.380Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T21:34:50.737Z`
+- Last Successful Mirror Verify: `2026-02-18T21:44:29.610Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-COMM-004` by hardening disposition execution to re-check legal holds at execution time (disposing only eligible documents, skipping newly-held documents, reverting skipped docs to `ACTIVE`, and recording `skippedForLegalHoldAtExecution` audit metadata), with new regression coverage in `apps/api/test/document-retention-verification.spec.ts` and parity evidence in `docs/parity/document-retention-workflows.md`.
 - 2026-02-18: Verified `REQ-BILL-004` by adding LEDES verification-hardening coverage for default-profile rotation (`isDefault` swap), explicit invoice-id export integrity (dedupe + missing-id rejection), and `includeExpenseLineItems=false` line filtering conformance, with parity evidence in `docs/parity/ledes-export-workflows.md` (`apps/api/test/billing-ledes-verification.spec.ts`).
 - 2026-02-18: Verified `REQ-BILL-003` by hardening trust reconciliation service invariants (resolution status restricted to `RESOLVED|WAIVED`, non-open discrepancies cannot be re-resolved), plus regression coverage for negative-balance discrepancy reason codes, draft->in-review note append behavior, and resolution guardrails (`apps/api/test/billing-trust-reconciliation-verification.spec.ts`, `docs/parity/trust-reconciliation-workflows.md`).
 - 2026-02-18: Verified `REQ-PORTAL-002` by adding explicit e-sign verification hardening coverage for client matter-scoped envelope listing, duplicate-webhook idempotency, refresh lifecycle history persistence, invalid-signature rejection, and portal envelope status refresh UX assertions (`apps/api/test/portal-esign-verification.spec.ts`, `apps/web/test/portal-page.spec.tsx`, `docs/parity/esign-provider-abstraction.md`).

--- a/docs/parity/document-retention-workflows.md
+++ b/docs/parity/document-retention-workflows.md
@@ -45,6 +45,7 @@ Executed on 2026-02-17:
 ```bash
 pnpm --filter api prisma:generate
 pnpm --filter api test -- document-retention.spec.ts
+pnpm --filter api test -- document-retention-verification.spec.ts
 pnpm --filter web test -- documents-page.spec.tsx
 pnpm test
 pnpm build
@@ -53,5 +54,9 @@ pnpm build
 Results:
 
 - New API retention workflow suite passed (`apps/api/test/document-retention.spec.ts`).
+- Verification hardening suite passed (`apps/api/test/document-retention-verification.spec.ts`) for:
+  - execution-time legal-hold re-check of pending disposition items,
+  - mixed execution path handling (dispose eligible docs, skip active-hold docs),
+  - audit metadata for `disposedCount` and `skippedForLegalHoldAtExecution`.
 - Updated documents page suite passed (`apps/web/test/documents-page.spec.tsx`).
 - Full monorepo tests and build passed.

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -451,11 +451,11 @@
           "title": "Implement document retention policies with legal hold workflow",
           "requirementId": "REQ-COMM-004",
           "promptSection": "Documents / Evidence + Security controls for retention/legal hold",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "documents", "security", "phase-2"],
-          "problemStatement": "Retention policy lifecycle, legal hold controls, and approval-gated disposition workflows are now implemented across API + documents UI.",
+          "problemStatement": "Retention/legal-hold workflows are verification-hardened with execution-time legal-hold precedence checks so pending disposition items are skipped when hold status changes before execution.",
           "requirementExcerpt": "Support retention policy assignment, legal hold precedence, disposition queue, and auditable retention actions.",
           "acceptanceCriteria": [
             "Create retention policy model with scope, trigger, and disposition rules.",
@@ -465,7 +465,8 @@
           "apiImpact": "Document management APIs gain retention policy assignment and disposition queue endpoints.",
           "securityImpact": "Improves defensible records governance and prevents unauthorized deletion.",
           "definitionOfDone": [
-            "Retention + legal hold + disposition lifecycle workflows are covered by API/Web tests with evidence in docs/parity/document-retention-workflows.md."
+            "Retention + legal hold + disposition lifecycle workflows are covered by API/Web tests with evidence in docs/parity/document-retention-workflows.md.",
+            "Disposition execution re-checks active legal holds and records skipped-at-execution counts in audit metadata."
           ]
         }
       ]

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T21:34:51.981Z",
+  "generatedAt": "2026-02-18T21:44:31.380Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,36 +14,27 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 3,
+    "unresolvedRequirements": 2,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-2": 3
+      "phase-2": 2
     },
     "unresolvedCountsByStatus": {
-      "Complete": 3
+      "Complete": 2
     },
     "unresolvedCountsByRisk": {
-      "Medium": 3
+      "Medium": 2
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 3
+      "Complete:Medium": 2
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-COMM-004",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Implement document retention policies with legal hold workflow",
-        "component": "API",
-        "epicCode": "PARITY-05",
-        "phase": "phase-2"
-      },
       {
         "requirementId": "REQ-MAT-004",
         "parityStatus": "Complete",
@@ -75,6 +66,13 @@
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-48",
+        "title": "Implement LEDES/UTBMS export jobs with validation profiles",
+        "state": "Done",
+        "updatedAt": "2026-02-18T21:38:38.111Z",
+        "requirementId": "REQ-BILL-004"
+      },
       {
         "key": "KAR-47",
         "title": "Implement trust reconciliation workflows with discrepancy resolution",
@@ -137,33 +135,27 @@
         "state": "Done",
         "updatedAt": "2026-02-18T20:03:28.782Z",
         "requirementId": "REQ-PORTAL-001"
-      },
-      {
-        "key": "KAR-16",
-        "title": "Build user-confirm merge workflow for dedupe suggestions",
-        "state": "Done",
-        "updatedAt": "2026-02-18T19:28:43.473Z",
-        "requirementId": "REQ-PORT-003"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:34:50.737Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:44:29.610Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "f402b34dc865cb34383060248ad6e7c0d2efcd75",
+    "gitHead": "d7f18f6f324dc7e3ca8f69dbf6b564b3d5af38dc",
     "gitStatusShort": [
-      "## lin/KAR-48-bill-004-verification-hardening",
+      "## lin/KAR-49-comm-004-verification-hardening",
+      " M apps/api/src/documents/documents.service.ts",
       " M docs/SESSION_HANDOFF.md",
-      " M docs/parity/ledes-export-workflows.md",
+      " M docs/parity/document-retention-workflows.md",
       " M tools/backlog-sync/requirements.matrix.json",
       " M tools/backlog-sync/session.snapshot.json",
       "?? agents.md",
-      "?? apps/api/test/billing-ledes-verification.spec.ts",
+      "?? apps/api/test/document-retention-verification.spec.ts",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],
-    "dirtyFileCount": 8
+    "dirtyFileCount": 9
   }
 }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-46
- URL: https://linear.app/karenap/issue/KAR-46/implement-document-retention-policies-with-legal-hold-workflow

## Requirement ID
- REQ-COMM-004

## Summary
- Hardened disposition execution logic to re-check legal-hold status at execution time, not just run creation time.
- Pending items whose documents are now under legal hold are skipped during execution, reset from `PENDING_DISPOSITION` to `ACTIVE`, and tracked explicitly in audit metadata.
- Added focused verification regression coverage for mixed execution behavior (dispose eligible + skip active legal holds) and updated parity docs/matrix to mark `REQ-COMM-004` as `Verified`.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm --filter api test -- document-retention-verification.spec.ts document-retention.spec.ts`
  - `pnpm --filter web test -- documents-page.spec.tsx`
  - `pnpm test`
  - `pnpm build`
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - New retention verification suite passed.
  - Existing retention + documents workflow suites passed.
  - Full workspace tests/build passed.
  - Backlog mirror and handoff checks passed.

## Notes
- Runtime behavior is intentionally stricter to preserve legal-hold precedence and defensible disposition workflows.
