### PR TITLE
[KAR-67] Refresh post-merge snapshot + handoff metadata

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-19T19:21:50.497Z`
+- Snapshot Timestamp: `2026-02-19T19:27:08.943Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-19T19:21:47.653Z`
+- Last Successful Mirror Verify: `2026-02-19T19:27:07.300Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -89,6 +89,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-19: Completed `KAR-67` / `REQ-PMS-CORE-005`; PR `#142` merged on `main`, Linear moved to `Done`, and mirror/snapshot metadata refreshed (`pnpm backlog:sync`, `pnpm backlog:verify`, `pnpm backlog:snapshot`, `pnpm backlog:handoff:check`).
 - 2026-02-19: Advanced `KAR-67` / `REQ-PMS-CORE-005` by completing matter-dashboard task + calendar lifecycle operations: added task delete endpoint/service audit path (`DELETE /tasks/:id`), calendar event update/delete endpoints with matter-scoped write enforcement and audit events (`PATCH /calendar/events/:id`, `DELETE /calendar/events/:id`), upgraded dashboard workflow to support task/event edit-cancel-delete UX with tabular actions (`apps/web/app/matters/[id]/page.tsx`), expanded regression coverage (`apps/api/test/tasks.spec.ts`, `apps/api/test/calendar-events.spec.ts`, `apps/web/test/matter-dashboard-page.spec.tsx`), and published parity evidence at `docs/parity/matter-dashboard-task-calendar-lifecycle.md`; validation passed via `pnpm --filter api test -- test/tasks.spec.ts test/calendar-events.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, `pnpm build`, `pnpm backlog:sync`, `pnpm backlog:verify`, and `pnpm backlog:snapshot`.
 - 2026-02-19: Completed `KAR-66` / `REQ-PMS-CORE-004` by adding matter-scoped communication update/delete operations (`PATCH /matters/:id/communications/:messageId`, `DELETE /matters/:id/communications/:messageId`) with strict matter/thread tenancy checks, participant remap handling, and audit events (`matter.communication.updated`, `matter.communication.deleted`) in `apps/api/src/matters/matters.service.ts` + `apps/api/src/matters/matters.controller.ts`; upgraded dashboard communications workflow to support inline edit/cancel/delete actions with participant mapping and row-level status feedback (`apps/web/app/matters/[id]/page.tsx`), and expanded lifecycle regression coverage in `apps/api/test/matters.spec.ts` and `apps/web/test/matter-dashboard-page.spec.tsx`; validation passed via `pnpm --filter api test -- test/matters.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, `pnpm build`, `pnpm backlog:sync`, `pnpm backlog:verify`, and `pnpm backlog:snapshot`, and the slice merged via PR `#139`.
 - 2026-02-19: Completed `KAR-65` / `REQ-PMS-CORE-003` by implementing matter-dashboard communication logging operations: new matter-scoped endpoint (`POST /matters/:id/communications/log`) with tenant + matter write enforcement, scoped-thread validation/new-thread creation, optional participant linkage, and `matter.communication.logged` audit events (`apps/api/src/matters/matters.service.ts`, `apps/api/src/matters/matters.controller.ts`, `apps/api/src/matters/dto/log-communication-entry.dto.ts`), plus dashboard in-context communication controls + tabular log view (`apps/web/app/matters/[id]/page.tsx`) and regression coverage (`apps/api/test/matters.spec.ts`, `apps/web/test/matter-dashboard-page.spec.tsx`); validation passed via `pnpm --filter api test -- test/matters.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, `pnpm build`, `pnpm backlog:sync`, `pnpm backlog:verify`, `pnpm backlog:snapshot`, and the slice merged via PR `#136`.

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-19T19:21:50.497Z",
+  "generatedAt": "2026-02-19T19:27:08.943Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -33,8 +33,7 @@
     "scopeLabel": "parity",
     "scopedIssueCount": 53,
     "stateCounts": {
-      "In Review": 1,
-      "Done": 42,
+      "Done": 43,
       "Backlog": 10
     },
     "inProgressIssueKeys": [],
@@ -43,8 +42,8 @@
       {
         "key": "KAR-67",
         "title": "Complete matter dashboard task and calendar lifecycle operations",
-        "state": "In Review",
-        "updatedAt": "2026-02-19T19:21:29.309Z",
+        "state": "Done",
+        "updatedAt": "2026-02-19T19:26:37.813Z",
         "requirementId": "REQ-PMS-CORE-005"
       },
       {
@@ -123,13 +122,13 @@
     "openIssues": []
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-19T19:21:47.653Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-19T19:27:07.300Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "6f1ddd3cf09f4b3644f2030d2af9d8721fb102f2",
+    "gitHead": "095f4f8831772ef9778fbf8b3808ab6c2d9c52fa",
     "gitStatusShort": [
-      "## lin/KAR-67-task-calendar-lifecycle-ops...origin/lin/KAR-67-task-calendar-lifecycle-ops"
+      "## lin/KAR-67-post-merge-snapshot-refresh"
     ],
     "dirtyFileCount": 0
   }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-67
- Requirement ID: REQ-PMS-CORE-005

## Summary
- refresh mirrored backlog state after KAR-67 merge and Linear transition to Done
- update session snapshot and handoff metadata timestamps
- add explicit handoff delta note for KAR-67 merge completion

## Verification Evidence
- pnpm backlog:sync
- pnpm backlog:verify
- pnpm backlog:snapshot
- pnpm backlog:handoff:check
