### PR TITLE
[KAR-84] Fix backlog mirror discovery and verify drift

### DIFF
--- a/apps/api/test/backlog-sync-graphql.spec.ts
+++ b/apps/api/test/backlog-sync-graphql.spec.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('Backlog sync GitHub discovery', () => {
+  const commonPath = join(__dirname, '../../../tools/backlog-sync/common.mjs');
+  const syncPath = join(__dirname, '../../../tools/backlog-sync/linear_to_github.mjs');
+  const verifyPath = join(__dirname, '../../../tools/backlog-sync/verify_backlog_sync.mjs');
+
+  it('defines shared GitHub GraphQL issue-list helper', () => {
+    const common = readFileSync(commonPath, 'utf8');
+    expect(common).toContain('export async function githubGraphQL');
+    expect(common).toContain("`${GITHUB_API_URL}/graphql`");
+    expect(common).toContain('export async function listGitHubIssuesGraphQL');
+    expect(common).toContain('repository(owner: $owner, name: $repo)');
+  });
+
+  it('uses GraphQL issue discovery in linear_to_github mirror sync', () => {
+    const syncScript = readFileSync(syncPath, 'utf8');
+    expect(syncScript).toContain('listGitHubIssuesGraphQL');
+    expect(syncScript).not.toContain('/repos/${owner}/${repo}/issues?');
+  });
+
+  it('uses GraphQL issue discovery in verify_backlog_sync', () => {
+    const verifyScript = readFileSync(verifyPath, 'utf8');
+    expect(verifyScript).toContain('listGitHubIssuesGraphQL');
+    expect(verifyScript).not.toContain('/repos/${owner}/${repo}/issues?state=all&labels=');
+  });
+});

--- a/docs/parity/backlog-mirror-graphql-fix.md
+++ b/docs/parity/backlog-mirror-graphql-fix.md
@@ -1,0 +1,31 @@
+# Backlog Mirror GraphQL Discovery Hardening (KAR-84)
+
+Requirement context: `REQ-OPS-003` follow-on hardening.
+
+## Problem
+
+GitHub mirror sync/verify scripts depended on REST issue listing with label filters. In this environment, REST listing returned empty sets, which caused:
+
+- false `Missing mirrors` failures in verify,
+- duplicate mirror issue creation in sync.
+
+## Remediation
+
+1. Added shared GitHub GraphQL helper and paginated issue listing utility:
+   - `tools/backlog-sync/common.mjs`
+2. Migrated mirror sync issue discovery to GraphQL:
+   - `tools/backlog-sync/linear_to_github.mjs`
+3. Migrated verify issue discovery to GraphQL:
+   - `tools/backlog-sync/verify_backlog_sync.mjs`
+4. Hardened Linear-ID mapping to be duplicate-safe (highest issue number wins) in sync and verify.
+5. Added executable guard test for script wiring:
+   - `apps/api/test/backlog-sync-graphql.spec.ts`
+
+## Verification Commands
+
+- `pnpm --filter api test -- backlog-sync-graphql.spec.ts`
+- `pnpm backlog:verify`
+
+## Outcome
+
+Backlog sync/verify now uses GraphQL issue discovery, reducing drift risk from REST label-list inconsistencies and preventing duplicate mirror creation from empty-list false negatives.

--- a/tools/backlog-sync/common.mjs
+++ b/tools/backlog-sync/common.mjs
@@ -182,6 +182,84 @@ export async function githubRequest(token, path, { method = 'GET', body, extraHe
   return payload;
 }
 
+export async function githubGraphQL(token, query, variables = {}) {
+  const response = await fetch(`${GITHUB_API_URL}/graphql`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(`GitHub GraphQL request failed (${response.status}): ${JSON.stringify(payload)}`);
+  }
+  if (payload.errors?.length) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(payload.errors)}`);
+  }
+  return payload.data;
+}
+
+export async function listGitHubIssuesGraphQL(token, { owner, repo, labels = null }) {
+  const issues = [];
+  let hasNextPage = true;
+  let cursor = null;
+
+  while (hasNextPage) {
+    const data = await githubGraphQL(
+      token,
+      `
+        query RepoIssues($owner: String!, $repo: String!, $after: String, $labels: [String!]) {
+          repository(owner: $owner, name: $repo) {
+            issues(
+              first: 100
+              after: $after
+              states: [OPEN, CLOSED]
+              orderBy: { field: UPDATED_AT, direction: DESC }
+              labels: $labels
+            ) {
+              nodes {
+                id
+                number
+                title
+                body
+                state
+                updatedAt
+                labels(first: 50) {
+                  nodes {
+                    name
+                  }
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+      `,
+      {
+        owner,
+        repo,
+        after: cursor,
+        labels: labels?.length ? labels : null,
+      },
+    );
+
+    const page = data?.repository?.issues;
+    issues.push(...ensureArray(page?.nodes));
+    hasNextPage = Boolean(page?.pageInfo?.hasNextPage);
+    cursor = page?.pageInfo?.endCursor || null;
+  }
+
+  return issues;
+}
+
 export async function getLinearTeamByKey(token, teamKey) {
   const data = await linearGraphQL(
     token,

--- a/tools/backlog-sync/linear_to_github.mjs
+++ b/tools/backlog-sync/linear_to_github.mjs
@@ -8,6 +8,7 @@ import {
   getLinearProjectByName,
   getLinearProjectIssues,
   githubRequest,
+  listGitHubIssuesGraphQL,
   linearPriorityToGitHubLabel,
   linearStateToGitHub,
   normalizeLabelName,
@@ -60,21 +61,17 @@ async function listRepoLabels() {
 }
 
 async function listRepoIssues({ labels = null } = {}) {
-  const issues = [];
-  let page = 1;
-  while (true) {
-    const query = new URLSearchParams({
-      state: 'all',
-      per_page: '100',
-      page: String(page),
-    });
-    if (labels) query.set('labels', labels);
-    const chunk = await githubRequest(githubToken, `/repos/${owner}/${repo}/issues?${query.toString()}`);
-    if (!Array.isArray(chunk) || chunk.length === 0) break;
-    issues.push(...chunk.filter((item) => !item.pull_request));
-    page += 1;
-  }
-  return issues;
+  const normalizedLabels = labels
+    ? String(labels)
+        .split(',')
+        .map((value) => normalizeLabelName(value))
+        .filter(Boolean)
+    : null;
+  return listGitHubIssuesGraphQL(githubToken, {
+    owner,
+    repo,
+    labels: normalizedLabels,
+  });
 }
 
 function colorForLabel(name) {
@@ -122,7 +119,8 @@ async function loadMirrorIssueMap() {
   for (const issue of issues) {
     const linearId = parseLinearId(issue.body);
     if (!linearId) continue;
-    if (!byLinearId.has(linearId)) {
+    const existing = byLinearId.get(linearId);
+    if (!existing || Number(issue.number) > Number(existing.number)) {
       byLinearId.set(linearId, issue);
     }
   }

--- a/tools/backlog-sync/verify_backlog_sync.mjs
+++ b/tools/backlog-sync/verify_backlog_sync.mjs
@@ -8,7 +8,7 @@ import {
   extractRequirementId,
   getLinearProjectByName,
   getLinearProjectIssues,
-  githubRequest,
+  listGitHubIssuesGraphQL,
   normalizeLabelName,
   requiredEnv,
 } from './common.mjs';
@@ -33,18 +33,11 @@ function parseRequirementFromBody(body) {
 }
 
 async function listMirroredGitHubIssues() {
-  const issues = [];
-  let page = 1;
-  while (true) {
-    const chunk = await githubRequest(
-      githubToken,
-      `/repos/${owner}/${repo}/issues?state=all&labels=${encodeURIComponent(scopeLabel)}&per_page=100&page=${page}`,
-    );
-    if (!Array.isArray(chunk) || chunk.length === 0) break;
-    issues.push(...chunk.filter((item) => !item.pull_request));
-    page += 1;
-  }
-  return issues;
+  return listGitHubIssuesGraphQL(githubToken, {
+    owner,
+    repo,
+    labels: [scopeLabel],
+  });
 }
 
 async function main() {
@@ -61,7 +54,11 @@ async function main() {
   const githubByLinearId = new Map();
   for (const issue of githubIssues) {
     const linearId = parseLinearId(issue.body);
-    if (linearId) githubByLinearId.set(linearId, issue);
+    if (!linearId) continue;
+    const existing = githubByLinearId.get(linearId);
+    if (!existing || Number(issue.number) > Number(existing.number)) {
+      githubByLinearId.set(linearId, issue);
+    }
   }
 
   const missingMirrors = [];


### PR DESCRIPTION
## Summary
- migrate backlog mirror/verify GitHub issue discovery from REST label listing to GraphQL pagination
- make Linear-ID mirror mapping duplicate-safe (newest issue number wins)
- add regression test for GraphQL discovery wiring and parity verification artifact

## Linear Issue
- KAR-84

## Requirement ID
- REQ-OPS-003

## Acceptance Criteria
- [x] mirror and verify use GraphQL issue discovery with label filtering
- [x] duplicate-safe Linear-ID mapping applied in sync and verify
- [x] repeated sync/verify no longer reports false missing mirrors in this environment

## Test Evidence
- `pnpm --filter api test -- backlog-sync-graphql.spec.ts`
- `pnpm backlog:verify` (with config token)
- `pnpm backlog:sync && pnpm backlog:verify` (with config token)
