### PR TITLE
[KAR-67] Refresh housekeeping snapshot metadata

### DIFF
--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-19T19:27:08.943Z`
+- Snapshot Timestamp: `2026-02-19T19:35:25.386Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-19T19:27:07.300Z`
+- Last Successful Mirror Verify: `2026-02-19T19:35:23.547Z`
 
 ## Canonical Context Routing (Linear-First)
 

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-19T19:27:08.943Z",
+  "generatedAt": "2026-02-19T19:35:25.386Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -43,7 +43,7 @@
         "key": "KAR-67",
         "title": "Complete matter dashboard task and calendar lifecycle operations",
         "state": "Done",
-        "updatedAt": "2026-02-19T19:26:37.813Z",
+        "updatedAt": "2026-02-19T19:31:09.467Z",
         "requirementId": "REQ-PMS-CORE-005"
       },
       {
@@ -122,13 +122,13 @@
     "openIssues": []
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-19T19:27:07.300Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-19T19:35:23.547Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "095f4f8831772ef9778fbf8b3808ab6c2d9c52fa",
+    "gitHead": "7cf91c199f03c2fa4e580a4ac5ce27ed7d0cb9e1",
     "gitStatusShort": [
-      "## lin/KAR-67-post-merge-snapshot-refresh"
+      "## main...origin/main"
     ],
     "dirtyFileCount": 0
   }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-67
- Requirement ID: REQ-PMS-CORE-005

## Summary
- run housekeeping sync pipeline (`backlog:sync`, `backlog:verify`, `backlog:snapshot`)
- refresh snapshot timestamp + mirror verify timestamp in `docs/SESSION_HANDOFF.md`
- keep handoff freshness check passing for new-chat continuity

## Verification Evidence
- pnpm backlog:sync
- pnpm backlog:verify
- pnpm backlog:snapshot
- pnpm backlog:handoff:check
