### PR TITLE
[KAR-59] Refresh snapshot and handoff after issue closure

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-19T16:53:37.851Z`
+- Snapshot Timestamp: `2026-02-19T16:58:14.053Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-19T16:53:35.594Z`
+- Last Successful Mirror Verify: `2026-02-19T16:58:11.749Z`
 
 ## Canonical Context Routing (Linear-First)
 

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-19T16:53:37.851Z",
+  "generatedAt": "2026-02-19T16:58:14.053Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -114,32 +114,21 @@
   "uiLaneSummary": {
     "label": "ui-ux",
     "issueCount": 7,
-    "openIssueCount": 1,
+    "openIssueCount": 0,
     "stateCounts": {
-      "Done": 6,
-      "In Review": 1
+      "Done": 7
     },
-    "openIssueKeys": [
-      "KAR-59"
-    ],
-    "openIssues": [
-      {
-        "key": "KAR-59",
-        "title": "Define and apply responsive behavior matrix under Brand Identity constraints",
-        "state": "In Review",
-        "requirementId": "REQ-UI-006",
-        "updatedAt": "2026-02-19T16:53:15.904Z"
-      }
-    ]
+    "openIssueKeys": [],
+    "openIssues": []
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-19T16:53:35.594Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-19T16:58:11.749Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "f59ca778f815c2ad541d2dc8a1b34b13c859b9b0",
+    "gitHead": "af3cee5929b6705ae3cf7c96912a7e4750d00c83",
     "gitStatusShort": [
-      "## lin/KAR-59-responsive-behavior-matrix...origin/lin/KAR-59-responsive-behavior-matrix"
+      "## main...origin/main"
     ],
     "dirtyFileCount": 0
   }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-59
- URL: https://linear.app/karenap/issue/KAR-59/define-and-apply-responsive-behavior-matrix-under-brand-identity-constraints

## Requirement ID
- REQ-UI-006

## Summary
- Refreshes `tools/backlog-sync/session.snapshot.json` and `docs/SESSION_HANDOFF.md` after `KAR-59` was merged and moved to `Done` in Linear.
- Keeps the new-chat continuity artifacts aligned with current Linear state (`uiLaneSummary` now shows all UI lane items done).

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm backlog:sync`
  - `pnpm backlog:verify`
  - `pnpm backlog:snapshot`
  - `pnpm backlog:handoff:check`
- Output summary:
  - All commands passed.

## Notes
- Housekeeping-only PR; no runtime/API code changes.
