### PR TITLE
[KAR-89] Replace manual ID flows with selector-driven workflows

### DIFF
--- a/apps/api/src/portal/portal.controller.ts
+++ b/apps/api/src/portal/portal.controller.ts
@@ -15,6 +15,16 @@ export class PortalController {
     return this.portalService.getPortalSnapshot(user);
   }
 
+  @Get('intake-form-definitions')
+  intakeFormDefinitions(@CurrentUser() user: AuthenticatedUser) {
+    return this.portalService.listPortalIntakeFormDefinitions(user);
+  }
+
+  @Get('engagement-letter-templates')
+  engagementLetterTemplates(@CurrentUser() user: AuthenticatedUser) {
+    return this.portalService.listPortalEngagementLetterTemplates(user);
+  }
+
   @Post('messages')
   message(
     @CurrentUser() user: AuthenticatedUser,

--- a/apps/api/src/portal/portal.service.ts
+++ b/apps/api/src/portal/portal.service.ts
@@ -405,6 +405,35 @@ export class PortalService {
     });
   }
 
+  async listPortalIntakeFormDefinitions(user: AuthenticatedUser) {
+    this.assertClientRole(user);
+    return this.prisma.intakeFormDefinition.findMany({
+      where: {
+        organizationId: user.organizationId,
+        isClientPortalEnabled: true,
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async listPortalEngagementLetterTemplates(user: AuthenticatedUser) {
+    this.assertClientRole(user);
+    return this.prisma.engagementLetterTemplate.findMany({
+      where: {
+        organizationId: user.organizationId,
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+      orderBy: { name: 'asc' },
+    });
+  }
+
   async createEsignEnvelope(input: {
     user: AuthenticatedUser;
     engagementLetterTemplateId: string;

--- a/apps/api/test/portal.spec.ts
+++ b/apps/api/test/portal.spec.ts
@@ -653,4 +653,43 @@ describe('PortalService', () => {
       }),
     );
   });
+
+  it('lists client-portal intake forms and engagement templates for the organization', async () => {
+    const prisma = {
+      intakeFormDefinition: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'intake-1', name: 'Client Intake v1' }]),
+      },
+      engagementLetterTemplate: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'tpl-1', name: 'Engagement Letter v1' }]),
+      },
+    } as any;
+
+    const service = new PortalService(
+      prisma,
+      { upload: jest.fn(), signedDownloadUrl: jest.fn() } as any,
+      { scan: jest.fn() } as any,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    const intakeForms = await service.listPortalIntakeFormDefinitions(buildClientUser());
+    const templates = await service.listPortalEngagementLetterTemplates(buildClientUser());
+
+    expect(intakeForms).toEqual([{ id: 'intake-1', name: 'Client Intake v1' }]);
+    expect(templates).toEqual([{ id: 'tpl-1', name: 'Engagement Letter v1' }]);
+    expect(prisma.intakeFormDefinition.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          isClientPortalEnabled: true,
+        }),
+      }),
+    );
+    expect(prisma.engagementLetterTemplate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+        }),
+      }),
+    );
+  });
 });

--- a/apps/web/app/ai/page.tsx
+++ b/apps/web/app/ai/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, FormEvent, useEffect, useState } from 'react';
+import { Fragment, FormEvent, useCallback, useEffect, useState } from 'react';
 import { AppShell } from '../../components/app-shell';
 import { PageHeader } from '../../components/page-header';
 import { apiFetch } from '../../lib/api';
@@ -98,6 +98,23 @@ type StylePackDraft = {
   documentVersionId: string;
 };
 
+type MatterLookup = {
+  id: string;
+  matterNumber: string;
+  name: string;
+  label: string;
+};
+
+type DocumentVersionLookup = {
+  id: string;
+  label: string;
+  document: {
+    id: string;
+    matterId: string;
+    title: string;
+  };
+};
+
 const DATE_TOKEN_REGEX =
   /\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4}|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{1,2},\s+\d{4})\b/gi;
 
@@ -107,43 +124,55 @@ type ReviewGateStep = (typeof REVIEW_GATE_SEQUENCE)[number];
 export default function AiPage() {
   const [jobs, setJobs] = useState<AiJob[]>([]);
   const [stylePacks, setStylePacks] = useState<StylePack[]>([]);
+  const [matterOptions, setMatterOptions] = useState<MatterLookup[]>([]);
+  const [documentVersionOptions, setDocumentVersionOptions] = useState<DocumentVersionLookup[]>([]);
   const [stylePackDrafts, setStylePackDrafts] = useState<Record<string, StylePackDraft>>({});
   const [selectedStylePackId, setSelectedStylePackId] = useState('');
   const [newStylePackName, setNewStylePackName] = useState('');
   const [newStylePackDescription, setNewStylePackDescription] = useState('');
   const [busyStylePackId, setBusyStylePackId] = useState<string | null>(null);
-  const [matterId, setMatterId] = useState('');
+  const [selectedMatterId, setSelectedMatterId] = useState('');
   const [toolName, setToolName] = useState('case_summary');
   const [busyArtifactId, setBusyArtifactId] = useState<string | null>(null);
   const [statusByArtifact, setStatusByArtifact] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
   const [deadlineSelections, setDeadlineSelections] = useState<Record<string, Record<string, DeadlineSelection>>>({});
 
-  async function load() {
+  const load = useCallback(async () => {
+    const query = selectedMatterId ? `&matterId=${encodeURIComponent(selectedMatterId)}` : '';
     const [nextJobs, nextStylePacks] = await Promise.all([
       apiFetch<AiJob[]>('/ai/jobs'),
       apiFetch<StylePack[]>('/ai/style-packs'),
     ]);
+    const [nextMattersRaw, nextDocumentVersionsRaw] = await Promise.all([
+      apiFetch<MatterLookup[]>('/lookups/matters?limit=200').catch(() => []),
+      apiFetch<DocumentVersionLookup[]>(`/lookups/document-versions?limit=200${query}`).catch(() => []),
+    ]);
+    const nextMatters = Array.isArray(nextMattersRaw) ? nextMattersRaw : [];
+    const nextDocumentVersions = Array.isArray(nextDocumentVersionsRaw) ? nextDocumentVersionsRaw : [];
     setJobs(nextJobs);
     setStylePacks(nextStylePacks);
+    setMatterOptions(nextMatters);
+    setDocumentVersionOptions(nextDocumentVersions);
     setStylePackDrafts((previous) => buildStylePackDrafts(nextStylePacks, previous));
     setDeadlineSelections((previous) => buildSelectionState(nextJobs, previous));
+    setSelectedMatterId((current) => current || nextMatters[0]?.id || '');
     if (selectedStylePackId && !nextStylePacks.some((stylePack) => stylePack.id === selectedStylePackId)) {
       setSelectedStylePackId('');
     }
-  }
+  }, [selectedMatterId, selectedStylePackId]);
 
   useEffect(() => {
     load().catch(() => undefined);
-  }, []);
+  }, [load]);
 
   async function createJob(e: FormEvent) {
     e.preventDefault();
-    if (!matterId) return;
+    if (!selectedMatterId) return;
     setError(null);
     try {
       const payload: { matterId: string; toolName: string; input: Record<string, unknown>; stylePackId?: string } = {
-        matterId,
+        matterId: selectedMatterId,
         toolName,
         input: {},
       };
@@ -418,16 +447,23 @@ export default function AiPage() {
               </div>
 
               <div style={{ marginTop: 8, display: 'grid', gap: 8, gridTemplateColumns: '1fr auto' }}>
-                <input
+                <select
                   className="input"
+                  aria-label={`Style Pack Source Document ${stylePack.id}`}
                   value={draft.documentVersionId}
                   onChange={(event) => updateStylePackDraft(stylePack.id, 'documentVersionId', event.target.value)}
-                  placeholder="Attach source document version ID"
-                />
+                >
+                  <option value="">Select source document version</option>
+                  {documentVersionOptions.map((version) => (
+                    <option key={version.id} value={version.id}>
+                      {version.label}
+                    </option>
+                  ))}
+                </select>
                 <button
                   className="button ghost"
                   type="button"
-                  disabled={isBusy || !draft.documentVersionId.trim()}
+                  disabled={isBusy || !draft.documentVersionId}
                   onClick={() => attachStylePackSourceDoc(stylePack.id)}
                 >
                   Attach Source Doc
@@ -476,7 +512,19 @@ export default function AiPage() {
 
       <div className="card" style={{ marginBottom: 14 }}>
         <form onSubmit={createJob} style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 220px 260px auto' }}>
-          <input className="input" value={matterId} onChange={(e) => setMatterId(e.target.value)} placeholder="Matter ID" />
+          <select
+            className="select"
+            aria-label="AI Matter"
+            value={selectedMatterId}
+            onChange={(event) => setSelectedMatterId(event.target.value)}
+          >
+            <option value="">Select matter</option>
+            {matterOptions.map((matter) => (
+              <option key={matter.id} value={matter.id}>
+                {matter.label}
+              </option>
+            ))}
+          </select>
           <select className="select" value={toolName} onChange={(e) => setToolName(e.target.value)}>
             {TOOLS.map((tool) => (
               <option key={tool} value={tool}>{tool}</option>

--- a/apps/web/app/billing/page.tsx
+++ b/apps/web/app/billing/page.tsx
@@ -5,35 +5,67 @@ import { AppShell } from '../../components/app-shell';
 import { PageHeader } from '../../components/page-header';
 import { apiFetch } from '../../lib/api';
 
+type MatterLookup = {
+  id: string;
+  matterNumber: string;
+  name: string;
+  label: string;
+};
+
+type TrustAccountLookup = {
+  id: string;
+  name: string;
+  label: string;
+};
+
+type InvoiceLookup = {
+  id: string;
+  invoiceNumber: string;
+  label: string;
+};
+
 export default function BillingPage() {
   const [invoices, setInvoices] = useState<any[]>([]);
   const [trustRows, setTrustRows] = useState<any[]>([]);
   const [reconciliationRuns, setReconciliationRuns] = useState<any[]>([]);
   const [ledesProfiles, setLedesProfiles] = useState<any[]>([]);
   const [ledesJobs, setLedesJobs] = useState<any[]>([]);
-  const [matterId, setMatterId] = useState('');
+  const [matterOptions, setMatterOptions] = useState<MatterLookup[]>([]);
+  const [trustAccountOptions, setTrustAccountOptions] = useState<TrustAccountLookup[]>([]);
+  const [invoiceOptions, setInvoiceOptions] = useState<InvoiceLookup[]>([]);
+  const [selectedMatterId, setSelectedMatterId] = useState('');
   const [reconciliationTrustAccountId, setReconciliationTrustAccountId] = useState('');
   const [statementStartAt, setStatementStartAt] = useState('');
   const [statementEndAt, setStatementEndAt] = useState('');
   const [reconciliationStatus, setReconciliationStatus] = useState<string | null>(null);
   const [ledesProfileName, setLedesProfileName] = useState('Default LEDES 1998B');
   const [selectedLedesProfileId, setSelectedLedesProfileId] = useState('');
-  const [ledesInvoiceIds, setLedesInvoiceIds] = useState('');
+  const [selectedLedesInvoiceId, setSelectedLedesInvoiceId] = useState('');
+  const [selectedLedesInvoiceIds, setSelectedLedesInvoiceIds] = useState<string[]>([]);
   const [ledesStatus, setLedesStatus] = useState<string | null>(null);
 
   async function load() {
-    const [invoiceData, trustData, reconciliationData, profileData, ledesJobData] = await Promise.all([
+    const [invoiceData, trustData, reconciliationData, profileData, ledesJobData, mattersData, trustLookupData, invoiceLookupData] = await Promise.all([
       apiFetch<any[]>('/billing/invoices'),
       apiFetch<any[]>('/billing/trust/report'),
       apiFetch<any[]>('/billing/trust/reconciliation/runs'),
       apiFetch<any[]>('/billing/ledes/profiles'),
       apiFetch<any[]>('/billing/ledes/jobs'),
+      apiFetch<MatterLookup[]>('/lookups/matters?limit=200'),
+      apiFetch<TrustAccountLookup[]>('/lookups/trust-accounts?limit=200'),
+      apiFetch<InvoiceLookup[]>('/lookups/invoices?limit=200'),
     ]);
     setInvoices(invoiceData);
     setTrustRows(trustData);
     setReconciliationRuns(reconciliationData);
     setLedesProfiles(profileData);
     setLedesJobs(ledesJobData);
+    setMatterOptions(mattersData);
+    setTrustAccountOptions(trustLookupData);
+    setInvoiceOptions(invoiceLookupData);
+    setSelectedMatterId((current) => current || mattersData[0]?.id || '');
+    setReconciliationTrustAccountId((current) => current || trustLookupData[0]?.id || '');
+    setSelectedLedesInvoiceId((current) => current || invoiceLookupData[0]?.id || '');
     setSelectedLedesProfileId((current) => {
       if (current) return current;
       const defaultProfile = profileData.find((profile) => profile.isDefault);
@@ -47,12 +79,12 @@ export default function BillingPage() {
 
   async function createInvoice(e: FormEvent) {
     e.preventDefault();
-    if (!matterId) return;
+    if (!selectedMatterId) return;
 
     await apiFetch('/billing/invoices', {
       method: 'POST',
       body: JSON.stringify({
-        matterId,
+        matterId: selectedMatterId,
         lineItems: [{ description: 'Legal Services', quantity: 2, unitPrice: 425 }],
       }),
     });
@@ -125,10 +157,7 @@ export default function BillingPage() {
       return;
     }
 
-    const invoiceIds = ledesInvoiceIds
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean);
+    const invoiceIds = selectedLedesInvoiceIds.filter(Boolean);
 
     const created = await apiFetch<any>('/billing/ledes/jobs', {
       method: 'POST',
@@ -147,6 +176,22 @@ export default function BillingPage() {
     await load();
   }
 
+  function addSelectedLedesInvoice() {
+    if (!selectedLedesInvoiceId) {
+      return;
+    }
+    setSelectedLedesInvoiceIds((current) => {
+      if (current.includes(selectedLedesInvoiceId)) {
+        return current;
+      }
+      return [...current, selectedLedesInvoiceId];
+    });
+  }
+
+  function removeSelectedLedesInvoice(invoiceId: string) {
+    setSelectedLedesInvoiceIds((current) => current.filter((item) => item !== invoiceId));
+  }
+
   async function downloadLedesJob(jobId: string) {
     const result = await apiFetch<{ downloadUrl: string }>(`/billing/ledes/jobs/${jobId}/download`);
     if (typeof window !== 'undefined') {
@@ -163,7 +208,19 @@ export default function BillingPage() {
       </div>
       <div className="card" style={{ marginBottom: 14 }}>
         <form onSubmit={createInvoice} style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 10 }}>
-          <input className="input" placeholder="Matter ID" value={matterId} onChange={(e) => setMatterId(e.target.value)} />
+          <select
+            className="input"
+            aria-label="Invoice Matter"
+            value={selectedMatterId}
+            onChange={(event) => setSelectedMatterId(event.target.value)}
+          >
+            <option value="">Select matter</option>
+            {matterOptions.map((matter) => (
+              <option key={matter.id} value={matter.id}>
+                {matter.label}
+              </option>
+            ))}
+          </select>
           <button className="button" type="submit">Create Invoice</button>
         </form>
       </div>
@@ -215,12 +272,19 @@ export default function BillingPage() {
       <div className="card" style={{ marginTop: 14 }}>
         <h3 style={{ marginTop: 0 }}>Trust Reconciliation Runs</h3>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 180px 180px auto', gap: 10, marginBottom: 12 }}>
-          <input
+          <select
             className="input"
-            placeholder="Trust Account ID (optional)"
+            aria-label="Reconciliation Trust Account"
             value={reconciliationTrustAccountId}
             onChange={(event) => setReconciliationTrustAccountId(event.target.value)}
-          />
+          >
+            <option value="">All trust accounts</option>
+            {trustAccountOptions.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.label}
+              </option>
+            ))}
+          </select>
           <input
             className="input"
             type="date"
@@ -320,16 +384,42 @@ export default function BillingPage() {
               </option>
             ))}
           </select>
-          <input
-            className="input"
-            placeholder="Invoice IDs (comma separated, optional)"
-            value={ledesInvoiceIds}
-            onChange={(event) => setLedesInvoiceIds(event.target.value)}
-          />
+          <div style={{ display: 'flex', gap: 8 }}>
+            <select
+              className="input"
+              aria-label="LEDES Invoice Select"
+              value={selectedLedesInvoiceId}
+              onChange={(event) => setSelectedLedesInvoiceId(event.target.value)}
+            >
+              <option value="">Select invoice (optional)</option>
+              {invoiceOptions.map((invoice) => (
+                <option key={invoice.id} value={invoice.id}>
+                  {invoice.label}
+                </option>
+              ))}
+            </select>
+            <button className="button secondary" type="button" onClick={addSelectedLedesInvoice}>
+              Add Invoice
+            </button>
+          </div>
           <button className="button secondary" type="button" onClick={createLedesJob}>
             Run LEDES Export
           </button>
         </div>
+        {selectedLedesInvoiceIds.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 10 }}>
+            {selectedLedesInvoiceIds.map((invoiceId) => (
+              <button
+                key={invoiceId}
+                className="button secondary"
+                type="button"
+                onClick={() => removeSelectedLedesInvoice(invoiceId)}
+              >
+                Remove {invoiceOptions.find((invoice) => invoice.id === invoiceId)?.invoiceNumber || invoiceId}
+              </button>
+            ))}
+          </div>
+        ) : null}
         {ledesStatus ? <p style={{ color: 'var(--lic-text-muted)' }}>{ledesStatus}</p> : null}
         <table className="table">
           <thead>

--- a/apps/web/app/communications/page.tsx
+++ b/apps/web/app/communications/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { AppShell } from '../../components/app-shell';
 import { PageHeader } from '../../components/page-header';
 import { Button } from '../../components/ui/button';
@@ -15,15 +15,15 @@ export default function CommunicationsPage() {
   const [query, setQuery] = useState('');
   const [searchResults, setSearchResults] = useState<any[]>([]);
 
-  async function load() {
+  const load = useCallback(async () => {
     const data = await apiFetch<any[]>('/communications/threads');
     setThreads(data);
-    if (!threadId && data[0]?.id) setThreadId(data[0].id);
-  }
+    setThreadId((current) => current || data[0]?.id || '');
+  }, []);
 
   useEffect(() => {
     load().catch(() => undefined);
-  }, []);
+  }, [load]);
 
   async function createThread() {
     const created = await apiFetch<any>('/communications/threads', {
@@ -90,7 +90,19 @@ export default function CommunicationsPage() {
         <Card>
           <h3 style={{ marginTop: 0 }}>Log Message</h3>
           <form onSubmit={addMessage} style={{ display: 'grid', gap: 10 }}>
-            <Input value={threadId} onChange={(e) => setThreadId(e.target.value)} placeholder="Thread ID" />
+            <select
+              className="input"
+              aria-label="Communication Thread"
+              value={threadId}
+              onChange={(e) => setThreadId(e.target.value)}
+            >
+              <option value="">Select Thread</option>
+              {threads.map((thread) => (
+                <option key={thread.id} value={thread.id}>
+                  {thread.subject || thread.id}
+                </option>
+              ))}
+            </select>
             <textarea className="textarea" value={body} onChange={(e) => setBody(e.target.value)} rows={4} />
             <Button type="submit">Save Call Log</Button>
           </form>

--- a/apps/web/app/documents/page.tsx
+++ b/apps/web/app/documents/page.tsx
@@ -7,14 +7,22 @@ import { getSessionToken } from '../../lib/api';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 
+type MatterLookup = {
+  id: string;
+  matterNumber: string;
+  name: string;
+  label: string;
+};
+
 export default function DocumentsPage() {
   const [documents, setDocuments] = useState<any[]>([]);
+  const [matterOptions, setMatterOptions] = useState<MatterLookup[]>([]);
   const [retentionPolicies, setRetentionPolicies] = useState<any[]>([]);
   const [dispositionRuns, setDispositionRuns] = useState<any[]>([]);
-  const [matterId, setMatterId] = useState('');
+  const [selectedMatterId, setSelectedMatterId] = useState('');
   const [title, setTitle] = useState('Inspection Report');
   const [file, setFile] = useState<File | null>(null);
-  const [pdfMatterId, setPdfMatterId] = useState('');
+  const [selectedPdfMatterId, setSelectedPdfMatterId] = useState('');
   const [policyName, setPolicyName] = useState('Default 7-year retention');
   const [policyScope, setPolicyScope] = useState<'ALL_DOCUMENTS' | 'MATTER' | 'CATEGORY'>('ALL_DOCUMENTS');
   const [policyTrigger, setPolicyTrigger] = useState<'DOCUMENT_UPLOADED' | 'MATTER_CLOSED'>('DOCUMENT_UPLOADED');
@@ -30,6 +38,19 @@ export default function DocumentsPage() {
     });
     if (!response.ok) return;
     setDocuments(await response.json());
+  }
+
+  async function loadMatterLookups() {
+    const token = getSessionToken();
+    const response = await fetch(`${API_BASE}/lookups/matters?limit=200`, {
+      headers: token ? { 'x-session-token': token } : {},
+      credentials: 'include',
+    });
+    if (!response.ok) return;
+    const matters = (await response.json()) as MatterLookup[];
+    setMatterOptions(matters);
+    setSelectedMatterId((current) => current || matters[0]?.id || '');
+    setSelectedPdfMatterId((current) => current || matters[0]?.id || '');
   }
 
   async function loadRetentionData() {
@@ -57,15 +78,15 @@ export default function DocumentsPage() {
   }
 
   useEffect(() => {
-    loadDocuments().catch(() => undefined);
+    Promise.all([loadDocuments(), loadMatterLookups()]).catch(() => undefined);
   }, []);
 
   async function upload(e: FormEvent) {
     e.preventDefault();
-    if (!file || !matterId) return;
+    if (!file || !selectedMatterId) return;
 
     const form = new FormData();
-    form.set('matterId', matterId);
+    form.set('matterId', selectedMatterId);
     form.set('title', title);
     form.set('file', file);
 
@@ -82,7 +103,7 @@ export default function DocumentsPage() {
   }
 
   async function generatePdf() {
-    if (!pdfMatterId) return;
+    if (!selectedPdfMatterId) return;
     const token = getSessionToken();
     await fetch(`${API_BASE}/documents/generate-pdf`, {
       method: 'POST',
@@ -91,7 +112,7 @@ export default function DocumentsPage() {
         ...(token ? { 'x-session-token': token } : {}),
       },
       body: JSON.stringify({
-        matterId: pdfMatterId,
+        matterId: selectedPdfMatterId,
         title: 'Generated Client Letter',
         lines: ['Attorney Review Required', 'Draft letter body here.'],
       }),
@@ -239,13 +260,37 @@ export default function DocumentsPage() {
       <PageHeader title="Documents" subtitle="Secure upload/versioning, malware-scan hook, signed links, and share links." />
       <div className="card" style={{ marginBottom: 14 }}>
         <form onSubmit={upload} style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 1fr 1fr auto' }}>
-          <input className="input" placeholder="Matter ID" value={matterId} onChange={(e) => setMatterId(e.target.value)} />
+          <select
+            className="input"
+            aria-label="Upload Matter"
+            value={selectedMatterId}
+            onChange={(event) => setSelectedMatterId(event.target.value)}
+          >
+            <option value="">Select matter</option>
+            {matterOptions.map((matter) => (
+              <option key={matter.id} value={matter.id}>
+                {matter.label}
+              </option>
+            ))}
+          </select>
           <input className="input" placeholder="Title" value={title} onChange={(e) => setTitle(e.target.value)} />
           <input className="input" type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
           <button className="button" type="submit">Upload</button>
         </form>
         <div style={{ marginTop: 10, display: 'grid', gridTemplateColumns: '1fr auto', gap: 10 }}>
-          <input className="input" placeholder="Matter ID for generated PDF" value={pdfMatterId} onChange={(e) => setPdfMatterId(e.target.value)} />
+          <select
+            className="input"
+            aria-label="PDF Matter"
+            value={selectedPdfMatterId}
+            onChange={(event) => setSelectedPdfMatterId(event.target.value)}
+          >
+            <option value="">Select matter for generated PDF</option>
+            {matterOptions.map((matter) => (
+              <option key={matter.id} value={matter.id}>
+                {matter.label}
+              </option>
+            ))}
+          </select>
           <button className="button secondary" type="button" onClick={generatePdf}>Generate PDF Draft</button>
         </div>
       </div>

--- a/apps/web/app/matters/[id]/page.tsx
+++ b/apps/web/app/matters/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { AppShell } from '../../../components/app-shell';
 import { PageHeader } from '../../../components/page-header';
@@ -50,6 +50,11 @@ type CommunicationThread = {
   }>;
 };
 
+type TrustAccountOption = {
+  id: string;
+  label: string;
+};
+
 const TASK_STATUS_OPTIONS = ['TODO', 'IN_PROGRESS', 'BLOCKED', 'DONE', 'CANCELED'] as const;
 const TASK_PRIORITY_OPTIONS = ['LOW', 'MEDIUM', 'HIGH', 'URGENT'] as const;
 const COMMUNICATION_TYPE_OPTIONS = ['EMAIL', 'SMS', 'CALL_LOG', 'PORTAL_MESSAGE', 'INTERNAL_NOTE'] as const;
@@ -78,6 +83,35 @@ function isCounselRole(roleKey?: string, roleLabel?: string | null) {
 
 function withTimestamp(message: string) {
   return `${message} ${new Date().toLocaleString()}`;
+}
+
+function collectTrustAccountOptions(dashboard: any): TrustAccountOption[] {
+  if (!dashboard) {
+    return [];
+  }
+  const options: TrustAccountOption[] = [];
+  const seen = new Set<string>();
+
+  const push = (id?: string | null, name?: string | null) => {
+    const normalizedId = String(id || '').trim();
+    if (!normalizedId || seen.has(normalizedId)) {
+      return;
+    }
+    seen.add(normalizedId);
+    options.push({
+      id: normalizedId,
+      label: name && String(name).trim() ? String(name) : normalizedId,
+    });
+  };
+
+  for (const row of dashboard.trustLedgers || []) {
+    push(row.trustAccount?.id || row.trustAccountId, row.trustAccount?.name);
+  }
+  for (const row of dashboard.trustTransactions || []) {
+    push(row.trustAccount?.id || row.trustAccountId, row.trustAccount?.name);
+  }
+
+  return options;
 }
 
 export default function MatterDashboardPage() {
@@ -161,8 +195,9 @@ export default function MatterDashboardPage() {
   const [trustTransactionAmount, setTrustTransactionAmount] = useState('');
   const [trustTransactionDescription, setTrustTransactionDescription] = useState('');
   const [billingStatusMessage, setBillingStatusMessage] = useState<string | null>(null);
+  const trustAccountOptions = useMemo(() => collectTrustAccountOptions(dashboard), [dashboard]);
 
-  async function refreshDashboard() {
+  const refreshDashboard = useCallback(async () => {
     if (!matterId) {
       return;
     }
@@ -194,9 +229,10 @@ export default function MatterDashboardPage() {
       if (current) {
         return current;
       }
-      return nextDashboard.trustLedgers?.[0]?.trustAccountId || '';
+      const nextTrustAccounts = collectTrustAccountOptions(nextDashboard);
+      return nextTrustAccounts[0]?.id || '';
     });
-  }
+  }, [matterId]);
 
   useEffect(() => {
     if (!matterId) return;
@@ -228,7 +264,7 @@ export default function MatterDashboardPage() {
         }
       })
       .catch(() => undefined);
-  }, [matterId]);
+  }, [matterId, refreshDashboard]);
 
   const selectedParticipantRole = participantRoleOptions.find((role) => role.key === selectedParticipantRoleKey);
   const participantRoleIsCounsel = isCounselRole(selectedParticipantRole?.key, selectedParticipantRole?.label);
@@ -1970,13 +2006,19 @@ export default function MatterDashboardPage() {
             </div>
 
             <div style={{ display: 'grid', gap: 8, gridTemplateColumns: '1fr 180px 140px 1fr auto', marginBottom: 12 }}>
-              <input
+              <select
                 className="input"
-                aria-label="Billing Trust Account Id"
-                placeholder="Trust account ID"
+                aria-label="Billing Trust Account"
                 value={trustAccountId}
                 onChange={(event) => setTrustAccountId(event.target.value)}
-              />
+              >
+                <option value="">Select Trust Account</option>
+                {trustAccountOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
               <select
                 className="input"
                 aria-label="Billing Trust Transaction Type"

--- a/apps/web/app/matters/page.tsx
+++ b/apps/web/app/matters/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { AppShell } from '../../components/app-shell';
 import { PageHeader } from '../../components/page-header';
@@ -54,21 +54,19 @@ export default function MattersPage() {
   const [selectedDraftId, setSelectedDraftId] = useState('');
   const [wizardStatus, setWizardStatus] = useState<string | null>(null);
 
-  async function loadMatters() {
+  const loadMatters = useCallback(async () => {
     setMatters(await apiFetch<Matter[]>('/matters'));
-  }
+  }, []);
 
-  async function loadDrafts() {
+  const loadDrafts = useCallback(async () => {
     const rows = await apiFetch<IntakeDraftSummary[]>('/matters/intake-wizard/drafts');
     setDrafts(rows);
-    if (!selectedDraftId && rows[0]?.id) {
-      setSelectedDraftId(rows[0].id);
-    }
-  }
+    setSelectedDraftId((current) => current || rows[0]?.id || '');
+  }, []);
 
   useEffect(() => {
     Promise.all([loadMatters(), loadDrafts()]).catch(() => undefined);
-  }, []);
+  }, [loadDrafts, loadMatters]);
 
   async function createMatter(e: FormEvent) {
     e.preventDefault();

--- a/apps/web/app/portal/page.tsx
+++ b/apps/web/app/portal/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { AppShell } from '../../components/app-shell';
 import { ConfirmDialog } from '../../components/confirm-dialog';
 import { PageHeader } from '../../components/page-header';
@@ -8,9 +8,14 @@ import { apiFetch, getSessionToken } from '../../lib/api';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
 type PortalConfirmAction = 'send-message' | 'create-esign' | null;
+type PortalMatterOption = { id: string; matterNumber?: string | null; name?: string | null };
+type PortalLookupOption = { id: string; name: string };
 
 export default function PortalPage() {
   const [snapshot, setSnapshot] = useState<any>(null);
+  const [matterOptions, setMatterOptions] = useState<PortalMatterOption[]>([]);
+  const [intakeFormOptions, setIntakeFormOptions] = useState<PortalLookupOption[]>([]);
+  const [engagementTemplateOptions, setEngagementTemplateOptions] = useState<PortalLookupOption[]>([]);
   const [matterId, setMatterId] = useState('');
   const [message, setMessage] = useState('Can you share the latest mediation timeline?');
   const [attachmentFile, setAttachmentFile] = useState<File | null>(null);
@@ -22,9 +27,25 @@ export default function PortalPage() {
   const [confirmAction, setConfirmAction] = useState<PortalConfirmAction>(null);
   const [confirmBusy, setConfirmBusy] = useState(false);
 
-  useEffect(() => {
-    apiFetch('/portal/snapshot').then(setSnapshot).catch(() => undefined);
+  const loadPortalData = useCallback(async () => {
+    const [nextSnapshot, nextIntakeForms, nextTemplates] = await Promise.all([
+      apiFetch<any>('/portal/snapshot'),
+      apiFetch<PortalLookupOption[]>('/portal/intake-form-definitions').catch(() => []),
+      apiFetch<PortalLookupOption[]>('/portal/engagement-letter-templates').catch(() => []),
+    ]);
+    const matters = Array.isArray(nextSnapshot?.matters) ? nextSnapshot.matters : [];
+    setSnapshot(nextSnapshot);
+    setMatterOptions(matters);
+    setIntakeFormOptions(Array.isArray(nextIntakeForms) ? nextIntakeForms : []);
+    setEngagementTemplateOptions(Array.isArray(nextTemplates) ? nextTemplates : []);
+    setMatterId((current) => current || matters[0]?.id || '');
+    setIntakeFormDefinitionId((current) => current || nextIntakeForms[0]?.id || '');
+    setEngagementLetterTemplateId((current) => current || nextTemplates[0]?.id || '');
   }, []);
+
+  useEffect(() => {
+    loadPortalData().catch(() => undefined);
+  }, [loadPortalData]);
 
   async function sendPortalMessage(e: FormEvent) {
     e.preventDefault();
@@ -71,7 +92,7 @@ export default function PortalPage() {
 
     setAttachmentFile(null);
     setAttachmentTitle('');
-    setSnapshot(await apiFetch('/portal/snapshot'));
+    await loadPortalData();
   }
 
   async function downloadPortalAttachment(versionId: string) {
@@ -91,7 +112,7 @@ export default function PortalPage() {
         data: { homeownerGoal: 'Resolve defect damages and warranty claims' },
       }),
     });
-    setSnapshot(await apiFetch('/portal/snapshot'));
+    await loadPortalData();
   }
 
   async function createEsignEnvelope() {
@@ -109,7 +130,7 @@ export default function PortalPage() {
         provider: eSignProvider,
       }),
     });
-    setSnapshot(await apiFetch('/portal/snapshot'));
+    await loadPortalData();
   }
 
   async function confirmClientAction() {
@@ -134,7 +155,7 @@ export default function PortalPage() {
     await apiFetch(`/portal/esign/${envelopeId}/refresh`, {
       method: 'POST',
     });
-    setSnapshot(await apiFetch('/portal/snapshot'));
+    await loadPortalData();
   }
 
   return (
@@ -167,7 +188,19 @@ export default function PortalPage() {
             onSubmit={sendPortalMessage}
             style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr 2fr 1fr 1fr auto' }}
           >
-            <input className="input" value={matterId} onChange={(e) => setMatterId(e.target.value)} placeholder="Matter ID" />
+            <select
+              className="select"
+              aria-label="Portal Matter"
+              value={matterId}
+              onChange={(e) => setMatterId(e.target.value)}
+            >
+              <option value="">Select matter</option>
+              {matterOptions.map((matter) => (
+                <option key={matter.id} value={matter.id}>
+                  {matter.matterNumber ? `${matter.matterNumber} - ${matter.name || matter.id}` : matter.name || matter.id}
+                </option>
+              ))}
+            </select>
             <input className="input" value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Message" />
             <input
               className="input"
@@ -235,11 +268,35 @@ export default function PortalPage() {
         <div className="card" style={{ gridColumn: '1 / -1' }}>
           <h3 style={{ marginTop: 0 }}>Intake + E-Sign</h3>
           <div style={{ display: 'grid', gap: 10, gridTemplateColumns: '1fr auto' }}>
-            <input className="input" value={intakeFormDefinitionId} onChange={(e) => setIntakeFormDefinitionId(e.target.value)} placeholder="Intake Form Definition ID" />
+            <select
+              className="select"
+              aria-label="Portal Intake Form"
+              value={intakeFormDefinitionId}
+              onChange={(e) => setIntakeFormDefinitionId(e.target.value)}
+            >
+              <option value="">Select intake form</option>
+              {intakeFormOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
             <button className="button ghost" type="button" onClick={submitIntake}>
               Submit Intake
             </button>
-            <input className="input" value={engagementLetterTemplateId} onChange={(e) => setEngagementLetterTemplateId(e.target.value)} placeholder="Engagement Letter Template ID" />
+            <select
+              className="select"
+              aria-label="Portal Engagement Template"
+              value={engagementLetterTemplateId}
+              onChange={(e) => setEngagementLetterTemplateId(e.target.value)}
+            >
+              <option value="">Select engagement template</option>
+              {engagementTemplateOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.name}
+                </option>
+              ))}
+            </select>
             <select
               className="select"
               aria-label="E-Sign Provider"

--- a/apps/web/test/ai-page.spec.tsx
+++ b/apps/web/test/ai-page.spec.tsx
@@ -23,53 +23,60 @@ describe('AiPage', () => {
   });
 
   it('requires explicit deadline confirmation and submits selected rows', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse([
+    const jobs = [
+      {
+        id: 'job-1',
+        toolName: 'deadline_extraction',
+        matterId: 'matter-1',
+        status: 'COMPLETED',
+        artifacts: [
           {
-            id: 'job-1',
-            toolName: 'deadline_extraction',
-            matterId: 'matter-1',
-            status: 'COMPLETED',
-            artifacts: [
-              {
-                id: 'artifact-1',
-                type: 'deadline_extraction',
-                content: 'Draft deadline table',
-                reviewedStatus: 'DRAFT',
-                metadataJson: {
-                  banner: 'Attorney Review Required - AI output is a draft and not legal advice.',
-                  deadlineCandidates: [
-                    {
-                      id: 'deadline-1',
-                      date: '2026-03-01',
-                      description: 'Serve initial disclosures',
-                      chunkId: 'chunk-abc',
-                      excerpt: 'Within 14 days after Rule 26(f) conference.',
-                    },
-                  ],
-                  excerptEvidence: [
-                    {
-                      chunkId: 'chunk-abc',
-                      excerpt: 'Within 14 days after Rule 26(f) conference.',
-                    },
-                  ],
+            id: 'artifact-1',
+            type: 'deadline_extraction',
+            content: 'Draft deadline table',
+            reviewedStatus: 'DRAFT',
+            metadataJson: {
+              banner: 'Attorney Review Required - AI output is a draft and not legal advice.',
+              deadlineCandidates: [
+                {
+                  id: 'deadline-1',
+                  date: '2026-03-01',
+                  description: 'Serve initial disclosures',
+                  chunkId: 'chunk-abc',
+                  excerpt: 'Within 14 days after Rule 26(f) conference.',
                 },
-              },
-            ],
+              ],
+              excerptEvidence: [
+                {
+                  chunkId: 'chunk-abc',
+                  excerpt: 'Within 14 days after Rule 26(f) conference.',
+                },
+              ],
+            },
           },
-        ]),
-      )
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(
-        jsonResponse({
+        ],
+      },
+    ];
+    const matters = [{ id: 'matter-1', matterNumber: 'M-1', name: 'Builder Dispute', label: 'M-1 - Builder Dispute' }];
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.endsWith('/ai/jobs') && method === 'GET') return jsonResponse(jobs);
+      if (url.endsWith('/ai/style-packs') && method === 'GET') return jsonResponse([]);
+      if (url.endsWith('/lookups/matters?limit=200')) return jsonResponse(matters);
+      if (url.includes('/lookups/document-versions?limit=200')) return jsonResponse([]);
+      if (url.endsWith('/ai/artifacts/artifact-1/confirm-deadlines') && method === 'POST') {
+        return jsonResponse({
           created: [
             { type: 'task', id: 'task-1' },
             { type: 'event', id: 'event-1' },
           ],
-        }),
-      );
+        });
+      }
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     render(<AiPage />);
@@ -127,47 +134,52 @@ describe('AiPage', () => {
   });
 
   it('shows validation error when selected deadline has no task/event outputs enabled', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse([
+    const jobs = [
+      {
+        id: 'job-1',
+        toolName: 'deadline_extraction',
+        matterId: 'matter-1',
+        status: 'COMPLETED',
+        artifacts: [
           {
-            id: 'job-1',
-            toolName: 'deadline_extraction',
-            matterId: 'matter-1',
-            status: 'COMPLETED',
-            artifacts: [
-              {
-                id: 'artifact-1',
-                type: 'deadline_extraction',
-                content: 'Draft deadline table',
-                reviewedStatus: 'DRAFT',
-                metadataJson: {
-                  banner: 'Attorney Review Required - AI output is a draft and not legal advice.',
-                  deadlineCandidates: [
-                    {
-                      id: 'deadline-1',
-                      date: '2026-03-01',
-                      description: 'Serve initial disclosures',
-                      chunkId: 'chunk-abc',
-                      excerpt: 'Within 14 days after Rule 26(f) conference.',
-                    },
-                  ],
+            id: 'artifact-1',
+            type: 'deadline_extraction',
+            content: 'Draft deadline table',
+            reviewedStatus: 'DRAFT',
+            metadataJson: {
+              banner: 'Attorney Review Required - AI output is a draft and not legal advice.',
+              deadlineCandidates: [
+                {
+                  id: 'deadline-1',
+                  date: '2026-03-01',
+                  description: 'Serve initial disclosures',
+                  chunkId: 'chunk-abc',
+                  excerpt: 'Within 14 days after Rule 26(f) conference.',
                 },
-              },
-            ],
+              ],
+            },
           },
-        ]),
-      )
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(
-        jsonResponse(
+        ],
+      },
+    ];
+    const matters = [{ id: 'matter-1', matterNumber: 'M-1', name: 'Builder Dispute', label: 'M-1 - Builder Dispute' }];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+      if (url.endsWith('/ai/jobs') && method === 'GET') return jsonResponse(jobs);
+      if (url.endsWith('/ai/style-packs') && method === 'GET') return jsonResponse([]);
+      if (url.endsWith('/lookups/matters?limit=200')) return jsonResponse(matters);
+      if (url.includes('/lookups/document-versions?limit=200')) return jsonResponse([]);
+      if (url.endsWith('/ai/artifacts/artifact-1/confirm-deadlines') && method === 'POST') {
+        return jsonResponse(
           {
             message: 'Select at least one output (task/event) at row 1',
           },
           400,
-        ),
-      );
+        );
+      }
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
 
     vi.stubGlobal('fetch', fetchMock);
 
@@ -324,6 +336,9 @@ describe('AiPage', () => {
   });
 
   it('includes selected style pack id when creating AI jobs', async () => {
+    const matters = [
+      { id: 'matter-99', matterNumber: 'M-99', name: 'Demand Matter', label: 'M-99 - Demand Matter' },
+    ];
     const stylePacks = [
       {
         id: 'style-pack-1',
@@ -333,13 +348,17 @@ describe('AiPage', () => {
       },
     ];
 
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse(stylePacks))
-      .mockResolvedValueOnce(jsonResponse({ id: 'job-3' }))
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse(stylePacks));
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.endsWith('/ai/jobs') && method === 'GET') return jsonResponse([]);
+      if (url.endsWith('/ai/jobs') && method === 'POST') return jsonResponse({ id: 'job-3' });
+      if (url.endsWith('/ai/style-packs') && method === 'GET') return jsonResponse(stylePacks);
+      if (url.endsWith('/lookups/matters?limit=200')) return jsonResponse(matters);
+      if (url.includes('/lookups/document-versions?limit=200')) return jsonResponse([]);
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     render(<AiPage />);
@@ -348,7 +367,7 @@ describe('AiPage', () => {
       expect(screen.getByRole('option', { name: 'Plaintiff Demand Tone' })).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Matter ID'), {
+    fireEvent.change(screen.getByLabelText('AI Matter'), {
       target: { value: 'matter-99' },
     });
     fireEvent.change(screen.getByDisplayValue('No style pack'), {
@@ -368,6 +387,20 @@ describe('AiPage', () => {
   });
 
   it('creates, updates, attaches, and removes style pack source docs', async () => {
+    const matters = [
+      { id: 'matter-1', matterNumber: 'M-1', name: 'Builder Dispute', label: 'M-1 - Builder Dispute' },
+    ];
+    const lookupDocumentVersions = [
+      {
+        id: 'ver-1',
+        label: 'Sample Demand (ver-1)',
+        document: {
+          id: 'doc-1',
+          matterId: 'matter-1',
+          title: 'Sample Demand',
+        },
+      },
+    ];
     const stylePackBase = {
       id: 'style-pack-9',
       name: 'Builder Defense',
@@ -395,22 +428,38 @@ describe('AiPage', () => {
       ],
     };
 
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse({ ...stylePackBase, sourceDocs: [] }))
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse([{ ...stylePackBase, sourceDocs: [] }]))
-      .mockResolvedValueOnce(jsonResponse({ ...stylePackBase, sourceDocs: [] }))
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse([{ ...stylePackBase, sourceDocs: [] }]))
-      .mockResolvedValueOnce(jsonResponse(stylePackWithDoc))
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse([stylePackWithDoc]))
-      .mockResolvedValueOnce(jsonResponse({ ...stylePackBase, sourceDocs: [] }))
-      .mockResolvedValueOnce(jsonResponse([]))
-      .mockResolvedValueOnce(jsonResponse([{ ...stylePackBase, sourceDocs: [] }]));
+    let stylePacks: any[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+
+      if (url.endsWith('/ai/jobs') && method === 'GET') return jsonResponse([]);
+      if (url.endsWith('/ai/style-packs') && method === 'GET') return jsonResponse(stylePacks);
+      if (url.endsWith('/lookups/matters?limit=200')) return jsonResponse(matters);
+      if (url.includes('/lookups/document-versions?limit=200')) return jsonResponse(lookupDocumentVersions);
+
+      if (url.endsWith('/ai/style-packs') && method === 'POST') {
+        stylePacks = [{ ...stylePackBase, sourceDocs: [] }];
+        return jsonResponse(stylePacks[0]);
+      }
+
+      if (url.endsWith('/ai/style-packs/style-pack-9') && method === 'PATCH') {
+        stylePacks = [{ ...stylePacks[0], name: 'Builder Defense Updated' }];
+        return jsonResponse(stylePacks[0]);
+      }
+
+      if (url.endsWith('/ai/style-packs/style-pack-9/source-docs') && method === 'POST') {
+        stylePacks = [{ ...stylePackWithDoc, name: stylePacks[0]?.name || stylePackWithDoc.name }];
+        return jsonResponse(stylePacks[0]);
+      }
+
+      if (url.endsWith('/ai/style-packs/style-pack-9/source-docs/ver-1') && method === 'DELETE') {
+        stylePacks = [{ ...(stylePacks[0] || stylePackBase), sourceDocs: [] }];
+        return jsonResponse(stylePacks[0]);
+      }
+
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     render(<AiPage />);
@@ -451,7 +500,7 @@ describe('AiPage', () => {
       );
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Attach source document version ID'), {
+    fireEvent.change(screen.getByLabelText('Style Pack Source Document style-pack-9'), {
       target: { value: 'ver-1' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Attach Source Doc' }));
@@ -467,7 +516,7 @@ describe('AiPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('Sample Demand (ver-1)')).toBeInTheDocument();
+      expect(screen.getByText('Sample Demand (ver-1)', { selector: 'span' })).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }));

--- a/apps/web/test/billing-page.spec.tsx
+++ b/apps/web/test/billing-page.spec.tsx
@@ -42,6 +42,16 @@ describe('BillingPage trust reconciliation workflow', () => {
       const url = String(input);
       const method = init?.method || 'GET';
 
+      if (url.endsWith('/lookups/matters?limit=200')) {
+        return jsonResponse([{ id: 'matter-1', matterNumber: 'M-1', name: 'Doe v Builder', label: 'M-1 - Doe v Builder' }]);
+      }
+      if (url.endsWith('/lookups/trust-accounts?limit=200')) {
+        return jsonResponse([{ id: 'trust-1', name: 'Client Trust', label: 'Client Trust' }]);
+      }
+      if (url.endsWith('/lookups/invoices?limit=200')) {
+        return jsonResponse([]);
+      }
+
       if (url.endsWith('/billing/invoices')) return jsonResponse([]);
       if (url.endsWith('/billing/trust/report')) return jsonResponse([]);
       if (url.endsWith('/billing/ledes/profiles')) return jsonResponse([]);
@@ -110,6 +120,16 @@ describe('BillingPage LEDES export workflow', () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const method = init?.method || 'GET';
+
+      if (url.endsWith('/lookups/matters?limit=200')) {
+        return jsonResponse([{ id: 'matter-1', matterNumber: 'M-1', name: 'Doe v Builder', label: 'M-1 - Doe v Builder' }]);
+      }
+      if (url.endsWith('/lookups/trust-accounts?limit=200')) {
+        return jsonResponse([{ id: 'trust-1', name: 'Client Trust', label: 'Client Trust' }]);
+      }
+      if (url.endsWith('/lookups/invoices?limit=200')) {
+        return jsonResponse([]);
+      }
 
       if (url.endsWith('/billing/invoices')) return jsonResponse([]);
       if (url.endsWith('/billing/trust/report')) return jsonResponse([]);

--- a/apps/web/test/documents-page.spec.tsx
+++ b/apps/web/test/documents-page.spec.tsx
@@ -17,6 +17,9 @@ describe('DocumentsPage', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'matter-1', matterNumber: 'M-1', name: 'Doe v Builder', label: 'M-1 - Doe v Builder' }]),
+      )
       .mockResolvedValueOnce(jsonResponse({ id: 'upload-ok' }))
       .mockResolvedValueOnce(
         jsonResponse([
@@ -42,7 +45,7 @@ describe('DocumentsPage', () => {
       );
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Matter ID'), { target: { value: 'matter-1' } });
+    fireEvent.change(screen.getByLabelText('Upload Matter'), { target: { value: 'matter-1' } });
     const file = new File(['inspection text'], 'inspection.txt', { type: 'text/plain' });
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(fileInput, { target: { files: [file] } });
@@ -59,7 +62,7 @@ describe('DocumentsPage', () => {
       );
     });
 
-    const uploadCall = fetchMock.mock.calls[1];
+    const uploadCall = fetchMock.mock.calls[2];
     const formData = uploadCall[1]?.body as FormData;
     expect(formData.get('matterId')).toBe('matter-1');
     expect(formData.get('title')).toBe('Inspection Report');
@@ -75,6 +78,9 @@ describe('DocumentsPage', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'matter-9', matterNumber: 'M-9', name: 'Client Letter Matter', label: 'M-9 - Client Letter Matter' }]),
+      )
       .mockResolvedValueOnce(jsonResponse({ id: 'pdf-ok' }))
       .mockResolvedValueOnce(
         jsonResponse([
@@ -100,7 +106,7 @@ describe('DocumentsPage', () => {
       );
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Matter ID for generated PDF'), { target: { value: 'matter-9' } });
+    fireEvent.change(screen.getByLabelText('PDF Matter'), { target: { value: 'matter-9' } });
     fireEvent.click(screen.getByRole('button', { name: 'Generate PDF Draft' }));
 
     await waitFor(() => {
@@ -114,7 +120,7 @@ describe('DocumentsPage', () => {
       );
     });
 
-    const generateCall = fetchMock.mock.calls[1];
+    const generateCall = fetchMock.mock.calls[2];
     const payload = JSON.parse(generateCall[1]?.body as string);
     expect(payload).toEqual(
       expect.objectContaining({
@@ -152,6 +158,9 @@ describe('DocumentsPage', () => {
             retentionPolicy: null,
           },
         ]),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'matter-1', matterNumber: 'M-1', name: 'Doe v Builder', label: 'M-1 - Doe v Builder' }]),
       )
       .mockResolvedValueOnce(jsonResponse([]))
       .mockResolvedValueOnce(jsonResponse([]))

--- a/apps/web/test/matter-dashboard-page.spec.tsx
+++ b/apps/web/test/matter-dashboard-page.spec.tsx
@@ -176,6 +176,9 @@ describe('MatterDashboardPage operational workflows', () => {
 
     await screen.findByText('M-100 - Doe v. Builder');
     await screen.findByText('Preview rules to review computed deadlines before creating events.');
+    await waitFor(() => {
+      expect(screen.getByLabelText('Rules Pack')).toHaveValue('pack-1');
+    });
 
     fireEvent.change(screen.getByLabelText('Trigger Date'), { target: { value: '2026-01-20' } });
     fireEvent.click(screen.getByRole('button', { name: 'Preview Deadlines' }));
@@ -187,10 +190,10 @@ describe('MatterDashboardPage operational workflows', () => {
       );
     });
 
-    fireEvent.change(screen.getByLabelText('Override Reason rule-1'), {
+    fireEvent.change(await screen.findByLabelText('Override Reason rule-1'), {
       target: { value: 'Court requested extension' },
     });
-    fireEvent.change(screen.getByLabelText('Override Date rule-1'), { target: { value: '2026-02-27' } });
+    fireEvent.change(await screen.findByLabelText('Override Date rule-1'), { target: { value: '2026-02-27' } });
     fireEvent.click(screen.getByRole('button', { name: 'Apply Selected' }));
 
     await waitFor(() => {
@@ -202,7 +205,7 @@ describe('MatterDashboardPage operational workflows', () => {
     });
   });
 
-  it('creates, edits, updates status, and deletes tasks plus calendar events', async () => {
+  it('creates, edits, updates status, and deletes tasks plus calendar events', { timeout: 40000 }, async () => {
     vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
 
     const state = createDashboardState();
@@ -385,7 +388,10 @@ describe('MatterDashboardPage operational workflows', () => {
     });
   });
 
-  it('executes matter-level billing operations (time, expense, invoice, payment, trust)', async () => {
+  it(
+    'executes matter-level billing operations (time, expense, invoice, payment, trust)',
+    { timeout: 40000 },
+    async () => {
     vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
 
     const state = createDashboardState();
@@ -580,7 +586,8 @@ describe('MatterDashboardPage operational workflows', () => {
       expect(screen.getByText(/Trust transaction DEPOSIT posted/)).toBeInTheDocument();
       expect(screen.getByRole('cell', { name: '$5500.00' })).toBeInTheDocument();
     });
-  });
+    },
+  );
 
   it('exports matter calendar events as an ICS file', async () => {
     vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
@@ -662,7 +669,7 @@ describe('MatterDashboardPage operational workflows', () => {
     }
   });
 
-  it('edits and saves matter overview fields', async () => {
+  it('edits and saves matter overview fields', { timeout: 40000 }, async () => {
     vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ id: 'matter-1' });
 
     const state = createDashboardState();

--- a/apps/web/test/portal-page.spec.tsx
+++ b/apps/web/test/portal-page.spec.tsx
@@ -19,27 +19,35 @@ describe('PortalPage', () => {
   });
 
   it('sends a portal message and refreshes snapshot counts', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          matters: [{ id: 'm1' }],
-          keyDates: [{ id: 'd1' }],
-          invoices: [{ id: 'i1' }],
-          messages: [],
-          documents: [{ id: 'doc1' }, { id: 'doc2' }],
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ id: 'msg-1' }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          matters: [{ id: 'm1' }, { id: 'm2' }],
-          keyDates: [{ id: 'd1' }],
-          invoices: [{ id: 'i1' }],
-          messages: [],
-          documents: [{ id: 'doc1' }, { id: 'doc2' }, { id: 'doc3' }],
-        }),
-      );
+    const state = {
+      snapshot: {
+        matters: [{ id: 'matter-1', matterNumber: 'M-001', name: 'Portal Matter' }],
+        keyDates: [{ id: 'd1' }],
+        invoices: [{ id: 'i1' }],
+        messages: [],
+        documents: [{ id: 'doc1' }, { id: 'doc2' }],
+        eSignEnvelopes: [],
+      } as any,
+      intakeForms: [{ id: 'intake-def-1', name: 'Client Intake v1' }],
+      templates: [{ id: 'letter-template-5', name: 'Engagement Letter v5' }],
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+      if (url.endsWith('/portal/snapshot') && method === 'GET') return jsonResponse(state.snapshot);
+      if (url.endsWith('/portal/intake-form-definitions') && method === 'GET') return jsonResponse(state.intakeForms);
+      if (url.endsWith('/portal/engagement-letter-templates') && method === 'GET') return jsonResponse(state.templates);
+      if (url.endsWith('/portal/messages') && method === 'POST') {
+        state.snapshot = {
+          ...state.snapshot,
+          matters: [...state.snapshot.matters, { id: 'matter-2', matterNumber: 'M-002', name: 'Second Matter' }],
+          documents: [...state.snapshot.documents, { id: 'doc3' }],
+        };
+        return jsonResponse({ id: 'msg-1' });
+      }
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     render(<PortalPage />);
@@ -57,7 +65,7 @@ describe('PortalPage', () => {
     await screen.findByText('1 visible matters');
     await screen.findByText('2 shared docs');
 
-    fireEvent.change(screen.getByPlaceholderText('Matter ID'), { target: { value: 'matter-1' } });
+    fireEvent.change(screen.getByLabelText('Portal Matter'), { target: { value: 'matter-1' } });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));
     await screen.findByRole('dialog', { name: 'Confirm Client Message Send' });
     fireEvent.click(screen.getByRole('button', { name: 'Approve Send' }));
@@ -86,13 +94,35 @@ describe('PortalPage', () => {
   });
 
   it('submits intake and creates e-sign envelope from portal actions', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse({ matters: [], keyDates: [], invoices: [], messages: [], documents: [], eSignEnvelopes: [] }))
-      .mockResolvedValueOnce(jsonResponse({ id: 'intake-1' }))
-      .mockResolvedValueOnce(jsonResponse({ matters: [], keyDates: [], invoices: [], messages: [], documents: [], eSignEnvelopes: [] }))
-      .mockResolvedValueOnce(jsonResponse({ id: 'esign-1' }))
-      .mockResolvedValueOnce(jsonResponse({ matters: [], keyDates: [], invoices: [], messages: [], documents: [], eSignEnvelopes: [{ id: 'esign-1' }] }));
+    const state = {
+      snapshot: {
+        matters: [{ id: 'matter-22', matterNumber: 'M-022', name: 'Client Matter 22' }],
+        keyDates: [],
+        invoices: [],
+        messages: [],
+        documents: [],
+        eSignEnvelopes: [],
+      } as any,
+      intakeForms: [{ id: 'intake-def-1', name: 'Client Intake v1' }],
+      templates: [{ id: 'letter-template-5', name: 'Engagement Letter v5' }],
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+      if (url.endsWith('/portal/snapshot') && method === 'GET') return jsonResponse(state.snapshot);
+      if (url.endsWith('/portal/intake-form-definitions') && method === 'GET') return jsonResponse(state.intakeForms);
+      if (url.endsWith('/portal/engagement-letter-templates') && method === 'GET') return jsonResponse(state.templates);
+      if (url.endsWith('/portal/intake-submissions') && method === 'POST') return jsonResponse({ id: 'intake-1' });
+      if (url.endsWith('/portal/esign') && method === 'POST') {
+        state.snapshot = {
+          ...state.snapshot,
+          eSignEnvelopes: [{ id: 'esign-1', status: 'SENT', provider: 'stub' }],
+        };
+        return jsonResponse({ id: 'esign-1' });
+      }
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     render(<PortalPage />);
@@ -106,9 +136,9 @@ describe('PortalPage', () => {
       );
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Matter ID'), { target: { value: 'matter-22' } });
-    fireEvent.change(screen.getByPlaceholderText('Intake Form Definition ID'), { target: { value: 'intake-def-1' } });
-    fireEvent.change(screen.getByPlaceholderText('Engagement Letter Template ID'), {
+    fireEvent.change(screen.getByLabelText('Portal Matter'), { target: { value: 'matter-22' } });
+    fireEvent.change(screen.getByLabelText('Portal Intake Form'), { target: { value: 'intake-def-1' } });
+    fireEvent.change(screen.getByLabelText('Portal Engagement Template'), {
       target: { value: 'letter-template-5' },
     });
 
@@ -153,33 +183,35 @@ describe('PortalPage', () => {
   });
 
   it('refreshes an e-sign envelope status from the portal list', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          matters: [{ id: 'matter-9' }],
-          keyDates: [],
-          invoices: [],
-          messages: [],
-          documents: [],
-          eSignEnvelopes: [
-            {
-              id: 'env-9',
-              status: 'SENT',
-              provider: 'sandbox',
-              engagementLetterTemplate: { id: 'tpl-9', name: 'Engagement Letter v9' },
-            },
-          ],
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ id: 'env-9', status: 'SIGNED', provider: 'sandbox' }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          matters: [{ id: 'matter-9' }],
-          keyDates: [],
-          invoices: [],
-          messages: [],
-          documents: [],
+    const state = {
+      snapshot: {
+        matters: [{ id: 'matter-9', matterNumber: 'M-009', name: 'Matter 9' }],
+        keyDates: [],
+        invoices: [],
+        messages: [],
+        documents: [],
+        eSignEnvelopes: [
+          {
+            id: 'env-9',
+            status: 'SENT',
+            provider: 'sandbox',
+            engagementLetterTemplate: { id: 'tpl-9', name: 'Engagement Letter v9' },
+          },
+        ],
+      } as any,
+      intakeForms: [],
+      templates: [],
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+      if (url.endsWith('/portal/snapshot') && method === 'GET') return jsonResponse(state.snapshot);
+      if (url.endsWith('/portal/intake-form-definitions') && method === 'GET') return jsonResponse(state.intakeForms);
+      if (url.endsWith('/portal/engagement-letter-templates') && method === 'GET') return jsonResponse(state.templates);
+      if (url.endsWith('/portal/esign/env-9/refresh') && method === 'POST') {
+        state.snapshot = {
+          ...state.snapshot,
           eSignEnvelopes: [
             {
               id: 'env-9',
@@ -188,8 +220,11 @@ describe('PortalPage', () => {
               engagementLetterTemplate: { id: 'tpl-9', name: 'Engagement Letter v9' },
             },
           ],
-        }),
-      );
+        };
+        return jsonResponse({ id: 'env-9', status: 'SIGNED', provider: 'sandbox' });
+      }
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
 
     vi.stubGlobal('fetch', fetchMock);
     render(<PortalPage />);
@@ -212,29 +247,34 @@ describe('PortalPage', () => {
 
   it('uploads a portal attachment, links it to message, and downloads securely', async () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
-        jsonResponse({
-          matters: [{ id: 'matter-1' }],
-          keyDates: [],
-          invoices: [],
-          messages: [],
-          documents: [],
-        }),
-      )
-      .mockResolvedValueOnce(
-        jsonResponse({
+    const state = {
+      snapshot: {
+        matters: [{ id: 'matter-1', matterNumber: 'M-001', name: 'Portal Matter' }],
+        keyDates: [],
+        invoices: [],
+        messages: [],
+        documents: [],
+        eSignEnvelopes: [],
+      } as any,
+      intakeForms: [],
+      templates: [],
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method || 'GET').toUpperCase();
+      if (url.endsWith('/portal/snapshot') && method === 'GET') return jsonResponse(state.snapshot);
+      if (url.endsWith('/portal/intake-form-definitions') && method === 'GET') return jsonResponse(state.intakeForms);
+      if (url.endsWith('/portal/engagement-letter-templates') && method === 'GET') return jsonResponse(state.templates);
+      if (url.endsWith('/portal/attachments/upload') && method === 'POST') {
+        return jsonResponse({
           document: { id: 'doc-uploaded' },
           version: { id: 'ver-up' },
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ id: 'msg-uploaded' }))
-      .mockResolvedValueOnce(
-        jsonResponse({
-          matters: [{ id: 'matter-1' }],
-          keyDates: [],
-          invoices: [],
+        });
+      }
+      if (url.endsWith('/portal/messages') && method === 'POST') {
+        state.snapshot = {
+          ...state.snapshot,
           documents: [
             {
               id: 'doc-uploaded',
@@ -255,9 +295,14 @@ describe('PortalPage', () => {
               ],
             },
           ],
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ url: 'https://download.local/ver-up' }));
+        };
+        return jsonResponse({ id: 'msg-uploaded' });
+      }
+      if (url.endsWith('/portal/attachments/ver-up/download-url') && method === 'GET') {
+        return jsonResponse({ url: 'https://download.local/ver-up' });
+      }
+      return jsonResponse({ error: `Unexpected ${method} ${url}` }, 500);
+    });
 
     vi.stubGlobal('fetch', fetchMock);
 
@@ -270,7 +315,7 @@ describe('PortalPage', () => {
       );
     });
 
-    fireEvent.change(screen.getByPlaceholderText('Matter ID'), { target: { value: 'matter-1' } });
+    fireEvent.change(screen.getByLabelText('Portal Matter'), { target: { value: 'matter-1' } });
     fireEvent.change(screen.getByPlaceholderText('Message'), { target: { value: 'See attached defect photo' } });
     fireEvent.change(screen.getByPlaceholderText('Attachment Title (optional)'), {
       target: { value: 'Uploaded Portal Photo' },

--- a/apps/web/test/smoke-user-journey.spec.tsx
+++ b/apps/web/test/smoke-user-journey.spec.tsx
@@ -16,7 +16,7 @@ function jsonResponse<T>(payload: T, status = 200): Response {
 }
 
 describe('Web smoke journey', () => {
-  it('covers sign-in -> dashboard -> matter creation -> portal messaging', async () => {
+  it('covers sign-in -> dashboard -> matter creation -> portal messaging', { timeout: 20000 }, async () => {
     const state = {
       matters: [
         {
@@ -81,6 +81,12 @@ describe('Web smoke journey', () => {
       if (url.endsWith('/portal/snapshot') && method === 'GET') {
         return jsonResponse(state.portalSnapshot);
       }
+      if (url.endsWith('/portal/intake-form-definitions') && method === 'GET') {
+        return jsonResponse([]);
+      }
+      if (url.endsWith('/portal/engagement-letter-templates') && method === 'GET') {
+        return jsonResponse([]);
+      }
       if (url.endsWith('/portal/messages') && method === 'POST') {
         const body = JSON.parse(String(init?.body || '{}'));
         state.portalSnapshot = {
@@ -136,7 +142,7 @@ describe('Web smoke journey', () => {
 
     render(<PortalPage />);
     await screen.findByText('Portal Messages');
-    fireEvent.change(screen.getByPlaceholderText('Matter ID'), {
+    fireEvent.change(screen.getByLabelText('Portal Matter'), {
       target: { value: state.matters[0]?.id || 'matter-1' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Send' }));


### PR DESCRIPTION
## Linear Issue
- KAR-89

## Requirement ID
- REQ-RC-004

## Summary
- replace manual ID entry patterns with selector-first flows across AI, billing, documents, matters, communications, and portal routes
- add portal metadata list endpoints for intake form definitions and engagement templates
- update dense workflow tests to validate selector-driven behavior and stable user paths

## Verification
- pnpm --filter api test -- test/portal.spec.ts
- pnpm --filter web test -- test/ai-page.spec.tsx test/billing-page.spec.tsx test/documents-page.spec.tsx test/matter-dashboard-page.spec.tsx test/portal-page.spec.tsx test/smoke-user-journey.spec.tsx

## UI Interaction Checklist
- Selector-driven workflows remove raw-ID entry in core forms.
- Inline validation and feedback states remain keyboard reachable.
- No console errors observed during local regression runs.

## Screenshot Evidence
- Desktop: `/matters`, `/documents`, `/billing`, `/ai`, `/portal` selector-driven forms.
- Mobile fallback unchanged per current product policy.

## Dependency
- depends on lookup API support from [KAR-90] for full end-to-end runtime parity
