### PR TITLE
[KAR-68] Implement matter dashboard document lifecycle operations

### DIFF
--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  Patch,
   Post,
   Query,
   Redirect,
@@ -18,6 +19,7 @@ import { RequirePermissions } from '../common/decorators/permissions.decorator';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { AuthenticatedUser, UploadedFile as UploadedBinary } from '../common/types';
 import { UploadDocumentDto } from './dto/upload-document.dto';
+import { UpdateDocumentDto } from './dto/update-document.dto';
 import { CreateRetentionPolicyDto } from './dto/create-retention-policy.dto';
 import { AssignRetentionPolicyDto } from './dto/assign-retention-policy.dto';
 import { PlaceLegalHoldDto, ReleaseLegalHoldDto } from './dto/legal-hold.dto';
@@ -70,6 +72,24 @@ export class DocumentsController {
       user,
       documentId: id,
       file,
+    });
+  }
+
+  @UseGuards(SessionAuthGuard, PermissionGuard)
+  @Patch(':id')
+  @RequirePermissions('documents:write')
+  update(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id') id: string,
+    @Body() dto: UpdateDocumentDto,
+  ) {
+    return this.documentsService.updateDocument({
+      user,
+      documentId: id,
+      title: dto.title,
+      category: dto.category,
+      tags: dto.tags,
+      sharedWithClient: dto.sharedWithClient,
     });
   }
 

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -866,7 +866,74 @@ export class DocumentsService {
       },
     });
 
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.version.uploaded',
+      entityType: 'documentVersion',
+      entityId: version.id,
+      metadata: {
+        documentId: document.id,
+        versionId: version.id,
+      },
+    });
+
     return version;
+  }
+
+  async updateDocument(input: {
+    user: AuthenticatedUser;
+    documentId: string;
+    title?: string;
+    category?: string;
+    tags?: string[];
+    sharedWithClient?: boolean;
+  }) {
+    const document = await this.prisma.document.findFirst({
+      where: {
+        id: input.documentId,
+        organizationId: input.user.organizationId,
+      },
+    });
+    if (!document) {
+      throw new NotFoundException('Document not found');
+    }
+    if (document.dispositionStatus === DocumentDispositionStatus.DISPOSED) {
+      throw new UnprocessableEntityException('Disposed documents cannot be modified');
+    }
+
+    await this.access.assertMatterAccess(input.user, document.matterId, 'write');
+
+    const updated = await this.prisma.document.update({
+      where: { id: document.id },
+      data: {
+        title: input.title,
+        category: input.category,
+        tags: input.tags,
+        sharedWithClient: input.sharedWithClient,
+      },
+      include: {
+        versions: {
+          orderBy: { uploadedAt: 'desc' },
+          take: 1,
+        },
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.updated',
+      entityType: 'document',
+      entityId: updated.id,
+      metadata: {
+        title: updated.title,
+        category: updated.category,
+        sharedWithClient: updated.sharedWithClient,
+      },
+    });
+
+    return updated;
   }
 
   async signedDownloadUrl(user: AuthenticatedUser, documentVersionId: string) {
@@ -915,13 +982,26 @@ export class DocumentsService {
     const token = randomUUID();
     const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * (input.expiresInHours ?? 24));
 
-    await this.prisma.documentShareLink.create({
+    const shareLink = await this.prisma.documentShareLink.create({
       data: {
         organizationId: input.user.organizationId,
         documentId: document.id,
         token,
         expiresAt,
         createdByUserId: input.user.id,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'document.share_link.created',
+      entityType: 'documentShareLink',
+      entityId: shareLink.id,
+      metadata: {
+        token,
+        documentId: document.id,
+        expiresAt: expiresAt.toISOString(),
       },
     });
 

--- a/apps/api/src/documents/dto/update-document.dto.ts
+++ b/apps/api/src/documents/dto/update-document.dto.ts
@@ -1,0 +1,20 @@
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class UpdateDocumentDto {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  category?: string;
+
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  tags?: string[];
+
+  @IsBoolean()
+  @IsOptional()
+  sharedWithClient?: boolean;
+}

--- a/apps/api/test/documents.spec.ts
+++ b/apps/api/test/documents.spec.ts
@@ -157,4 +157,150 @@ describe('DocumentsService', () => {
       await fakeClam.close();
     }
   });
+
+  it('uploads a new document version and emits audit event', async () => {
+    const prisma = {
+      document: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          dispositionStatus: 'ACTIVE',
+        }),
+      },
+      documentVersion: {
+        create: jest.fn().mockResolvedValue({
+          id: 'version-2',
+          documentId: 'doc-1',
+        }),
+      },
+    } as any;
+
+    const appendEvent = jest.fn();
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn().mockResolvedValue({ key: 's3/new-version-key' }) } as any,
+      { scan: jest.fn().mockResolvedValue({ clean: true }) } as any,
+      { appendEvent } as any,
+    );
+
+    const version = await service.uploadVersion({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      documentId: 'doc-1',
+      file: {
+        buffer: Buffer.from('new version'),
+        mimetype: 'text/plain',
+        originalname: 'new-version.txt',
+        size: 11,
+      } as any,
+    });
+
+    expect(version.id).toBe('version-2');
+    expect(prisma.documentVersion.create).toHaveBeenCalled();
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.version.uploaded',
+        entityType: 'documentVersion',
+        entityId: 'version-2',
+      }),
+    );
+  });
+
+  it('updates document shared status and emits audit event', async () => {
+    const prisma = {
+      document: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          dispositionStatus: 'ACTIVE',
+        }),
+        update: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          title: 'Inspection Report',
+          category: 'REPORT',
+          tags: ['inspection'],
+          sharedWithClient: true,
+          versions: [],
+        }),
+      },
+    } as any;
+
+    const appendEvent = jest.fn();
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      { appendEvent } as any,
+    );
+
+    const updated = await service.updateDocument({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      documentId: 'doc-1',
+      sharedWithClient: true,
+    });
+
+    expect(updated.sharedWithClient).toBe(true);
+    expect(prisma.document.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'doc-1' },
+        data: expect.objectContaining({
+          sharedWithClient: true,
+        }),
+      }),
+    );
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.updated',
+        entityType: 'document',
+        entityId: 'doc-1',
+      }),
+    );
+  });
+
+  it('creates share link and emits audit event', async () => {
+    const prisma = {
+      document: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          organizationId: 'org-1',
+          matterId: 'matter-1',
+          dispositionStatus: 'ACTIVE',
+        }),
+      },
+      documentShareLink: {
+        create: jest.fn().mockResolvedValue({
+          id: 'share-1',
+          token: 'token-1',
+        }),
+      },
+    } as any;
+
+    const appendEvent = jest.fn();
+    const service = new DocumentsService(
+      prisma,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+      { upload: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      { appendEvent } as any,
+    );
+
+    const share = await service.createShareLink({
+      user: { id: 'u1', organizationId: 'org-1' } as any,
+      documentId: 'doc-1',
+      expiresInHours: 1,
+    });
+
+    expect(share.url).toContain('/shared-doc/');
+    expect(prisma.documentShareLink.create).toHaveBeenCalled();
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'document.share_link.created',
+        entityType: 'documentShareLink',
+        entityId: 'share-1',
+      }),
+    );
+  });
 });

--- a/apps/web/app/matters/[id]/page.tsx
+++ b/apps/web/app/matters/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { AppShell } from '../../../components/app-shell';
 import { PageHeader } from '../../../components/page-header';
-import { apiFetch } from '../../../lib/api';
+import { apiFetch, getSessionToken } from '../../../lib/api';
 
 type DeadlinePreviewRow = {
   ruleId: string;
@@ -52,6 +52,7 @@ const TASK_STATUS_OPTIONS = ['TODO', 'IN_PROGRESS', 'BLOCKED', 'DONE', 'CANCELED
 const TASK_PRIORITY_OPTIONS = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'] as const;
 const COMMUNICATION_TYPE_OPTIONS = ['EMAIL', 'SMS', 'CALL_LOG', 'PORTAL_MESSAGE', 'INTERNAL_NOTE'] as const;
 const COMMUNICATION_DIRECTION_OPTIONS = ['INBOUND', 'OUTBOUND', 'INTERNAL'] as const;
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 
 function toDateTimeLocalValue(value?: string | null) {
   if (!value) {
@@ -103,6 +104,10 @@ export default function MatterDashboardPage() {
   const [communicationOccurredAt, setCommunicationOccurredAt] = useState(new Date().toISOString().slice(0, 16));
   const [communicationStatusMessage, setCommunicationStatusMessage] = useState<string | null>(null);
   const [editingCommunicationId, setEditingCommunicationId] = useState<string | null>(null);
+  const [documentTitle, setDocumentTitle] = useState('Matter Document');
+  const [documentFile, setDocumentFile] = useState<File | null>(null);
+  const [documentVersionFiles, setDocumentVersionFiles] = useState<Record<string, File | null>>({});
+  const [documentStatusMessage, setDocumentStatusMessage] = useState<string | null>(null);
 
   async function refreshDashboard() {
     if (!matterId) {
@@ -499,6 +504,87 @@ export default function MatterDashboardPage() {
 
     setCommunicationStatusMessage('Communication entry removed.');
     await refreshDashboard();
+  }
+
+  async function uploadDocumentForm(path: string, formData: FormData) {
+    const token = getSessionToken();
+    const response = await fetch(`${API_BASE}${path}`, {
+      method: 'POST',
+      body: formData,
+      headers: token ? { 'x-session-token': token } : undefined,
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`${response.status} ${response.statusText}: ${text}`);
+    }
+    return response.status === 204 ? null : response.json();
+  }
+
+  async function uploadMatterDocument() {
+    if (!matterId || !documentTitle.trim() || !documentFile) {
+      setDocumentStatusMessage('Document title and file are required.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.set('matterId', matterId);
+    formData.set('title', documentTitle.trim());
+    formData.set('file', documentFile);
+
+    await uploadDocumentForm('/documents/upload', formData);
+    setDocumentTitle('Matter Document');
+    setDocumentFile(null);
+    setDocumentStatusMessage('Document uploaded.');
+    await refreshDashboard();
+  }
+
+  async function uploadMatterDocumentVersion(documentId: string) {
+    const file = documentVersionFiles[documentId];
+    if (!file) {
+      setDocumentStatusMessage('Select a version file before uploading.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.set('file', file);
+    await uploadDocumentForm(`/documents/${documentId}/versions`, formData);
+    setDocumentVersionFiles((current) => ({
+      ...current,
+      [documentId]: null,
+    }));
+    setDocumentStatusMessage('Document version uploaded.');
+    await refreshDashboard();
+  }
+
+  async function toggleMatterDocumentSharing(documentId: string, sharedWithClient: boolean) {
+    await apiFetch(`/documents/${documentId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        sharedWithClient: !sharedWithClient,
+      }),
+    });
+    setDocumentStatusMessage(sharedWithClient ? 'Client sharing disabled.' : 'Client sharing enabled.');
+    await refreshDashboard();
+  }
+
+  async function createMatterDocumentShareLink(documentId: string) {
+    const share = await apiFetch<{ url: string; expiresAt: string }>(`/documents/${documentId}/share-link`, {
+      method: 'POST',
+      body: JSON.stringify({
+        expiresInHours: 72,
+      }),
+    });
+    setDocumentStatusMessage(`Share link issued (expires ${new Date(share.expiresAt).toLocaleString()}): ${share.url}`);
+  }
+
+  async function issueLatestDocumentDownload(documentId: string, latestVersionId?: string | null) {
+    if (!latestVersionId) {
+      setDocumentStatusMessage(`No versions available for ${documentId}.`);
+      return;
+    }
+    const download = await apiFetch<{ url: string }>(`/documents/versions/${latestVersionId}/download-url`);
+    setDocumentStatusMessage(`Signed download URL issued: ${download.url}`);
   }
 
   const communicationRows = dashboard
@@ -1079,11 +1165,100 @@ export default function MatterDashboardPage() {
 
           <div className="card">
             <h3 style={{ marginTop: 0 }}>Documents</h3>
-            <ul style={{ margin: 0, paddingLeft: 18 }}>
-              {dashboard.documents?.map((doc: any) => (
-                <li key={doc.id}>{doc.title}</li>
-              ))}
-            </ul>
+            <div style={{ display: 'grid', gap: 8, gridTemplateColumns: '1fr 1fr auto' }}>
+              <input
+                className="input"
+                aria-label="Matter Document Title"
+                placeholder="Document title"
+                value={documentTitle}
+                onChange={(event) => setDocumentTitle(event.target.value)}
+              />
+              <input
+                className="input"
+                aria-label="Matter Document File"
+                type="file"
+                onChange={(event) => setDocumentFile(event.target.files?.[0] || null)}
+              />
+              <button className="button" type="button" onClick={uploadMatterDocument}>
+                Upload Document
+              </button>
+            </div>
+            {documentStatusMessage ? (
+              <p style={{ marginTop: 8, color: 'var(--lic-text-muted)' }}>{documentStatusMessage}</p>
+            ) : null}
+            <table className="table" style={{ marginTop: 10 }}>
+              <thead>
+                <tr>
+                  <th>Title</th>
+                  <th>Versions</th>
+                  <th>Shared</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(dashboard.documents || []).map((doc: any) => (
+                  <tr key={doc.id}>
+                    <td>{doc.title}</td>
+                    <td>{doc.versions?.length || 0}</td>
+                    <td>{doc.sharedWithClient ? 'Yes' : 'No'}</td>
+                    <td>
+                      <div style={{ display: 'grid', gap: 8 }}>
+                        <input
+                          className="input"
+                          aria-label={`Document Version File ${doc.id}`}
+                          type="file"
+                          onChange={(event) =>
+                            setDocumentVersionFiles((current) => ({
+                              ...current,
+                              [doc.id]: event.target.files?.[0] || null,
+                            }))
+                          }
+                        />
+                        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                          <button
+                            className="button secondary"
+                            type="button"
+                            aria-label={`Upload Document Version ${doc.id}`}
+                            onClick={() => uploadMatterDocumentVersion(doc.id)}
+                          >
+                            Upload Version
+                          </button>
+                          <button
+                            className="button secondary"
+                            type="button"
+                            aria-label={`Toggle Document Sharing ${doc.id}`}
+                            onClick={() => toggleMatterDocumentSharing(doc.id, Boolean(doc.sharedWithClient))}
+                          >
+                            {doc.sharedWithClient ? 'Disable Sharing' : 'Enable Sharing'}
+                          </button>
+                          <button
+                            className="button secondary"
+                            type="button"
+                            aria-label={`Create Document Share Link ${doc.id}`}
+                            onClick={() => createMatterDocumentShareLink(doc.id)}
+                          >
+                            Create Share Link
+                          </button>
+                          <button
+                            className="button secondary"
+                            type="button"
+                            aria-label={`Issue Document Download URL ${doc.id}`}
+                            onClick={() => issueLatestDocumentDownload(doc.id, doc.versions?.[0]?.id || null)}
+                          >
+                            Download Latest
+                          </button>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {(dashboard.documents || []).length === 0 ? (
+                  <tr>
+                    <td colSpan={4}>No documents for this matter yet.</td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
           </div>
 
           <div className="card">

--- a/apps/web/test/matter-dashboard-page.spec.tsx
+++ b/apps/web/test/matter-dashboard-page.spec.tsx
@@ -43,6 +43,12 @@ function createDashboardState() {
         occurredAt: string;
       }>;
     }>,
+    documents: [] as Array<{
+      id: string;
+      title: string;
+      sharedWithClient: boolean;
+      versions: Array<{ id: string }>;
+    }>,
   };
 }
 
@@ -62,7 +68,7 @@ function buildDashboardFixture(
     tasks: state.tasks,
     calendarEvents: state.calendarEvents,
     communicationThreads: state.communicationThreads,
-    documents: [],
+    documents: state.documents,
     invoices: [],
     aiJobs: [],
     domainSectionCompleteness: { completedCount: 0, totalCount: 0, completionPercent: 0, sections: {} },
@@ -416,6 +422,141 @@ describe('MatterDashboardPage operational workflows', () => {
       );
       expect(screen.getByText('Participant removed.')).toBeInTheDocument();
       expect(screen.queryByRole('cell', { name: 'Taylor Expert' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('manages document lifecycle actions in matter dashboard context', async () => {
+    vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
+
+    const state = createDashboardState();
+    state.documents.push({
+      id: 'doc-1',
+      title: 'Inspection Report',
+      sharedWithClient: false,
+      versions: [{ id: 'version-1' }],
+    });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.endsWith('/matters/matter-1/dashboard') && method === 'GET') {
+        return jsonResponse(buildDashboardFixture(state));
+      }
+      if (url.endsWith('/calendar/rules-packs') && method === 'GET') {
+        return jsonResponse([{ id: 'pack-1', name: 'CA Superior Civil v1', pack: { version: '1.0' } }]);
+      }
+      if (url.endsWith('/contacts') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/matters/matter-1/participant-roles') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/documents/upload') && method === 'POST') {
+        const formData = init?.body as FormData;
+        const title = String(formData.get('title') || 'Matter Document');
+        state.documents.unshift({
+          id: `doc-${state.documents.length + 1}`,
+          title,
+          sharedWithClient: false,
+          versions: [{ id: `version-${state.documents.length + 1}` }],
+        });
+        return jsonResponse({ document: { id: state.documents[0].id } });
+      }
+      if (url.endsWith('/documents/doc-1/versions') && method === 'POST') {
+        const document = state.documents.find((doc) => doc.id === 'doc-1');
+        if (document) {
+          document.versions.unshift({ id: 'version-2' });
+        }
+        return jsonResponse({ id: 'version-2' });
+      }
+      if (url.endsWith('/documents/doc-1') && method === 'PATCH') {
+        const payload = JSON.parse(String(init?.body || '{}'));
+        const document = state.documents.find((doc) => doc.id === 'doc-1');
+        if (document && typeof payload.sharedWithClient === 'boolean') {
+          document.sharedWithClient = payload.sharedWithClient;
+        }
+        return jsonResponse({ id: 'doc-1', sharedWithClient: payload.sharedWithClient });
+      }
+      if (url.endsWith('/documents/doc-1/share-link') && method === 'POST') {
+        return jsonResponse({
+          url: 'http://localhost:3000/shared-doc/share-token-1',
+          expiresAt: '2026-03-09T12:00:00.000Z',
+        });
+      }
+      if (url.endsWith('/documents/versions/version-2/download-url') && method === 'GET') {
+        return jsonResponse({
+          url: 'http://localhost:9000/download/version-2',
+        });
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<MatterDashboardPage />);
+
+    await screen.findByText('M-100 - Doe v. Builder');
+    await screen.findByRole('cell', { name: 'Inspection Report' });
+
+    fireEvent.change(screen.getByLabelText('Matter Document Title'), { target: { value: 'Uploaded Scope Photo' } });
+    fireEvent.change(screen.getByLabelText('Matter Document File'), {
+      target: { files: [new File(['scope photo'], 'scope-photo.txt', { type: 'text/plain' })] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Upload Document' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/upload',
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      );
+      expect(screen.getByText('Document uploaded.')).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: 'Uploaded Scope Photo' })).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Document Version File doc-1'), {
+      target: { files: [new File(['v2'], 'inspection-v2.txt', { type: 'text/plain' })] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Upload Document Version doc-1' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/doc-1/versions',
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      );
+      expect(screen.getByText('Document version uploaded.')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle Document Sharing doc-1' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/doc-1',
+        expect.objectContaining({ method: 'PATCH', credentials: 'include' }),
+      );
+      expect(screen.getByText('Client sharing enabled.')).toBeInTheDocument();
+      expect(screen.getByRole('cell', { name: 'Yes' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Document Share Link doc-1' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/doc-1/share-link',
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      );
+      expect(screen.getByText(/Share link issued/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Issue Document Download URL doc-1' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/documents/versions/version-2/download-url',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+      expect(screen.getByText(/Signed download URL issued/)).toBeInTheDocument();
     });
   });
 

--- a/docs/SESSION_HANDOFF.md
+++ b/docs/SESSION_HANDOFF.md
@@ -5,9 +5,9 @@ This document is the persistent handoff layer for new chats. Linear is canonical
 ## Snapshot Metadata
 
 - Snapshot File: `tools/backlog-sync/session.snapshot.json`
-- Snapshot Timestamp: `2026-02-19T19:35:25.386Z`
+- Snapshot Timestamp: `2026-02-19T22:48:01.876Z`
 - Snapshot Schema Version: `1.1.0`
-- Last Successful Mirror Verify: `2026-02-19T19:35:23.547Z`
+- Last Successful Mirror Verify: `2026-02-19T22:48:00.419Z`
 
 ## Canonical Context Routing (Linear-First)
 
@@ -89,6 +89,7 @@ For each requirement slice:
 
 ## Delta Log
 
+- 2026-02-19: Advanced `KAR-68` / `REQ-PMS-CORE-006` to `In Review` by implementing matter-dashboard document lifecycle operations: added document metadata update endpoint (`PATCH /documents/:id`) with matter-scoped write enforcement, expanded document audit coverage for version upload/share-link creation (`document.version.uploaded`, `document.share_link.created`, `document.updated`), upgraded dashboard documents panel with in-context upload/version/share/download controls and client-sharing toggle (`apps/web/app/matters/[id]/page.tsx`), added API/Web regression coverage (`apps/api/test/documents.spec.ts`, `apps/web/test/matter-dashboard-page.spec.tsx`), and published parity evidence at `docs/parity/matter-dashboard-document-lifecycle.md`; validation passed via `pnpm --filter api test -- test/documents.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, `pnpm build`, `pnpm backlog:sync`, `pnpm backlog:verify`, and `pnpm backlog:snapshot`.
 - 2026-02-19: Completed `KAR-67` / `REQ-PMS-CORE-005`; PR `#142` merged on `main`, Linear moved to `Done`, and mirror/snapshot metadata refreshed (`pnpm backlog:sync`, `pnpm backlog:verify`, `pnpm backlog:snapshot`, `pnpm backlog:handoff:check`).
 - 2026-02-19: Advanced `KAR-67` / `REQ-PMS-CORE-005` by completing matter-dashboard task + calendar lifecycle operations: added task delete endpoint/service audit path (`DELETE /tasks/:id`), calendar event update/delete endpoints with matter-scoped write enforcement and audit events (`PATCH /calendar/events/:id`, `DELETE /calendar/events/:id`), upgraded dashboard workflow to support task/event edit-cancel-delete UX with tabular actions (`apps/web/app/matters/[id]/page.tsx`), expanded regression coverage (`apps/api/test/tasks.spec.ts`, `apps/api/test/calendar-events.spec.ts`, `apps/web/test/matter-dashboard-page.spec.tsx`), and published parity evidence at `docs/parity/matter-dashboard-task-calendar-lifecycle.md`; validation passed via `pnpm --filter api test -- test/tasks.spec.ts test/calendar-events.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, `pnpm build`, `pnpm backlog:sync`, `pnpm backlog:verify`, and `pnpm backlog:snapshot`.
 - 2026-02-19: Completed `KAR-66` / `REQ-PMS-CORE-004` by adding matter-scoped communication update/delete operations (`PATCH /matters/:id/communications/:messageId`, `DELETE /matters/:id/communications/:messageId`) with strict matter/thread tenancy checks, participant remap handling, and audit events (`matter.communication.updated`, `matter.communication.deleted`) in `apps/api/src/matters/matters.service.ts` + `apps/api/src/matters/matters.controller.ts`; upgraded dashboard communications workflow to support inline edit/cancel/delete actions with participant mapping and row-level status feedback (`apps/web/app/matters/[id]/page.tsx`), and expanded lifecycle regression coverage in `apps/api/test/matters.spec.ts` and `apps/web/test/matter-dashboard-page.spec.tsx`; validation passed via `pnpm --filter api test -- test/matters.spec.ts`, `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`, `pnpm test`, `pnpm build`, `pnpm backlog:sync`, `pnpm backlog:verify`, and `pnpm backlog:snapshot`, and the slice merged via PR `#139`.

--- a/docs/parity/matter-dashboard-document-lifecycle.md
+++ b/docs/parity/matter-dashboard-document-lifecycle.md
@@ -1,0 +1,42 @@
+# Matter Dashboard Document Lifecycle Verification
+
+Requirement: `REQ-PMS-CORE-006`  
+Scope: verify matter-dashboard document lifecycle operations (upload, version upload, client sharing toggle, share-link issuance, signed-download issuance) with matter-scoped access and audit logging.
+
+## Artifact
+
+- API lifecycle updates:
+  - `apps/api/src/documents/documents.controller.ts`
+  - `apps/api/src/documents/documents.service.ts`
+  - `apps/api/src/documents/dto/update-document.dto.ts`
+- Web dashboard document workflow:
+  - `apps/web/app/matters/[id]/page.tsx`
+- Regression tests:
+  - `apps/api/test/documents.spec.ts`
+  - `apps/web/test/matter-dashboard-page.spec.tsx`
+
+## Verification Coverage
+
+- Matter dashboard document operations:
+  - upload new document from matter context (`POST /documents/upload`).
+  - upload new version for existing matter document (`POST /documents/:id/versions`).
+  - toggle client sharing status (`PATCH /documents/:id` with `sharedWithClient`).
+  - generate expiring share link (`POST /documents/:id/share-link`).
+  - issue signed download URL for latest version (`GET /documents/versions/:versionId/download-url`).
+- Authorization and audit:
+  - update/version/share operations are matter-write scoped via `AccessService`.
+  - document lifecycle operations emit auditable events (`document.version.uploaded`, `document.updated`, `document.share_link.created`).
+- UI behavior:
+  - dashboard document card includes actionable controls with explicit feedback messages.
+  - row-level version upload controls are keyboard accessible and labeled.
+
+## Verification Commands
+
+- `pnpm --filter api test -- test/documents.spec.ts`
+- `pnpm --filter web test -- test/matter-dashboard-page.spec.tsx`
+- `pnpm test`
+- `pnpm build`
+- `pnpm backlog:sync`
+- `pnpm backlog:verify`
+- `pnpm backlog:snapshot`
+- `pnpm backlog:handoff:check`

--- a/tools/backlog-sync/requirements.matrix.json
+++ b/tools/backlog-sync/requirements.matrix.json
@@ -503,6 +503,29 @@
             "Retention + legal hold + disposition lifecycle workflows are covered by API/Web tests with evidence in docs/parity/document-retention-workflows.md.",
             "Disposition execution re-checks active legal holds and records skipped-at-execution counts in audit metadata."
           ]
+        },
+        {
+          "title": "Complete matter dashboard document lifecycle operations",
+          "requirementId": "REQ-PMS-CORE-006",
+          "promptSection": "Matters / Matter dashboard / Documents",
+          "parityStatus": "Verified",
+          "component": "Web",
+          "risk": "Medium",
+          "labels": ["parity", "documents", "matters", "pms-core"],
+          "problemStatement": "Matter dashboard document lifecycle is now complete with in-context upload/version/share/download operations, client-sharing toggles, and audit-backed server-side enforcement.",
+          "requirementExcerpt": "Matter dashboard must support operational document management with secure sharing and auditability.",
+          "acceptanceCriteria": [
+            "Users can upload and version documents from matter dashboard context.",
+            "Users can toggle client sharing and issue secure document share/download links from matter dashboard context.",
+            "Document lifecycle operations enforce matter-scoped write access and emit audit log events."
+          ],
+          "apiImpact": "Adds document metadata update endpoint plus dashboard-integrated document upload/version/share operations.",
+          "securityImpact": "Preserves tenant/matter authorization and signed-link expiry controls for client-facing document access.",
+          "definitionOfDone": [
+            "API regression coverage validates document update/version/share lifecycle audit trails.",
+            "Matter dashboard UI supports document upload/version/share/download actions with user feedback states.",
+            "Verification artifact documented at docs/parity/matter-dashboard-document-lifecycle.md."
+          ]
         }
       ]
     },

--- a/tools/backlog-sync/session.snapshot.json
+++ b/tools/backlog-sync/session.snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "generatedAt": "2026-02-19T19:35:25.386Z",
+  "generatedAt": "2026-02-19T22:48:01.876Z",
   "sourceOfTruth": "Linear",
   "contextContract": {
     "canonicalOrder": [
@@ -13,10 +13,10 @@
     "githubIssues": "mirror-only"
   },
   "matrixSummary": {
-    "totalRequirements": 35,
+    "totalRequirements": 36,
     "unresolvedRequirements": 0,
     "totalCountsByPhase": {
-      "phase-1": 30,
+      "phase-1": 31,
       "phase-2": 5
     },
     "unresolvedCountsByPhase": {},
@@ -31,8 +31,9 @@
   "linearSummary": {
     "projectName": "Prompt Parity - Karen Legal Suite",
     "scopeLabel": "parity",
-    "scopedIssueCount": 53,
+    "scopedIssueCount": 54,
     "stateCounts": {
+      "In Review": 1,
       "Done": 43,
       "Backlog": 10
     },
@@ -40,10 +41,17 @@
     "inProgressWithoutVerificationEvidence": [],
     "recentlyUpdatedIssues": [
       {
+        "key": "KAR-68",
+        "title": "Implement matter dashboard document lifecycle operations",
+        "state": "In Review",
+        "updatedAt": "2026-02-19T22:47:27.999Z",
+        "requirementId": "REQ-PMS-CORE-006"
+      },
+      {
         "key": "KAR-67",
         "title": "Complete matter dashboard task and calendar lifecycle operations",
         "state": "Done",
-        "updatedAt": "2026-02-19T19:31:09.467Z",
+        "updatedAt": "2026-02-19T19:39:03.964Z",
         "requirementId": "REQ-PMS-CORE-005"
       },
       {
@@ -101,13 +109,6 @@
         "state": "Done",
         "updatedAt": "2026-02-18T22:14:53.656Z",
         "requirementId": "REQ-MAT-005"
-      },
-      {
-        "key": "KAR-44",
-        "title": "Implement advanced conflict rule profiles and resolution workflows",
-        "state": "Done",
-        "updatedAt": "2026-02-18T22:14:52.975Z",
-        "requirementId": "REQ-MAT-004"
       }
     ]
   },
@@ -122,14 +123,22 @@
     "openIssues": []
   },
   "operational": {
-    "lastSuccessfulBacklogVerifyAt": "2026-02-19T19:35:23.547Z",
+    "lastSuccessfulBacklogVerifyAt": "2026-02-19T22:48:00.419Z",
     "verifyStatePath": "tools/backlog-sync/state/verify.last.json"
   },
   "workspace": {
-    "gitHead": "7cf91c199f03c2fa4e580a4ac5ce27ed7d0cb9e1",
+    "gitHead": "3229d4922e5c4b57d4a270d9790087ad5dbae36c",
     "gitStatusShort": [
-      "## main...origin/main"
+      "## lin/KAR-68-matter-dashboard-document-lifecycle",
+      " M apps/api/src/documents/documents.controller.ts",
+      " M apps/api/src/documents/documents.service.ts",
+      " M apps/api/test/documents.spec.ts",
+      " M apps/web/app/matters/[id]/page.tsx",
+      " M apps/web/test/matter-dashboard-page.spec.tsx",
+      " M tools/backlog-sync/requirements.matrix.json",
+      "?? apps/api/src/documents/dto/update-document.dto.ts",
+      "?? docs/parity/matter-dashboard-document-lifecycle.md"
     ],
-    "dirtyFileCount": 0
+    "dirtyFileCount": 8
   }
 }


### PR DESCRIPTION
## Linear Issue
- Key: KAR-68
- Requirement ID: REQ-PMS-CORE-006

## Summary
- add document metadata update endpoint (`PATCH /documents/:id`) for matter-scoped sharing toggles
- add audit coverage for document version upload and share-link issuance in document service
- expand matter dashboard documents panel with in-context upload/version/share/download actions
- add API + web regression coverage and parity artifact documentation

## Acceptance Criteria
- [x] Users can upload and version documents from matter dashboard context.
- [x] Users can toggle client sharing and issue secure document share/download links from matter dashboard context.
- [x] Document lifecycle operations enforce matter-scoped write access and emit audit log events.

## Verification Evidence
- pnpm --filter api test -- test/documents.spec.ts
- pnpm --filter web test -- test/matter-dashboard-page.spec.tsx
- pnpm test
- pnpm build
- pnpm backlog:sync
- pnpm backlog:verify
- pnpm backlog:snapshot
- pnpm backlog:handoff:check
- docs/parity/matter-dashboard-document-lifecycle.md

## UI Interaction Checklist
- [x] Canonical source reviewed: brand/Brand Identity Document/
- [x] Checklist reviewed: docs/UI_INTERACTION_COMPLIANCE_CHECKLIST.md
- [x] New document controls are keyboard accessible and have explicit labels
- [x] Focus-visible behavior preserved via existing shared input/button classes
- [x] No console errors observed during dashboard document workflow verification

## Screenshot Evidence
- Not captured in this PR; coverage provided by `apps/web/test/matter-dashboard-page.spec.tsx` for full document lifecycle flow in dashboard context.

## Files
- apps/api/src/documents/documents.controller.ts
- apps/api/src/documents/documents.service.ts
- apps/api/src/documents/dto/update-document.dto.ts
- apps/api/test/documents.spec.ts
- apps/web/app/matters/[id]/page.tsx
- apps/web/test/matter-dashboard-page.spec.tsx
- tools/backlog-sync/requirements.matrix.json
- docs/parity/matter-dashboard-document-lifecycle.md
- docs/SESSION_HANDOFF.md
- tools/backlog-sync/session.snapshot.json
