### PR TITLE
[KAR-44] Verify and harden conflict profile workflows

### DIFF
--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -288,19 +288,33 @@ export class AdminService {
     if (!existing && !input.name) {
       throw new UnprocessableEntityException('Profile name is required');
     }
+
+    const mergedWeights: Partial<ConflictRuleWeights> = {
+      ...(existing?.weights || {}),
+      ...(input.weights || {}),
+    };
+    const mergedThresholds: Partial<ConflictRuleThresholds> = {
+      ...(existing?.thresholds || {}),
+      ...(input.thresholds || {}),
+    };
+
     const nextProfile = this.normalizeConflictProfile({
       id: targetId,
       name: input.name ?? existing?.name ?? 'Conflict Profile',
-      description: input.description,
-      practiceAreas: input.practiceAreas,
-      matterTypeIds: input.matterTypeIds,
-      isDefault: input.isDefault,
-      isActive: input.isActive,
-      thresholds: input.thresholds,
-      weights: input.weights,
+      description: input.description ?? existing?.description,
+      practiceAreas: input.practiceAreas ?? existing?.practiceAreas,
+      matterTypeIds: input.matterTypeIds ?? existing?.matterTypeIds,
+      isDefault: input.isDefault ?? existing?.isDefault,
+      isActive: input.isActive ?? existing?.isActive,
+      thresholds: mergedThresholds,
+      weights: mergedWeights,
       createdAt: existing?.createdAt || now,
       updatedAt: now,
     });
+
+    if (!nextProfile.isActive && nextProfile.isDefault) {
+      nextProfile.isDefault = false;
+    }
 
     const nextProfiles = profiles.filter((profile) => profile.id !== targetId);
     if (nextProfile.isDefault) {
@@ -312,6 +326,12 @@ export class AdminService {
     }
     nextProfiles.push(nextProfile);
     nextProfiles.sort((a, b) => a.name.localeCompare(b.name));
+    if (!nextProfiles.some((profile) => profile.isDefault)) {
+      const fallbackDefault = nextProfiles.find((profile) => profile.isActive) || nextProfiles[0];
+      if (fallbackDefault) {
+        fallbackDefault.isDefault = true;
+      }
+    }
 
     const updated = await this.prisma.organization.update({
       where: { id: input.organizationId },
@@ -616,20 +636,33 @@ export class AdminService {
 
     const practiceArea = (input.practiceArea || '').trim().toLowerCase();
     const matterTypeId = (input.matterTypeId || '').trim().toLowerCase();
-    const scoped = input.profiles.filter((profile) => {
-      if (!profile.isActive) {
-        return false;
-      }
-      const practiceMatch =
-        profile.practiceAreas.length === 0 ||
-        profile.practiceAreas.some((value) => value.toLowerCase() === practiceArea);
-      const matterTypeMatch =
-        profile.matterTypeIds.length === 0 ||
-        profile.matterTypeIds.some((value) => value.toLowerCase() === matterTypeId);
-      return practiceMatch && matterTypeMatch;
-    });
+    const scoped = input.profiles
+      .filter((profile) => {
+        if (!profile.isActive) {
+          return false;
+        }
+        const practiceMatch =
+          profile.practiceAreas.length === 0 ||
+          profile.practiceAreas.some((value) => value.toLowerCase() === practiceArea);
+        const matterTypeMatch =
+          profile.matterTypeIds.length === 0 ||
+          profile.matterTypeIds.some((value) => value.toLowerCase() === matterTypeId);
+        return practiceMatch && matterTypeMatch;
+      })
+      .map((profile) => ({
+        profile,
+        specificity:
+          (profile.practiceAreas.length > 0 ? 1 : 0) +
+          (profile.matterTypeIds.length > 0 ? 1 : 0),
+      }));
 
-    const defaultProfile = scoped.find((profile) => profile.isDefault) || scoped[0];
+    if (scoped.length === 0) {
+      throw new UnprocessableEntityException('No active conflict rule profile available');
+    }
+
+    const maxSpecificity = Math.max(...scoped.map((entry) => entry.specificity));
+    const candidates = scoped.filter((entry) => entry.specificity === maxSpecificity).map((entry) => entry.profile);
+    const defaultProfile = candidates.find((profile) => profile.isDefault) || candidates[0];
     if (!defaultProfile) {
       throw new UnprocessableEntityException('No active conflict rule profile available');
     }

--- a/apps/api/test/admin-conflict-verification.spec.ts
+++ b/apps/api/test/admin-conflict-verification.spec.ts
@@ -1,0 +1,230 @@
+import { NotFoundException } from '@nestjs/common';
+import { AdminService } from '../src/admin/admin.service';
+
+describe('AdminService conflict profile verification hardening', () => {
+  it('preserves existing profile fields when applying partial updates', async () => {
+    const prisma = {
+      organization: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'org-1',
+          settingsJson: {
+            conflictRuleProfiles: [
+              {
+                id: 'profile-1',
+                name: 'Construction Conflicts',
+                description: 'Construction only',
+                practiceAreas: ['Construction Litigation'],
+                matterTypeIds: ['matter-type-1'],
+                isDefault: true,
+                isActive: true,
+                thresholds: { warn: 25, block: 50 },
+                weights: { name: 60, email: 50, phone: 40, matter: 30, relationship: 20 },
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+              },
+            ],
+          },
+        }),
+        update: jest.fn().mockImplementation(async ({ data }) => ({
+          id: 'org-1',
+          settingsJson: data.settingsJson,
+        })),
+      },
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new AdminService(prisma, audit);
+
+    const result = await service.upsertConflictRuleProfile({
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      id: 'profile-1',
+      name: 'Construction Conflicts v2',
+    });
+
+    const updatedProfiles = prisma.organization.update.mock.calls[0][0].data.settingsJson.conflictRuleProfiles;
+    expect(updatedProfiles).toHaveLength(1);
+    expect(updatedProfiles[0]).toEqual(
+      expect.objectContaining({
+        id: 'profile-1',
+        name: 'Construction Conflicts v2',
+        description: 'Construction only',
+        practiceAreas: ['Construction Litigation'],
+        matterTypeIds: ['matter-type-1'],
+        isDefault: true,
+        isActive: true,
+        thresholds: { warn: 25, block: 50 },
+        weights: { name: 60, email: 50, phone: 40, matter: 30, relationship: 20 },
+      }),
+    );
+    expect(result.profile).toEqual(expect.objectContaining({ id: 'profile-1', isDefault: true, isActive: true }));
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'conflict_rule_profile.updated',
+      }),
+    );
+  });
+
+  it('reassigns default profile when previous default is deactivated', async () => {
+    const prisma = {
+      organization: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'org-1',
+          settingsJson: {
+            conflictRuleProfiles: [
+              {
+                id: 'profile-default',
+                name: 'Default Profile',
+                isDefault: true,
+                isActive: true,
+                thresholds: { warn: 45, block: 70 },
+                weights: { name: 40, email: 35, phone: 30, matter: 30, relationship: 15 },
+              },
+              {
+                id: 'profile-secondary',
+                name: 'Secondary Profile',
+                isDefault: false,
+                isActive: true,
+                thresholds: { warn: 45, block: 70 },
+                weights: { name: 40, email: 35, phone: 30, matter: 30, relationship: 15 },
+              },
+            ],
+          },
+        }),
+        update: jest.fn().mockImplementation(async ({ data }) => ({
+          id: 'org-1',
+          settingsJson: data.settingsJson,
+        })),
+      },
+    } as any;
+    const service = new AdminService(prisma, { appendEvent: jest.fn().mockResolvedValue(undefined) } as any);
+
+    await service.upsertConflictRuleProfile({
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      id: 'profile-default',
+      isActive: false,
+    });
+
+    const updatedProfiles = prisma.organization.update.mock.calls[0][0].data.settingsJson.conflictRuleProfiles;
+    const defaultProfile = updatedProfiles.find((profile: any) => profile.id === 'profile-default');
+    const secondaryProfile = updatedProfiles.find((profile: any) => profile.id === 'profile-secondary');
+    expect(defaultProfile).toEqual(expect.objectContaining({ isActive: false, isDefault: false }));
+    expect(secondaryProfile).toEqual(expect.objectContaining({ isActive: true, isDefault: true }));
+  });
+
+  it('selects scoped active profile for conflict checks when practice area and matter type match', async () => {
+    const prisma = {
+      organization: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'org-1',
+          settingsJson: {
+            conflictRuleProfiles: [
+              {
+                id: 'profile-default',
+                name: 'Default Profile',
+                isDefault: true,
+                isActive: true,
+                practiceAreas: [],
+                matterTypeIds: [],
+                thresholds: { warn: 60, block: 90 },
+                weights: { name: 20, email: 10, phone: 10, matter: 15, relationship: 5 },
+              },
+              {
+                id: 'profile-construction',
+                name: 'Construction Profile',
+                isDefault: false,
+                isActive: true,
+                practiceAreas: ['Construction Litigation'],
+                matterTypeIds: ['mt-1'],
+                thresholds: { warn: 20, block: 35 },
+                weights: { name: 40, email: 20, phone: 10, matter: 20, relationship: 5 },
+              },
+            ],
+          },
+        }),
+      },
+      contact: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'contact-1',
+            displayName: 'Jane Doe',
+            primaryEmail: 'jane@example.com',
+            primaryPhone: '555-101-0000',
+          },
+        ]),
+      },
+      matter: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      contactRelationship: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      conflictCheckResult: {
+        create: jest.fn().mockImplementation(async ({ data }) => ({ id: 'check-1', ...data })),
+      },
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new AdminService(prisma, audit);
+
+    const check = await service.runConflictCheck({
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      queryText: 'Jane Doe',
+      practiceArea: 'Construction Litigation',
+      matterTypeId: 'mt-1',
+    });
+
+    expect(prisma.conflictCheckResult.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          resultJson: expect.objectContaining({
+            profile: expect.objectContaining({ id: 'profile-construction' }),
+            recommendation: 'BLOCK',
+          }),
+        }),
+      }),
+    );
+    expect(check).toEqual(expect.objectContaining({ id: 'check-1' }));
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'conflict_check.executed',
+        metadata: expect.objectContaining({
+          profileId: 'profile-construction',
+          recommendation: 'BLOCK',
+        }),
+      }),
+    );
+  });
+
+  it('rejects explicit selection of inactive conflict profile', async () => {
+    const prisma = {
+      organization: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'org-1',
+          settingsJson: {
+            conflictRuleProfiles: [
+              {
+                id: 'profile-inactive',
+                name: 'Inactive Profile',
+                isDefault: true,
+                isActive: false,
+                thresholds: { warn: 45, block: 70 },
+                weights: { name: 40, email: 35, phone: 30, matter: 30, relationship: 15 },
+              },
+            ],
+          },
+        }),
+      },
+    } as any;
+    const service = new AdminService(prisma, { appendEvent: jest.fn().mockResolvedValue(undefined) } as any);
+
+    await expect(
+      service.runConflictCheck({
+        organizationId: 'org-1',
+        actorUserId: 'user-1',
+        queryText: 'Jane Doe',
+        profileId: 'profile-inactive',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-18T21:44:31.380Z`
+- Snapshot Timestamp: `2026-02-18T21:57:20.704Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-18T21:44:29.610Z`
+- Last Successful Mirror Verify: `2026-02-18T21:57:19.133Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -82,6 +82,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-18: Verified `REQ-MAT-004` by hardening conflict profile update semantics (partial updates now preserve existing scope/weights/thresholds/default flags), adding deterministic default reassignment when a default profile is deactivated, and enforcing scoped-profile selection precedence so the most specific active match is selected for checks (`apps/api/test/admin-conflict-verification.spec.ts`, `docs/parity/conflict-rule-profiles.md`).
 - 2026-02-18: Verified `REQ-COMM-004` by hardening disposition execution to re-check legal holds at execution time (disposing only eligible documents, skipping newly-held documents, reverting skipped docs to `ACTIVE`, and recording `skippedForLegalHoldAtExecution` audit metadata), with new regression coverage in `apps/api/test/document-retention-verification.spec.ts` and parity evidence in `docs/parity/document-retention-workflows.md`.
 - 2026-02-18: Verified `REQ-BILL-004` by adding LEDES verification-hardening coverage for default-profile rotation (`isDefault` swap), explicit invoice-id export integrity (dedupe + missing-id rejection), and `includeExpenseLineItems=false` line filtering conformance, with parity evidence in `docs/parity/ledes-export-workflows.md` (`apps/api/test/billing-ledes-verification.spec.ts`).
 - 2026-02-18: Verified `REQ-BILL-003` by hardening trust reconciliation service invariants (resolution status restricted to `RESOLVED|WAIVED`, non-open discrepancies cannot be re-resolved), plus regression coverage for negative-balance discrepancy reason codes, draft->in-review note append behavior, and resolution guardrails (`apps/api/test/billing-trust-reconciliation-verification.spec.ts`, `docs/parity/trust-reconciliation-workflows.md`).

--- a/docs/parity/conflict-rule-profiles.md
+++ b/docs/parity/conflict-rule-profiles.md
@@ -42,10 +42,18 @@ Scope: profile-based conflict checks with weighted scoring, recommendation outpu
 
 - API regression coverage:
   - `apps/api/test/admin.spec.ts`
+  - `apps/api/test/admin-conflict-verification.spec.ts`
   - verifies:
     - profile upsert in organization settings
     - conflict check execution with scoring flow
     - resolution with rationale and audit event
+    - partial profile updates preserve existing scope/weights/thresholds/default flags
+    - default profile fallback re-assignment when deactivating prior default
+    - scoped profile selection precedence (most specific active match wins over global default)
 - Full-suite validation:
   - `pnpm test`
   - `pnpm build`
+
+## Verification Command
+
+- `pnpm --filter api test -- admin-conflict-verification.spec.ts admin.spec.ts`

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -332,11 +332,11 @@
           "title": "Implement advanced conflict rule profiles and resolution workflows",
           "requirementId": "REQ-MAT-004",
           "promptSection": "CRM / ConflictCheckResult + advanced conflict rule profiles",
-          "parityStatus": "Complete",
+          "parityStatus": "Verified",
           "component": "API",
           "risk": "Medium",
           "labels": ["parity", "matters", "security", "phase-2"],
-          "problemStatement": "Conflict profile configuration, weighted scoring checks, recommendation output, and attorney resolution audit workflow are now implemented across admin API + UI.",
+          "problemStatement": "Conflict profile workflows are verification-hardened with safe partial-update merge semantics and scoped profile selection precedence (specific active scope beats global default).",
           "requirementExcerpt": "Advanced conflict rules should support profile-based matching, relationship-aware scoring, and logged attorney override decisions.",
           "acceptanceCriteria": [
             "Create conflict rule profiles with weighted match criteria and scope by practice area/matter type.",
@@ -346,7 +346,8 @@
           "apiImpact": "Added admin conflict rule profile CRUD, conflict check execution/list, and resolution endpoints with result payload scoring and resolution history fields.",
           "securityImpact": "Reduces conflict-of-interest risk and improves defensible compliance records.",
           "definitionOfDone": [
-            "Advanced conflict profile CRUD, scoring checks, and resolution audit tests are passing with evidence in docs/parity/conflict-rule-profiles.md."
+            "Advanced conflict profile CRUD, scoring checks, and resolution audit tests are passing with evidence in docs/parity/conflict-rule-profiles.md.",
+            "Profile updates preserve unspecified scope/threshold/weight/default fields and conflict checks choose the most specific active scoped profile."
           ]
         },
         {

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-18T21:44:31.380Z",
+  "generatedAt": "2026-02-18T21:57:20.704Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -14,36 +14,27 @@
   },
   "matrixSummary": {
     "totalRequirements": 34,
-    "unresolvedRequirements": 2,
+    "unresolvedRequirements": 1,
     "totalCountsByPhase": {
       "phase-1": 29,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {
-      "phase-2": 2
+      "phase-2": 1
     },
     "unresolvedCountsByStatus": {
-      "Complete": 2
+      "Complete": 1
     },
     "unresolvedCountsByRisk": {
-      "Medium": 2
+      "Medium": 1
     },
     "unresolvedCountsByStatusAndRisk": {
-      "Complete:Medium": 2
+      "Complete:Medium": 1
     }
   },
   "priority": {
     "algorithm": "phase-1 before phase-2, then Missing -> Partial -> Complete (each ordered by risk High -> Medium -> Low)",
     "topRequirements": [
-      {
-        "requirementId": "REQ-MAT-004",
-        "parityStatus": "Complete",
-        "risk": "Medium",
-        "title": "Implement advanced conflict rule profiles and resolution workflows",
-        "component": "API",
-        "epicCode": "PARITY-04",
-        "phase": "phase-2"
-      },
       {
         "requirementId": "REQ-MAT-005",
         "parityStatus": "Complete",
@@ -66,6 +57,13 @@
     "inProgressIssueKeys": [],
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
+      {
+        "key": "KAR-46",
+        "title": "Implement document retention policies with legal hold workflow",
+        "state": "Done",
+        "updatedAt": "2026-02-18T21:48:53.396Z",
+        "requirementId": "REQ-COMM-004"
+      },
       {
         "key": "KAR-48",
         "title": "Implement LEDES/UTBMS export jobs with validation profiles",
@@ -128,31 +126,24 @@
         "state": "Done",
         "updatedAt": "2026-02-18T20:16:45.391Z",
         "requirementId": "REQ-PORT-004"
-      },
-      {
-        "key": "KAR-30",
-        "title": "Implement secure portal attachments in message workflow",
-        "state": "Done",
-        "updatedAt": "2026-02-18T20:03:28.782Z",
-        "requirementId": "REQ-PORTAL-001"
       }
     ]
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:44:29.610Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-18T21:57:19.133Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "d7f18f6f324dc7e3ca8f69dbf6b564b3d5af38dc",
+    "gitHead": "4f27524f0da2e441f01ab703f3182d3a776a93fe",
     "gitStatusShort": [
-      "## lin/KAR-49-comm-004-verification-hardening",
-      " M apps/api/src/documents/documents.service.ts",
+      "## lin/KAR-44-mat-004-verification-hardening",
+      " M apps/api/src/admin/admin.service.ts",
       " M docs/SESSION_HANDOFF.md",
-      " M docs/parity/document-retention-workflows.md",
+      " M docs/parity/conflict-rule-profiles.md",
       " M tools/backlog-sync/requirements.matrix.json",
       " M tools/backlog-sync/session.snapshot.json",
       "?? agents.md",
-      "?? apps/api/test/document-retention-verification.spec.ts",
+      "?? apps/api/test/admin-conflict-verification.spec.ts",
       "?? brand/",
       "?? uirefactorprompt.md"
     ],


### PR DESCRIPTION
## Linear Issue
- KAR-44

## Requirement ID
- REQ-MAT-004

## Summary
- preserve existing conflict profile fields on partial profile updates
- enforce default reassignment when default profile is deactivated
- select most specific active scoped profile over global defaults for conflict checks
- add dedicated verification suite and parity evidence updates

## Validation
- pnpm --filter api test -- admin-conflict-verification.spec.ts admin.spec.ts
- pnpm test
- pnpm build
