### PR TITLE
[KAR-94] Tighten API lint and static quality enforcement

### DIFF
--- a/apps/api/.eslintrc.cjs
+++ b/apps/api/.eslintrc.cjs
@@ -21,6 +21,7 @@ module.exports = {
         varsIgnorePattern: '^_',
       },
     ],
+    '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
   },
 };

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { createHash } from 'node:crypto';
 import PizZip from 'pizzip';
 import Docxtemplater from 'docxtemplater';
+import expressionParser from 'docxtemplater/expressions.js';
 import {
   ContactKind,
   DocumentConfidentiality,
@@ -23,8 +24,6 @@ import { AuditService } from '../audit/audit.service';
 
 // Docxtemplater nested expressions (matter.name, customFields.matter.key, etc.)
 // are enabled via the angular expression parser.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const expressionParser = require('docxtemplater/expressions.js');
 
 type MergeContact = {
   id: string;

--- a/apps/api/test/lint-config.guardrail.spec.ts
+++ b/apps/api/test/lint-config.guardrail.spec.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('API lint guardrails', () => {
+  const eslintConfigPath = join(__dirname, '../.eslintrc.cjs');
+
+  it('enforces no-require-imports rule', () => {
+    const eslintConfig = readFileSync(eslintConfigPath, 'utf8');
+
+    expect(eslintConfig).toContain("'@typescript-eslint/no-require-imports': 'error'");
+  });
+});


### PR DESCRIPTION
## Summary
- replace CommonJS `require('docxtemplater/expressions.js')` usage with an ES import in documents service
- enforce `@typescript-eslint/no-require-imports` at API lint level
- add guardrail test to prevent lint-regression on require-import rule configuration

## Linear Issue
- KAR-94

## Requirement ID
- REQ-RC-008

## Validation
- `pnpm --filter api lint`
- `pnpm --filter api test`
- `pnpm --filter api build`
- `pnpm build`
