### PR TITLE
[KAR-91] Implement provider readiness cutover and status telemetry

### DIFF
--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -4,8 +4,11 @@ import { isProductionLikeProfile } from './provider-readiness.util';
 type ProviderStatusRow = {
   key: string;
   mode: string;
+  provider: string;
   critical: boolean;
   healthy: boolean;
+  issues: string[];
+  checkedAt: string;
   detail: string;
   missingEnv?: string[];
 };
@@ -13,6 +16,7 @@ type ProviderStatusRow = {
 @Injectable()
 export class OpsService {
   providerStatus() {
+    const checkedAt = new Date().toISOString();
     const profile = (process.env.RUNTIME_PROFILE || process.env.NODE_ENV || 'development').toLowerCase();
     const productionLike = isProductionLikeProfile(profile);
     const syncLiveEnabled = this.isEnabled(process.env.INTEGRATION_SYNC_ENABLE_LIVE);
@@ -24,6 +28,7 @@ export class OpsService {
         mode: this.hasEnv('STRIPE_SECRET_KEY') ? 'live' : 'stub',
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['live', 'stub'],
         missingEnv: this.collectMissing([
           {
@@ -48,6 +53,7 @@ export class OpsService {
         mode: emailMode,
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'resend'],
         missingEnv: this.collectMissing(
           [
@@ -75,6 +81,7 @@ export class OpsService {
         mode: smsMode,
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'twilio'],
         missingEnv: this.collectMissing(
           [
@@ -102,10 +109,11 @@ export class OpsService {
     const malwareMode = this.normalizeMode(process.env.MALWARE_SCANNER_PROVIDER, 'stub');
     providers.push(
       this.row({
-        key: 'malware_scan',
+        key: 'malware_scanner',
         mode: malwareMode,
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'clamav'],
         missingEnv: this.collectMissing(
           [
@@ -133,6 +141,7 @@ export class OpsService {
         mode: esignMode,
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'sandbox'],
         missingEnv: this.collectMissing(
           [
@@ -150,10 +159,11 @@ export class OpsService {
     const clioMode = this.resolveOauthMode('CLIO_LIVE_OAUTH');
     providers.push(
       this.row({
-        key: 'clio_oauth',
+        key: 'clio',
         mode: clioMode,
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'live'],
         missingEnv: this.collectMissing(
           [
@@ -175,10 +185,11 @@ export class OpsService {
     const mycaseMode = this.resolveOauthMode('MYCASE_LIVE_OAUTH');
     providers.push(
       this.row({
-        key: 'mycase_oauth',
+        key: 'mycase',
         mode: mycaseMode,
         critical: true,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'live'],
         missingEnv: this.collectMissing(
           [
@@ -199,10 +210,11 @@ export class OpsService {
 
     providers.push(
       this.row({
-        key: 'clio_webhooks',
+        key: 'connectors_clio_webhooks',
         mode: syncLiveEnabled ? 'live' : 'stub',
         critical: syncLiveEnabled,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'live'],
         missingEnv: this.collectMissing(
           [
@@ -221,10 +233,11 @@ export class OpsService {
 
     providers.push(
       this.row({
-        key: 'mycase_webhooks',
+        key: 'connectors_mycase_webhooks',
         mode: syncLiveEnabled ? 'live' : 'stub',
         critical: syncLiveEnabled,
         productionLike,
+        checkedAt,
         supportedModes: ['stub', 'live'],
         missingEnv: this.collectMissing(
           [
@@ -246,7 +259,7 @@ export class OpsService {
     return {
       profile,
       healthy,
-      evaluatedAt: new Date().toISOString(),
+      evaluatedAt: checkedAt,
       providers,
     };
   }
@@ -256,6 +269,7 @@ export class OpsService {
     mode: string;
     critical: boolean;
     productionLike: boolean;
+    checkedAt: string;
     detail: string;
     supportedModes: string[];
     missingEnv?: string[];
@@ -265,30 +279,32 @@ export class OpsService {
     const unsupportedMode = !supportedModes.includes(mode);
     const missingEnv = [...new Set((input.missingEnv || []).map((item) => String(item || '').trim()).filter(Boolean))];
 
-    let healthy = true;
+    const issues: string[] = [];
     if (unsupportedMode) {
-      healthy = false;
+      issues.push(`Unsupported mode "${mode}" (supported: ${supportedModes.join(', ')})`);
     }
     if (input.critical && missingEnv.length > 0) {
-      healthy = false;
+      issues.push(`Missing required configuration: ${missingEnv.join(', ')}`);
     }
     if (input.critical && input.productionLike && (mode === 'stub' || mode === 'false' || mode === 'off')) {
-      healthy = false;
+      issues.push('Critical provider cannot run in stub mode for production-like profiles');
     }
 
+    const healthy = issues.length === 0;
+
     const detailParts = [input.detail];
-    if (unsupportedMode) {
-      detailParts.push(`Unsupported mode "${mode}" (supported: ${supportedModes.join(', ')})`);
-    }
-    if (missingEnv.length > 0) {
-      detailParts.push(`Missing: ${missingEnv.join(', ')}`);
+    if (issues.length > 0) {
+      detailParts.push(issues.join('. '));
     }
 
     return {
       key: input.key,
       mode,
+      provider: mode,
       critical: input.critical,
       healthy,
+      issues,
+      checkedAt: input.checkedAt,
       detail: detailParts.join('. '),
       missingEnv,
     };

--- a/apps/api/src/ops/provider-readiness.util.ts
+++ b/apps/api/src/ops/provider-readiness.util.ts
@@ -1,8 +1,11 @@
 type ProviderStatusRow = {
   key: string;
   mode: string;
+  provider?: string;
   critical: boolean;
   healthy: boolean;
+  issues?: string[];
+  checkedAt?: string;
   detail: string;
   missingEnv?: string[];
 };
@@ -24,7 +27,8 @@ export function assertProviderReadiness(profile: string, providers: ProviderStat
   const breakdown = unhealthyCritical
     .map((provider) => {
       const missing = provider.missingEnv && provider.missingEnv.length > 0 ? ` missing=${provider.missingEnv.join('|')}` : '';
-      return `${provider.key} (mode=${provider.mode}${missing})`;
+      const issues = provider.issues && provider.issues.length > 0 ? ` issues=${provider.issues.join('|')}` : '';
+      return `${provider.key} (mode=${provider.mode}${missing}${issues})`;
     })
     .join('; ');
   throw new Error(

--- a/apps/api/test/ops-provider-status.spec.ts
+++ b/apps/api/test/ops-provider-status.spec.ts
@@ -21,7 +21,9 @@ describe('OpsService provider status', () => {
     const status = service.providerStatus();
 
     expect(status.healthy).toBe(false);
+    expect(status.providers.every((row) => typeof row.checkedAt === 'string')).toBe(true);
     expect(status.providers.some((row) => row.key === 'stripe' && row.healthy === false)).toBe(true);
+    expect(status.providers.some((row) => row.key === 'email' && (row.issues || []).length > 0)).toBe(true);
   });
 
   it('marks providers healthy when live mode is configured', () => {
@@ -81,8 +83,8 @@ describe('OpsService provider status', () => {
 
     const service = new OpsService();
     const status = service.providerStatus();
-    const clio = status.providers.find((row) => row.key === 'clio_oauth');
-    const mycase = status.providers.find((row) => row.key === 'mycase_oauth');
+    const clio = status.providers.find((row) => row.key === 'clio');
+    const mycase = status.providers.find((row) => row.key === 'mycase');
 
     expect(clio?.mode).toBe('live');
     expect(mycase?.mode).toBe('live');

--- a/apps/api/test/provider-live-validation.spec.ts
+++ b/apps/api/test/provider-live-validation.spec.ts
@@ -62,7 +62,7 @@ describe('provider live validation matrix', () => {
     expect(status.healthy).toBe(false);
 
     const email = status.providers.find((row) => row.key === 'email');
-    const clio = status.providers.find((row) => row.key === 'clio_oauth');
+    const clio = status.providers.find((row) => row.key === 'clio');
     expect(email?.missingEnv).toContain('RESEND_API_KEY');
     expect(clio?.missingEnv).toContain('CLIO_CLIENT_SECRET');
     expect(() => assertProviderReadiness(status.profile, status.providers)).toThrow('RESEND_API_KEY');
@@ -87,7 +87,7 @@ describe('provider live validation matrix', () => {
     process.env.MALWARE_SCANNER_FAIL_OPEN = 'true';
 
     const status = new OpsService().providerStatus();
-    const malware = status.providers.find((row) => row.key === 'malware_scan');
+    const malware = status.providers.find((row) => row.key === 'malware_scanner');
 
     expect(status.healthy).toBe(false);
     expect(malware?.missingEnv).toContain('MALWARE_SCANNER_FAIL_OPEN=false');
@@ -102,7 +102,7 @@ describe('provider live validation matrix', () => {
     process.env.CLIO_CLIENT_SECRET = 'stub-clio-client-secret';
 
     const status = new OpsService().providerStatus();
-    const clio = status.providers.find((row) => row.key === 'clio_oauth');
+    const clio = status.providers.find((row) => row.key === 'clio');
 
     expect(status.healthy).toBe(false);
     expect(clio?.missingEnv).toContain('CLIO_CLIENT_ID');
@@ -115,8 +115,8 @@ describe('provider live validation matrix', () => {
     delete process.env.MYCASE_WEBHOOK_REGISTER_URL;
 
     const status = new OpsService().providerStatus();
-    const clioWebhook = status.providers.find((row) => row.key === 'clio_webhooks');
-    const mycaseWebhook = status.providers.find((row) => row.key === 'mycase_webhooks');
+    const clioWebhook = status.providers.find((row) => row.key === 'connectors_clio_webhooks');
+    const mycaseWebhook = status.providers.find((row) => row.key === 'connectors_mycase_webhooks');
 
     expect(status.healthy).toBe(false);
     expect(clioWebhook?.missingEnv).toContain('CLIO_WEBHOOK_REGISTER_URL');

--- a/apps/api/test/provider-readiness.spec.ts
+++ b/apps/api/test/provider-readiness.spec.ts
@@ -15,6 +15,7 @@ describe('provider readiness util', () => {
           mode: 'stub',
           critical: true,
           healthy: false,
+          issues: ['Critical provider cannot run in stub mode for production-like profiles'],
           detail: 'stub provider',
         },
       ]),
@@ -29,11 +30,24 @@ describe('provider readiness util', () => {
           mode: 'resend',
           critical: true,
           healthy: false,
+          issues: ['Missing required configuration: RESEND_API_KEY, RESEND_FROM_EMAIL'],
           detail: 'missing resend credentials',
           missingEnv: ['RESEND_API_KEY', 'RESEND_FROM_EMAIL'],
         },
       ]),
     ).toThrow('RESEND_API_KEY');
+    expect(() =>
+      assertProviderReadiness('staging', [
+        {
+          key: 'email',
+          mode: 'resend',
+          critical: true,
+          healthy: false,
+          issues: ['Missing required configuration: RESEND_API_KEY'],
+          detail: 'missing resend credentials',
+        },
+      ]),
+    ).toThrow('issues=Missing required configuration: RESEND_API_KEY');
   });
 
   it('allows unhealthy providers in non-production profiles', () => {

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -30,8 +30,11 @@ type WebhookDeliverySummary = {
 type ProviderStatusRow = {
   key: string;
   mode: string;
+  provider?: string;
   critical: boolean;
   healthy: boolean;
+  issues?: string[];
+  checkedAt?: string;
   detail: string;
   missingEnv?: string[];
 };
@@ -582,17 +585,19 @@ export default function AdminPage() {
                     <th>Mode</th>
                     <th>Critical</th>
                     <th>Status</th>
-                    <th>Missing Env</th>
+                    <th>Issues</th>
+                    <th>Checked</th>
                   </tr>
                 </thead>
                 <tbody>
                   {providerStatus.providers.map((provider) => (
                     <tr key={provider.key}>
                       <td>{provider.key}</td>
-                      <td>{provider.mode}</td>
+                      <td>{provider.provider || provider.mode}</td>
                       <td>{provider.critical ? 'Yes' : 'No'}</td>
                       <td>{provider.healthy ? 'HEALTHY' : 'UNHEALTHY'}</td>
-                      <td>{provider.missingEnv && provider.missingEnv.length > 0 ? provider.missingEnv.join(', ') : '-'}</td>
+                      <td>{provider.issues && provider.issues.length > 0 ? provider.issues.join('; ') : '-'}</td>
+                      <td>{provider.checkedAt ? new Date(provider.checkedAt).toLocaleString() : '-'}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/apps/web/test/admin-page.spec.tsx
+++ b/apps/web/test/admin-page.spec.tsx
@@ -65,18 +65,24 @@ describe('AdminPage webhook delivery monitor', () => {
         {
           key: 'stripe',
           mode: 'live',
+          provider: 'live',
           critical: true,
           healthy: true,
+          issues: [],
+          checkedAt: '2026-02-26T18:30:00.000Z',
           detail: 'configured',
           missingEnv: [],
         },
         {
           key: 'email',
           mode: 'stub',
+          provider: 'stub',
           critical: true,
           healthy: false,
+          issues: ['Critical provider cannot run in stub mode for production-like profiles'],
+          checkedAt: '2026-02-26T18:30:00.000Z',
           detail: 'stub provider',
-          missingEnv: ['RESEND_API_KEY'],
+          missingEnv: [],
         },
       ],
     };
@@ -124,7 +130,7 @@ describe('AdminPage webhook delivery monitor', () => {
     await screen.findByText('https://hooks.example/receiver');
     expect(await screen.findByText('Provider Readiness')).toBeInTheDocument();
     expect(screen.getByText('Profile: STAGING')).toBeInTheDocument();
-    expect(screen.getByText('RESEND_API_KEY')).toBeInTheDocument();
+    expect(screen.getByText('Critical provider cannot run in stub mode for production-like profiles')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 


### PR DESCRIPTION
### Motivation

- Provide a single authoritative readiness endpoint for cutover planning and health telemetry that includes blocking issues and timestamps for critical providers. 
- Enforce fail-fast startup in production-like profiles when critical providers are improperly configured to avoid unsafe production deployments. 
- Surface provider readiness and blocking issues to admins in the existing Admin panel without changing interaction patterns or layout intent.

### Description

- Expanded `/ops/provider-status` payload to include per-provider `provider`, `issues[]`, and `checkedAt` fields and to set `evaluatedAt` from the per-check timestamp; retained existing `mode`, `detail`, and `missingEnv` for compatibility (implemented in `apps/api/src/ops/ops.service.ts`).
- Standardized and expanded the set of critical checks (stripe, email, sms, malware scanner, e-sign, connectors for clio/mycase) and renamed a few provider keys for clarity (`malware_scan` → `malware_scanner`, `clio_oauth` → `clio`, `mycase_oauth` → `mycase`, `clio_webhooks`/`mycase_webhooks` → `connectors_*`).
- Converted per-row health logic to collect explicit `issues[]` messages (unsupported mode, missing configuration, production stub enforcement) and compute `healthy` from the absence of issues, and included `issues` in readiness error breakdowns (implemented in `apps/api/src/ops/provider-readiness.util.ts`).
- Updated Admin UI provider readiness card to show `Issues` and `Checked` timestamp columns while preserving the existing card/table flow and styling (`apps/web/app/admin/page.tsx`).
- Updated and added tests to validate telemetry, renamed keys, and fail-fast messaging for production-like profiles (`apps/api/test/*`, `apps/web/test/admin-page.spec.tsx`).

### Testing

- Ran API unit tests with `pnpm --filter api test` and all API test suites passed (57/57). 
- Ran the single web admin test with `pnpm --filter web test test/admin-page.spec.tsx` and it passed. 
- Ran full web tests with `pnpm --filter web test` and the suite passed (19 files, 58 tests). 
- Attempted `pnpm build` but the build failed in this environment due to `next/font` unable to fetch Google Fonts (`IBM Plex Sans`, `IBM Plex Sans Condensed`, `IBM Plex Mono`); this is a network/resource issue during build rather than test regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a093d27e38832586d4aeb5a09d69d1)