### PR TITLE
[KAR-68] Add matter overview edit API and dashboard workflow

### DIFF
--- a/apps/api/src/matters/dto/update-matter.dto.ts
+++ b/apps/api/src/matters/dto/update-matter.dto.ts
@@ -1,0 +1,44 @@
+import { MatterStatus } from '@prisma/client';
+import { IsDateString, IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class UpdateMatterDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  matterNumber?: string;
+
+  @IsString()
+  @IsOptional()
+  practiceArea?: string;
+
+  @IsEnum(MatterStatus)
+  @IsOptional()
+  status?: MatterStatus;
+
+  @IsString()
+  @IsOptional()
+  jurisdiction?: string | null;
+
+  @IsString()
+  @IsOptional()
+  venue?: string | null;
+
+  @IsString()
+  @IsOptional()
+  stageId?: string | null;
+
+  @IsString()
+  @IsOptional()
+  matterTypeId?: string | null;
+
+  @IsDateString()
+  @IsOptional()
+  openedAt?: string;
+
+  @IsDateString()
+  @IsOptional()
+  closedAt?: string | null;
+}

--- a/apps/api/src/matters/matters.controller.ts
+++ b/apps/api/src/matters/matters.controller.ts
@@ -11,6 +11,7 @@ import { IntakeWizardDto } from './dto/intake-wizard.dto';
 import { SaveIntakeDraftDto } from './dto/save-intake-draft.dto';
 import { LogCommunicationEntryDto } from './dto/log-communication-entry.dto';
 import { UpdateCommunicationEntryDto } from './dto/update-communication-entry.dto';
+import { UpdateMatterDto } from './dto/update-matter.dto';
 
 @Controller('matters')
 @UseGuards(SessionAuthGuard, PermissionGuard)
@@ -29,6 +30,16 @@ export class MattersController {
     return this.mattersService.create({
       organizationId: user.organizationId,
       actorUserId: user.id,
+      ...dto,
+    });
+  }
+
+  @Patch(':id')
+  @RequirePermissions('matters:write')
+  update(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: UpdateMatterDto) {
+    return this.mattersService.updateMatter({
+      user,
+      matterId: id,
       ...dto,
     });
   }

--- a/apps/api/src/matters/matters.service.ts
+++ b/apps/api/src/matters/matters.service.ts
@@ -75,6 +75,201 @@ export class MattersService {
     return matter;
   }
 
+  async updateMatter(input: {
+    user: AuthenticatedUser;
+    matterId: string;
+    name?: string;
+    matterNumber?: string;
+    practiceArea?: string;
+    status?: MatterStatus;
+    jurisdiction?: string | null;
+    venue?: string | null;
+    stageId?: string | null;
+    matterTypeId?: string | null;
+    openedAt?: string;
+    closedAt?: string | null;
+  }) {
+    await this.accessService.assertMatterAccess(input.user, input.matterId, 'write');
+
+    const matter = await this.prisma.matter.findFirst({
+      where: {
+        id: input.matterId,
+        organizationId: input.user.organizationId,
+      },
+      select: {
+        id: true,
+      },
+    });
+    if (!matter) {
+      throw new NotFoundException('Matter not found');
+    }
+
+    const data: Prisma.MatterUpdateInput = {};
+    const updatedFields: string[] = [];
+
+    if (input.name !== undefined) {
+      const name = this.safeString(input.name);
+      if (!name) {
+        throw new BadRequestException('Matter name cannot be empty');
+      }
+      data.name = name;
+      updatedFields.push('name');
+    }
+
+    if (input.matterNumber !== undefined) {
+      const matterNumber = this.safeString(input.matterNumber);
+      if (!matterNumber) {
+        throw new BadRequestException('Matter number cannot be empty');
+      }
+      const duplicate = await this.prisma.matter.findFirst({
+        where: {
+          organizationId: input.user.organizationId,
+          matterNumber,
+          id: {
+            not: input.matterId,
+          },
+        },
+        select: { id: true },
+      });
+      if (duplicate) {
+        throw new BadRequestException('Matter number already exists in this organization');
+      }
+      data.matterNumber = matterNumber;
+      updatedFields.push('matterNumber');
+    }
+
+    if (input.practiceArea !== undefined) {
+      const practiceArea = this.safeString(input.practiceArea);
+      if (!practiceArea) {
+        throw new BadRequestException('Practice area cannot be empty');
+      }
+      data.practiceArea = practiceArea;
+      updatedFields.push('practiceArea');
+    }
+
+    if (input.status !== undefined) {
+      data.status = input.status;
+      updatedFields.push('status');
+    }
+
+    if (input.jurisdiction !== undefined) {
+      data.jurisdiction = this.normalizeOptionalText(input.jurisdiction) ?? null;
+      updatedFields.push('jurisdiction');
+    }
+
+    if (input.venue !== undefined) {
+      data.venue = this.normalizeOptionalText(input.venue) ?? null;
+      updatedFields.push('venue');
+    }
+
+    if (input.stageId !== undefined) {
+      const stageId = this.normalizeOptionalText(input.stageId);
+      if (stageId) {
+        const stage = await this.prisma.matterStage.findFirst({
+          where: {
+            id: stageId,
+            organizationId: input.user.organizationId,
+          },
+          select: { id: true },
+        });
+        if (!stage) {
+          throw new NotFoundException('Matter stage not found');
+        }
+        data.stage = {
+          connect: { id: stageId },
+        };
+      } else {
+        data.stage = {
+          disconnect: true,
+        };
+      }
+      updatedFields.push('stageId');
+    }
+
+    if (input.matterTypeId !== undefined) {
+      const matterTypeId = this.normalizeOptionalText(input.matterTypeId);
+      if (matterTypeId) {
+        const matterType = await this.prisma.matterType.findFirst({
+          where: {
+            id: matterTypeId,
+            organizationId: input.user.organizationId,
+          },
+          select: { id: true },
+        });
+        if (!matterType) {
+          throw new NotFoundException('Matter type not found');
+        }
+        data.matterType = {
+          connect: { id: matterTypeId },
+        };
+      } else {
+        data.matterType = {
+          disconnect: true,
+        };
+      }
+      updatedFields.push('matterTypeId');
+    }
+
+    if (input.openedAt !== undefined) {
+      const openedAt = new Date(input.openedAt);
+      if (Number.isNaN(openedAt.getTime())) {
+        throw new BadRequestException('Invalid openedAt timestamp');
+      }
+      data.openedAt = openedAt;
+      updatedFields.push('openedAt');
+    }
+
+    if (input.closedAt !== undefined) {
+      const closedAtValue = this.normalizeOptionalText(input.closedAt);
+      if (!closedAtValue) {
+        data.closedAt = null;
+      } else {
+        const closedAt = new Date(closedAtValue);
+        if (Number.isNaN(closedAt.getTime())) {
+          throw new BadRequestException('Invalid closedAt timestamp');
+        }
+        data.closedAt = closedAt;
+      }
+      updatedFields.push('closedAt');
+    }
+
+    if (updatedFields.length === 0) {
+      return this.dashboard(input.user, input.matterId);
+    }
+
+    const updatedMatter = await this.prisma.matter.update({
+      where: { id: input.matterId },
+      data,
+      select: {
+        id: true,
+        matterNumber: true,
+        name: true,
+        practiceArea: true,
+        status: true,
+        stageId: true,
+        matterTypeId: true,
+        jurisdiction: true,
+        venue: true,
+        openedAt: true,
+        closedAt: true,
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.user.organizationId,
+      actorUserId: input.user.id,
+      action: 'matter.updated',
+      entityType: 'matter',
+      entityId: input.matterId,
+      metadata: {
+        updatedFields,
+        matter: updatedMatter,
+      },
+    });
+
+    return this.dashboard(input.user, input.matterId);
+  }
+
   async addParticipant(input: {
     user: AuthenticatedUser;
     matterId: string;

--- a/apps/api/test/matters.spec.ts
+++ b/apps/api/test/matters.spec.ts
@@ -973,4 +973,90 @@ describe('MattersService', () => {
     expect(loaded.id).toBe('draft-1');
     expect(loaded.payload.matterNumber).toBe('M-21-INTAKE');
   });
+
+  it('updates matter overview fields and emits audit events', async () => {
+    const prisma = {
+      matter: {
+        findFirst: jest.fn().mockResolvedValueOnce({ id: 'matter-1' }).mockResolvedValueOnce(null),
+        update: jest.fn().mockResolvedValue({
+          id: 'matter-1',
+          matterNumber: 'M-2',
+          name: 'Updated Matter',
+          practiceArea: 'Construction Litigation',
+          status: 'PENDING',
+          stageId: null,
+          matterTypeId: null,
+          jurisdiction: 'CA',
+          venue: 'Los Angeles',
+          openedAt: new Date('2026-02-01T12:00:00.000Z'),
+          closedAt: null,
+        }),
+      },
+    } as any;
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const access = { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new MattersService(prisma, audit, access);
+    jest.spyOn(service, 'dashboard').mockResolvedValue({ id: 'matter-1', name: 'Updated Matter' } as any);
+
+    const result = await service.updateMatter({
+      user: baseUser,
+      matterId: 'matter-1',
+      name: ' Updated Matter ',
+      matterNumber: ' M-2 ',
+      practiceArea: ' Construction Litigation ',
+      status: 'PENDING' as any,
+      jurisdiction: ' CA ',
+      venue: ' Los Angeles ',
+      openedAt: '2026-02-01T12:00:00.000Z',
+      closedAt: null,
+    });
+
+    expect(access.assertMatterAccess).toHaveBeenCalledWith(baseUser, 'matter-1', 'write');
+    expect(prisma.matter.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'matter-1' },
+        data: expect.objectContaining({
+          name: 'Updated Matter',
+          matterNumber: 'M-2',
+          practiceArea: 'Construction Litigation',
+          status: 'PENDING',
+          jurisdiction: 'CA',
+          venue: 'Los Angeles',
+          openedAt: expect.any(Date),
+          closedAt: null,
+        }),
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'matter.updated',
+        entityType: 'matter',
+        entityId: 'matter-1',
+      }),
+    );
+    expect(result).toEqual({ id: 'matter-1', name: 'Updated Matter' });
+  });
+
+  it('rejects duplicate matter number updates within organization', async () => {
+    const prisma = {
+      matter: {
+        findFirst: jest.fn().mockResolvedValueOnce({ id: 'matter-1' }).mockResolvedValueOnce({ id: 'matter-2' }),
+        update: jest.fn(),
+      },
+    } as any;
+    const service = new MattersService(
+      prisma,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    await expect(
+      service.updateMatter({
+        user: baseUser,
+        matterId: 'matter-1',
+        matterNumber: 'M-2',
+      }),
+    ).rejects.toThrow('Matter number already exists in this organization');
+    expect(prisma.matter.update).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/app/matters/[id]/page.tsx
+++ b/apps/web/app/matters/[id]/page.tsx
@@ -52,6 +52,7 @@ const TASK_STATUS_OPTIONS = ['TODO', 'IN_PROGRESS', 'BLOCKED', 'DONE', 'CANCELED
 const TASK_PRIORITY_OPTIONS = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'] as const;
 const COMMUNICATION_TYPE_OPTIONS = ['EMAIL', 'SMS', 'CALL_LOG', 'PORTAL_MESSAGE', 'INTERNAL_NOTE'] as const;
 const COMMUNICATION_DIRECTION_OPTIONS = ['INBOUND', 'OUTBOUND', 'INTERNAL'] as const;
+const MATTER_STATUS_OPTIONS = ['OPEN', 'PENDING', 'CLOSED', 'ARCHIVED'] as const;
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 
 function toDateTimeLocalValue(value?: string | null) {
@@ -69,6 +70,16 @@ export default function MatterDashboardPage() {
   const params = useParams() as { id: string };
   const matterId = params.id;
   const [dashboard, setDashboard] = useState<any>(null);
+  const [editingOverview, setEditingOverview] = useState(false);
+  const [overviewName, setOverviewName] = useState('');
+  const [overviewMatterNumber, setOverviewMatterNumber] = useState('');
+  const [overviewPracticeArea, setOverviewPracticeArea] = useState('');
+  const [overviewStatus, setOverviewStatus] = useState<(typeof MATTER_STATUS_OPTIONS)[number]>('OPEN');
+  const [overviewVenue, setOverviewVenue] = useState('');
+  const [overviewJurisdiction, setOverviewJurisdiction] = useState('');
+  const [overviewOpenedAt, setOverviewOpenedAt] = useState('');
+  const [overviewClosedAt, setOverviewClosedAt] = useState('');
+  const [overviewStatusMessage, setOverviewStatusMessage] = useState<string | null>(null);
   const [rulesPacks, setRulesPacks] = useState<Array<{ id: string; name: string; pack?: { version?: string } }>>([]);
   const [selectedRulesPackId, setSelectedRulesPackId] = useState('');
   const [triggerDate, setTriggerDate] = useState(new Date().toISOString().slice(0, 10));
@@ -115,6 +126,18 @@ export default function MatterDashboardPage() {
     }
     const nextDashboard = await apiFetch<any>(`/matters/${matterId}/dashboard`);
     setDashboard(nextDashboard);
+    setOverviewName(nextDashboard.name || '');
+    setOverviewMatterNumber(nextDashboard.matterNumber || '');
+    setOverviewPracticeArea(nextDashboard.practiceArea || '');
+    setOverviewStatus(
+      MATTER_STATUS_OPTIONS.includes(nextDashboard.status as (typeof MATTER_STATUS_OPTIONS)[number])
+        ? nextDashboard.status
+        : 'OPEN',
+    );
+    setOverviewVenue(nextDashboard.venue || '');
+    setOverviewJurisdiction(nextDashboard.jurisdiction || '');
+    setOverviewOpenedAt(toDateTimeLocalValue(nextDashboard.openedAt));
+    setOverviewClosedAt(toDateTimeLocalValue(nextDashboard.closedAt));
     const threadIds = (nextDashboard.communicationThreads || []).map((thread: CommunicationThread) => thread.id);
     setSelectedCommunicationThreadId((current) => {
       if (threadIds.length === 0) {
@@ -191,6 +214,59 @@ export default function MatterDashboardPage() {
     setPreviewRows([]);
     setOverrideDates({});
     setOverrideReasons({});
+    await refreshDashboard();
+  }
+
+  function cancelOverviewEdit() {
+    if (!dashboard) {
+      setEditingOverview(false);
+      return;
+    }
+    setOverviewName(dashboard.name || '');
+    setOverviewMatterNumber(dashboard.matterNumber || '');
+    setOverviewPracticeArea(dashboard.practiceArea || '');
+    setOverviewStatus(
+      MATTER_STATUS_OPTIONS.includes(dashboard.status as (typeof MATTER_STATUS_OPTIONS)[number])
+        ? dashboard.status
+        : 'OPEN',
+    );
+    setOverviewVenue(dashboard.venue || '');
+    setOverviewJurisdiction(dashboard.jurisdiction || '');
+    setOverviewOpenedAt(toDateTimeLocalValue(dashboard.openedAt));
+    setOverviewClosedAt(toDateTimeLocalValue(dashboard.closedAt));
+    setEditingOverview(false);
+    setOverviewStatusMessage('Matter overview edit cancelled.');
+  }
+
+  async function updateMatterOverview() {
+    if (!matterId) {
+      return;
+    }
+    if (!overviewName.trim() || !overviewMatterNumber.trim() || !overviewPracticeArea.trim()) {
+      setOverviewStatusMessage('Matter name, number, and practice area are required.');
+      return;
+    }
+    if (!MATTER_STATUS_OPTIONS.includes(overviewStatus)) {
+      setOverviewStatusMessage('Matter status is invalid.');
+      return;
+    }
+
+    await apiFetch(`/matters/${matterId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        name: overviewName.trim(),
+        matterNumber: overviewMatterNumber.trim(),
+        practiceArea: overviewPracticeArea.trim(),
+        status: overviewStatus,
+        venue: overviewVenue.trim() ? overviewVenue.trim() : null,
+        jurisdiction: overviewJurisdiction.trim() ? overviewJurisdiction.trim() : null,
+        ...(overviewOpenedAt ? { openedAt: new Date(overviewOpenedAt).toISOString() } : {}),
+        closedAt: overviewClosedAt ? new Date(overviewClosedAt).toISOString() : null,
+      }),
+    });
+
+    setEditingOverview(false);
+    setOverviewStatusMessage('Matter overview updated.');
     await refreshDashboard();
   }
 
@@ -618,10 +694,96 @@ export default function MatterDashboardPage() {
         <div className="card-grid">
           <div className="card">
             <h3 style={{ marginTop: 0 }}>Overview</h3>
-            <p>Practice Area: {dashboard.practiceArea}</p>
-            <p>Status: {dashboard.status}</p>
-            <p>Venue: {dashboard.venue || '-'}</p>
-            <p>Jurisdiction: {dashboard.jurisdiction || '-'}</p>
+            {editingOverview ? (
+              <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))' }}>
+                <input
+                  className="input"
+                  aria-label="Matter Name"
+                  value={overviewName}
+                  onChange={(event) => setOverviewName(event.target.value)}
+                  placeholder="Matter name"
+                />
+                <input
+                  className="input"
+                  aria-label="Matter Number"
+                  value={overviewMatterNumber}
+                  onChange={(event) => setOverviewMatterNumber(event.target.value)}
+                  placeholder="Matter number"
+                />
+                <input
+                  className="input"
+                  aria-label="Practice Area"
+                  value={overviewPracticeArea}
+                  onChange={(event) => setOverviewPracticeArea(event.target.value)}
+                  placeholder="Practice area"
+                />
+                <select
+                  className="select"
+                  aria-label="Matter Status"
+                  value={overviewStatus}
+                  onChange={(event) => setOverviewStatus(event.target.value as (typeof MATTER_STATUS_OPTIONS)[number])}
+                >
+                  {MATTER_STATUS_OPTIONS.map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  className="input"
+                  aria-label="Matter Venue"
+                  value={overviewVenue}
+                  onChange={(event) => setOverviewVenue(event.target.value)}
+                  placeholder="Venue"
+                />
+                <input
+                  className="input"
+                  aria-label="Matter Jurisdiction"
+                  value={overviewJurisdiction}
+                  onChange={(event) => setOverviewJurisdiction(event.target.value)}
+                  placeholder="Jurisdiction"
+                />
+                <input
+                  className="input"
+                  aria-label="Matter Opened At"
+                  type="datetime-local"
+                  value={overviewOpenedAt}
+                  onChange={(event) => setOverviewOpenedAt(event.target.value)}
+                />
+                <input
+                  className="input"
+                  aria-label="Matter Closed At"
+                  type="datetime-local"
+                  value={overviewClosedAt}
+                  onChange={(event) => setOverviewClosedAt(event.target.value)}
+                />
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <button className="button" type="button" onClick={updateMatterOverview}>
+                    Save Overview
+                  </button>
+                  <button className="button secondary" type="button" onClick={cancelOverviewEdit}>
+                    Cancel Overview Edit
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <p>Name: {dashboard.name}</p>
+                <p>Matter Number: {dashboard.matterNumber}</p>
+                <p>Practice Area: {dashboard.practiceArea}</p>
+                <p>Status: {dashboard.status}</p>
+                <p>Venue: {dashboard.venue || '-'}</p>
+                <p>Jurisdiction: {dashboard.jurisdiction || '-'}</p>
+                <p>Opened: {dashboard.openedAt ? new Date(dashboard.openedAt).toLocaleString() : '-'}</p>
+                <p>Closed: {dashboard.closedAt ? new Date(dashboard.closedAt).toLocaleString() : '-'}</p>
+                <button className="button secondary" type="button" onClick={() => setEditingOverview(true)}>
+                  Edit Overview
+                </button>
+              </div>
+            )}
+            {overviewStatusMessage ? (
+              <p style={{ marginTop: 8, color: 'var(--lic-text-muted)' }}>{overviewStatusMessage}</p>
+            ) : null}
           </div>
 
           <div className="card">

--- a/apps/web/test/matter-dashboard-page.spec.tsx
+++ b/apps/web/test/matter-dashboard-page.spec.tsx
@@ -341,6 +341,84 @@ describe('MatterDashboardPage operational workflows', () => {
     });
   });
 
+  it('edits and saves matter overview fields', async () => {
+    vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
+
+    const state = createDashboardState();
+    const overview = {
+      matterNumber: 'M-100',
+      name: 'Doe v. Builder',
+      practiceArea: 'Construction Litigation',
+      status: 'OPEN',
+      venue: 'Superior',
+      jurisdiction: 'CA',
+      openedAt: '2026-01-02T16:00:00.000Z',
+      closedAt: null as string | null,
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.endsWith('/matters/matter-1/dashboard') && method === 'GET') {
+        return jsonResponse(buildDashboardFixture(state, overview));
+      }
+      if (url.endsWith('/calendar/rules-packs') && method === 'GET') {
+        return jsonResponse([{ id: 'pack-1', name: 'CA Superior Civil v1', pack: { version: '1.0' } }]);
+      }
+      if (url.endsWith('/contacts') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/matters/matter-1/participant-roles') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/matters/matter-1') && method === 'PATCH') {
+        const body = JSON.parse(String(init?.body || '{}'));
+        overview.name = body.name;
+        overview.matterNumber = body.matterNumber;
+        overview.practiceArea = body.practiceArea;
+        overview.status = body.status;
+        overview.venue = body.venue;
+        overview.jurisdiction = body.jurisdiction;
+        overview.openedAt = body.openedAt;
+        overview.closedAt = body.closedAt;
+        return jsonResponse(buildDashboardFixture(state, overview));
+      }
+
+      throw new Error(`Unhandled request: ${method} ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<MatterDashboardPage />);
+
+    await screen.findByText('M-100 - Doe v. Builder');
+    fireEvent.click(screen.getByRole('button', { name: 'Edit Overview' }));
+
+    fireEvent.change(screen.getByLabelText('Matter Name'), { target: { value: 'Updated Builder Dispute' } });
+    fireEvent.change(screen.getByLabelText('Matter Number'), { target: { value: 'M-101' } });
+    fireEvent.change(screen.getByLabelText('Practice Area'), { target: { value: 'General Civil Litigation' } });
+    fireEvent.change(screen.getByLabelText('Matter Status'), { target: { value: 'PENDING' } });
+    fireEvent.change(screen.getByLabelText('Matter Venue'), { target: { value: 'Downtown Court' } });
+    fireEvent.change(screen.getByLabelText('Matter Jurisdiction'), { target: { value: 'NV' } });
+    fireEvent.change(screen.getByLabelText('Matter Opened At'), { target: { value: '2026-02-03T11:45' } });
+    fireEvent.change(screen.getByLabelText('Matter Closed At'), { target: { value: '2026-03-03T15:30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Overview' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/matters/matter-1',
+        expect.objectContaining({ method: 'PATCH', credentials: 'include' }),
+      );
+      expect(screen.getByText('Matter overview updated.')).toBeInTheDocument();
+      expect(screen.getByText('M-101 - Updated Builder Dispute')).toBeInTheDocument();
+      expect(screen.getByText('Practice Area: General Civil Litigation')).toBeInTheDocument();
+      expect(screen.getByText('Status: PENDING')).toBeInTheDocument();
+      expect(screen.getByText('Venue: Downtown Court')).toBeInTheDocument();
+      expect(screen.getByText('Jurisdiction: NV')).toBeInTheDocument();
+    });
+  });
+
   it('adds and removes participants in matter context', async () => {
     vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
 


### PR DESCRIPTION
## Summary
Implements matter overview editing for core practice-management workflows.

### What changed
- Added `PATCH /matters/:id` endpoint for matter overview updates.
- Added `UpdateMatterDto` validation for editable overview fields.
- Added `MattersService.updateMatter(...)` with:
  - matter-scoped write access enforcement
  - organization-scoped duplicate `matterNumber` guard
  - organization-scoped `stageId`/`matterTypeId` validation
  - date validation (`openedAt`, `closedAt`)
  - audit emission (`matter.updated`)
- Added Overview edit/save/cancel flow in matter dashboard UI.
- Added API and web regression tests for overview edit workflow.

## Linear Issue
- Key: `KAR-68`
- Link: https://linear.app/karenap/issue/KAR-68

## Requirement ID
- `REQ-PMS-CORE-005`

## Verification Evidence
- `pnpm -C apps/api test -- matters.spec.ts` ✅
- `pnpm -C apps/web test -- matter-dashboard-page.spec.tsx` ✅
- `pnpm build` ✅

## UI Interaction Checklist
- [x] Keyboard navigation verified for Overview edit controls.
- [x] Focus-visible styling preserved on actionable controls.
- [x] Labels present for Overview form inputs.
- [x] No console errors observed during manual dashboard overview edit/save/cancel flow.

## Screenshot Evidence
- Matter dashboard Overview card (default state) reviewed locally.
- Matter dashboard Overview card (editing state with save/cancel controls) reviewed locally.
- Matter dashboard Overview card (post-save updated values + status feedback) reviewed locally.

## Notes
- Full `pnpm test` currently has one pre-existing failure in `apps/web/test/smoke-user-journey.spec.tsx` unrelated to this change.
