### PR TITLE
[KAR-64] Refresh post-merge snapshot and handoff

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-19T18:02:01.491Z`
+- Snapshot Timestamp: `2026-02-19T18:06:44.636Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-19T18:01:59.708Z`
+- Last Successful Mirror Verify: `2026-02-19T18:06:40.972Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -89,7 +89,7 @@ For each requirement slice:
 
 ## Delta Log
 
-- 2026-02-19: Started `KAR-64` / `REQ-PMS-CORE-002` by adding matter-dashboard participant operations: API endpoints for participant role-option listing and scoped participant removal (`GET /matters/:id/participant-roles`, `DELETE /matters/:id/participants/:participantId`) with audit logging, plus web add/remove participant controls and regression coverage in `apps/api/test/matters.spec.ts` and `apps/web/test/matter-dashboard-page.spec.tsx`; validation passed via `pnpm --filter api test -- test/matters.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, and `pnpm build`.
+- 2026-02-19: Completed `KAR-64` / `REQ-PMS-CORE-002` by adding matter-dashboard participant operations: API endpoints for participant role-option listing and scoped participant removal (`GET /matters/:id/participant-roles`, `DELETE /matters/:id/participants/:participantId`) with audit logging, plus web add/remove participant controls and regression coverage in `apps/api/test/matters.spec.ts` and `apps/web/test/matter-dashboard-page.spec.tsx`; validation passed via `pnpm --filter api test -- test/matters.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, and `pnpm build`, and the slice merged via PR `#133`.
 - 2026-02-19: Completed `KAR-63` / `REQ-PMS-CORE-001` by adding core matter-dashboard operations for day-to-day practice management: task creation with due datetime + priority, inline task status updates (new API endpoint `PATCH /tasks/:id` with matter-access checks + `task.updated` audit events), and calendar event creation from matter context, with regression coverage in `apps/api/test/tasks.spec.ts` and `apps/web/test/matter-dashboard-page.spec.tsx`.
 - 2026-02-19: Implemented `KAR-59` / `REQ-UI-006` responsive matrix compliance by adding deterministic app-shell viewport modes (`desktop`, `compact`, `tablet`, `unsupported`) in `apps/web/components/app-shell.tsx`, aligning shell/table/touch-target behavior to Brand Identity breakpoints in `apps/web/app/globals.css` (including unsupported `<768px` notice copy), adding responsive regression coverage (`apps/web/test/app-shell-responsive.spec.tsx`), extending regression lane script coverage (`apps/web/package.json`), and documenting verification evidence in `docs/parity/ui-responsive-behavior-verification.md`.
 - 2026-02-19: Implemented `KAR-57` / `REQ-UI-004` primitive-system uplift by introducing canonical shared primitives in `apps/web/components/ui/` (`Button`, `Input`, `Select`, `Badge`, `Table`, `Card`, `Drawer`, `Modal`, `Toast`), integrating primitives into representative workflow routes (`apps/web/app/contacts/page.tsx`, `apps/web/app/communications/page.tsx`) and review/toast surfaces (`apps/web/components/confirm-dialog.tsx`, `apps/web/components/toast-stack.tsx`), adding primitive regression coverage (`apps/web/test/ui-primitives.spec.tsx`), and documenting parity evidence (`docs/parity/ui-primitives-state-verification.md`).

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-19T18:02:01.491Z",
+  "generatedAt": "2026-02-19T18:06:44.636Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -33,8 +33,7 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 50,
     "stateCounts": {
-      "In Review": 1,
-      "Done": 39,
+      "Done": 40,
       "Backlog": 10
     },
     "inProgressIssueKeys": [],
@@ -43,8 +42,8 @@
       {
         "key": "KAR-64",
         "title": "Implement matter dashboard participant add/remove operations",
-        "state": "In Review",
-        "updatedAt": "2026-02-19T18:01:44.510Z",
+        "state": "Done",
+        "updatedAt": "2026-02-19T18:05:32.518Z",
         "requirementId": "REQ-PMS-CORE-002"
       },
       {
@@ -123,14 +122,15 @@
     "openIssues": []
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-19T18:01:59.708Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-19T18:06:40.972Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "8f66c5ee8c8315809ac4fdeced031281ef66cba8",
+    "gitHead": "fd3f484cce72528b6684830f85e4e09c067594d4",
     "gitStatusShort": [
-      "## lin/KAR-64-matter-dashboard-participant-ops...origin/lin/KAR-64-matter-dashboard-participant-ops"
+      "## main...origin/main",
+      " M docs/SESSION_HANDOFF.md"
     ],
-    "dirtyFileCount": 0
+    "dirtyFileCount": 1
   }
 }


### PR DESCRIPTION
## Summary
- refresh session snapshot after KAR-64 moved to Done
- update session handoff timestamps and KAR-64 delta wording to completed status

## Linear Issue
- KAR-64
- https://linear.app/karenap/issue/KAR-64/implement-matter-dashboard-participant-addremove-operations

## Requirement ID
- REQ-PMS-CORE-002

## Acceptance Criteria Checklist
- [x] Snapshot regenerated after closure state transition
- [x] Handoff timestamp aligned with latest snapshot + verify state
- [x] Handoff delta log reflects KAR-64 completion

## Test Evidence
- `pnpm backlog:sync`
- `pnpm backlog:verify`
- `pnpm backlog:snapshot`
- `pnpm backlog:handoff:check`
