### PR TITLE
[KAR-96] Add production observability and alerting baseline

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -28,6 +28,8 @@ import { LookupsModule } from './lookups/lookups.module';
 import { OpsModule } from './ops/ops.module';
 import { AuditInterceptor } from './common/interceptors/audit.interceptor';
 import { GuardsModule } from './common/guards/guards.module';
+import { RequestObservabilityInterceptor } from './observability/request-observability.interceptor';
+import { ObservabilityModule } from './observability/observability.module';
 
 @Module({
   imports: [
@@ -60,8 +62,13 @@ import { GuardsModule } from './common/guards/guards.module';
     PortalModule,
     LookupsModule,
     OpsModule,
+    ObservabilityModule,
   ],
   providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: RequestObservabilityInterceptor,
+    },
     {
       provide: APP_INTERCEPTOR,
       useClass: AuditInterceptor,

--- a/apps/api/src/communications/providers/message-dispatch.service.ts
+++ b/apps/api/src/communications/providers/message-dispatch.service.ts
@@ -75,11 +75,7 @@ export class MessageDispatchService {
         lastError = error;
         const retryable = this.isRetryable(error);
         const statusCode = this.getStatusCode(error);
-        this.logger.warn(
-          `Message dispatch failed via ${input.providerName} (attempt ${attempt}/${maxAttempts})` +
-            `${statusCode ? ` status=${statusCode}` : ''}` +
-            `${retryable ? ' retryable=true' : ' retryable=false'}`,
-        );
+        this.logger.warn(JSON.stringify({ event: 'provider.dispatch.failed', provider: input.providerName, attempt, maxAttempts, statusCode, retryable }));
         if (!retryable || attempt >= maxAttempts) {
           break;
         }
@@ -90,7 +86,7 @@ export class MessageDispatchService {
     }
 
     if (failOpen && input.providerName !== 'stub') {
-      this.logger.warn(`Fail-open is enabled. Falling back to stub provider for ${input.providerName}.`);
+      this.logger.warn(JSON.stringify({ event: 'provider.dispatch.fail_open_fallback', provider: input.providerName }));
       return input.fallback();
     }
 

--- a/apps/api/src/communications/providers/resend-email.provider.ts
+++ b/apps/api/src/communications/providers/resend-email.provider.ts
@@ -66,7 +66,7 @@ export class ResendEmailProvider implements EmailProvider {
     }
 
     const providerMessageId = String(rawBody.id || `resend-${Date.now()}`);
-    this.logger.log(`Resend accepted email for ${input.to} (${providerMessageId})`);
+    this.logger.log(JSON.stringify({ event: 'provider.resend.accepted', provider: 'resend', recipient: input.to, providerMessageId }));
     return {
       id: `resend-${providerMessageId}`,
       provider: 'resend',

--- a/apps/api/src/communications/providers/twilio-sms.provider.ts
+++ b/apps/api/src/communications/providers/twilio-sms.provider.ts
@@ -66,7 +66,7 @@ export class TwilioSmsProvider implements SmsProvider {
     const status: SendMessageResult['status'] =
       providerStatus === 'failed' || providerStatus === 'undelivered' ? 'failed' : 'queued';
 
-    this.logger.log(`Twilio accepted SMS for ${input.to} (${providerMessageId})`);
+    this.logger.log(JSON.stringify({ event: 'provider.twilio.accepted', provider: 'twilio', recipient: input.to, providerMessageId, status }));
     return {
       id: `twilio-${providerMessageId}`,
       provider: 'twilio',

--- a/apps/api/src/observability/observability.module.ts
+++ b/apps/api/src/observability/observability.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ObservabilityService } from './observability.service';
+
+@Global()
+@Module({
+  providers: [ObservabilityService],
+  exports: [ObservabilityService],
+})
+export class ObservabilityModule {}

--- a/apps/api/src/observability/observability.service.ts
+++ b/apps/api/src/observability/observability.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+
+type RequestMetric = { timestampMs: number; statusCode: number };
+
+@Injectable()
+export class ObservabilityService {
+  private readonly requestMetrics: RequestMetric[] = [];
+
+  recordRequest(statusCode: number, timestampMs = Date.now()) {
+    this.requestMetrics.push({ statusCode, timestampMs });
+    this.prune(timestampMs);
+  }
+
+  getRequestSummary(windowMinutes: number) {
+    const now = Date.now();
+    this.prune(now, windowMinutes);
+    const cutoff = now - windowMinutes * 60_000;
+    const inWindow = this.requestMetrics.filter((metric) => metric.timestampMs >= cutoff);
+    const totalRequests = inWindow.length;
+    const errorRequests = inWindow.filter((metric) => metric.statusCode >= 500).length;
+
+    return {
+      totalRequests,
+      errorRequests,
+    };
+  }
+
+  private prune(nowMs: number, windowMinutes = 60) {
+    const cutoff = nowMs - windowMinutes * 60_000;
+    while (this.requestMetrics.length > 0 && this.requestMetrics[0].timestampMs < cutoff) {
+      this.requestMetrics.shift();
+    }
+  }
+}

--- a/apps/api/src/observability/request-observability.interceptor.ts
+++ b/apps/api/src/observability/request-observability.interceptor.ts
@@ -1,0 +1,71 @@
+import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { Observable, tap } from 'rxjs';
+import { Request, Response } from 'express';
+import { ObservabilityService } from './observability.service';
+
+@Injectable()
+export class RequestObservabilityInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(RequestObservabilityInterceptor.name);
+
+  constructor(private readonly observability: ObservabilityService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const response = context.switchToHttp().getResponse<Response>();
+    const startedAt = Date.now();
+
+    const requestId = this.readHeader(request, 'x-request-id') || randomUUID();
+    const correlationId = this.readHeader(request, 'x-correlation-id') || requestId;
+    response.setHeader('x-request-id', requestId);
+    response.setHeader('x-correlation-id', correlationId);
+
+    return next.handle().pipe(
+      tap({
+        next: () => this.logEvent(request, response, requestId, correlationId, startedAt),
+        error: (error) => this.logEvent(request, response, requestId, correlationId, startedAt, error),
+      }),
+    );
+  }
+
+  private logEvent(
+    request: Request,
+    response: Response,
+    requestId: string,
+    correlationId: string,
+    startedAt: number,
+    error?: unknown,
+  ) {
+    const statusCode = response.statusCode || 500;
+    this.observability.recordRequest(statusCode);
+    const payload = {
+      event: 'http.request.completed',
+      requestId,
+      correlationId,
+      method: request.method,
+      path: request.originalUrl || request.url,
+      statusCode,
+      durationMs: Date.now() - startedAt,
+      errorName: error instanceof Error ? error.name : undefined,
+      errorMessage: error instanceof Error ? error.message : undefined,
+    };
+
+    if (statusCode >= 500 || error) {
+      this.logger.error(JSON.stringify(payload));
+      return;
+    }
+    this.logger.log(JSON.stringify(payload));
+  }
+
+  private readHeader(request: Request, name: string): string | undefined {
+    const value = request.headers[name];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+    return undefined;
+  }
+}

--- a/apps/api/src/ops/alert-baseline.util.ts
+++ b/apps/api/src/ops/alert-baseline.util.ts
@@ -1,0 +1,74 @@
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+
+export type AlertDefinition = {
+  key: 'api_error_rate_spike' | 'queue_job_failures' | 'webhook_delivery_failures' | 'provider_health_failures';
+  severity: AlertSeverity;
+  threshold: string;
+  description: string;
+  escalation: string;
+};
+
+export type AlertEvaluationInput = {
+  api: { totalRequests: number; errorRequests: number };
+  queue: { failedJobs: number; totalJobs: number };
+  webhooks: { failedDeliveries: number; retryingDeliveries: number; totalDeliveries: number };
+  providers: { criticalUnhealthyCount: number };
+  thresholds: {
+    apiErrorRate: number;
+    queueFailureCount: number;
+    webhookFailureCount: number;
+    webhookRetryingCount: number;
+    providerUnhealthyCount: number;
+  };
+};
+
+export type AlertEvaluationRow = AlertDefinition & {
+  triggered: boolean;
+  observed: string;
+};
+
+export function evaluateAlertBaseline(input: AlertEvaluationInput): AlertEvaluationRow[] {
+  const apiErrorRate = input.api.totalRequests > 0 ? input.api.errorRequests / input.api.totalRequests : 0;
+  const queueFailureRate = input.queue.totalJobs > 0 ? input.queue.failedJobs / input.queue.totalJobs : 0;
+
+  return [
+    {
+      key: 'api_error_rate_spike',
+      severity: 'critical',
+      threshold: `>= ${(input.thresholds.apiErrorRate * 100).toFixed(1)}% 5xx responses over lookback`,
+      description: 'API 5xx rate indicates a systemic service reliability regression.',
+      escalation: 'Page on-call API owner and start incident triage in #ops-incidents.',
+      triggered: apiErrorRate >= input.thresholds.apiErrorRate,
+      observed: `${input.api.errorRequests}/${input.api.totalRequests} (${(apiErrorRate * 100).toFixed(1)}%)`,
+    },
+    {
+      key: 'queue_job_failures',
+      severity: 'warning',
+      threshold: `>= ${input.thresholds.queueFailureCount} failed jobs over lookback`,
+      description: 'Background queue failures can silently block async workflows.',
+      escalation: 'Assign worker owner to inspect failures/dead letters and retry policy.',
+      triggered: input.queue.failedJobs >= input.thresholds.queueFailureCount,
+      observed: `${input.queue.failedJobs}/${input.queue.totalJobs} failed (${(queueFailureRate * 100).toFixed(1)}%)`,
+    },
+    {
+      key: 'webhook_delivery_failures',
+      severity: 'warning',
+      threshold: `>= ${input.thresholds.webhookFailureCount} failed OR >= ${input.thresholds.webhookRetryingCount} retrying deliveries over lookback`,
+      description: 'Persistent webhook failures indicate external integration disruption.',
+      escalation: 'Notify integration owner and evaluate endpoint health/credentials.',
+      triggered:
+        input.webhooks.failedDeliveries >= input.thresholds.webhookFailureCount ||
+        input.webhooks.retryingDeliveries >= input.thresholds.webhookRetryingCount,
+      observed: `failed=${input.webhooks.failedDeliveries}, retrying=${input.webhooks.retryingDeliveries}, total=${input.webhooks.totalDeliveries}`,
+    },
+    {
+      key: 'provider_health_failures',
+      severity: 'critical',
+      threshold: `>= ${input.thresholds.providerUnhealthyCount} unhealthy critical providers`,
+      description: 'Provider readiness failures block production traffic safety checks.',
+      escalation: 'Block deploys/traffic shifts until provider readiness is healthy.',
+      triggered: input.providers.criticalUnhealthyCount >= input.thresholds.providerUnhealthyCount,
+      observed: `${input.providers.criticalUnhealthyCount} unhealthy critical providers`,
+    },
+  ];
+}

--- a/apps/api/src/ops/ops.controller.ts
+++ b/apps/api/src/ops/ops.controller.ts
@@ -14,4 +14,10 @@ export class OpsController {
   providerStatus() {
     return this.opsService.providerStatus();
   }
+
+  @Get('alerts/baseline')
+  @RequirePermissions('organizations:read')
+  alertBaseline() {
+    return this.opsService.alertBaseline();
+  }
 }

--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -1,4 +1,7 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { ObservabilityService } from '../observability/observability.service';
+import { evaluateAlertBaseline } from './alert-baseline.util';
 import { isProductionLikeProfile } from './provider-readiness.util';
 
 type ProviderStatusRow = {
@@ -12,6 +15,50 @@ type ProviderStatusRow = {
 
 @Injectable()
 export class OpsService {
+  constructor(
+    private readonly prisma?: PrismaService,
+    private readonly observability?: ObservabilityService,
+  ) {}
+
+  async alertBaseline() {
+    const lookbackMinutes = this.readInt('OPS_ALERT_LOOKBACK_MINUTES', 15, 1, 120);
+    const apiErrorRate = this.readFloat('OPS_ALERT_API_ERROR_RATE', 0.05, 0.001, 1);
+    const queueFailureCount = this.readInt('OPS_ALERT_QUEUE_FAILURE_COUNT', 5, 1, 10_000);
+    const webhookFailureCount = this.readInt('OPS_ALERT_WEBHOOK_FAILURE_COUNT', 3, 1, 10_000);
+    const webhookRetryingCount = this.readInt('OPS_ALERT_WEBHOOK_RETRYING_COUNT', 5, 1, 10_000);
+    const providerUnhealthyCount = this.readInt('OPS_ALERT_PROVIDER_UNHEALTHY_COUNT', 1, 1, 100);
+
+    const since = new Date(Date.now() - lookbackMinutes * 60_000);
+    const [failedJobs, totalJobs, failedDeliveries, retryingDeliveries, totalDeliveries] = await Promise.all([
+      this.prisma?.aiJob.count({ where: { createdAt: { gte: since }, status: 'FAILED' } }) || Promise.resolve(0),
+      this.prisma?.aiJob.count({ where: { createdAt: { gte: since } } }) || Promise.resolve(0),
+      this.prisma?.webhookDelivery.count({ where: { createdAt: { gte: since }, status: 'FAILED' } }) || Promise.resolve(0),
+      this.prisma?.webhookDelivery.count({ where: { createdAt: { gte: since }, status: 'RETRYING' } }) || Promise.resolve(0),
+      this.prisma?.webhookDelivery.count({ where: { createdAt: { gte: since } } }) || Promise.resolve(0),
+    ]);
+
+    const providerStatus = this.providerStatus();
+    const criticalUnhealthyCount = providerStatus.providers.filter((provider) => provider.critical && !provider.healthy).length;
+
+    return {
+      lookbackMinutes,
+      evaluatedAt: new Date().toISOString(),
+      alerts: evaluateAlertBaseline({
+        api: this.observability?.getRequestSummary(lookbackMinutes) || { totalRequests: 0, errorRequests: 0 },
+        queue: { failedJobs, totalJobs },
+        webhooks: { failedDeliveries, retryingDeliveries, totalDeliveries },
+        providers: { criticalUnhealthyCount },
+        thresholds: {
+          apiErrorRate,
+          queueFailureCount,
+          webhookFailureCount,
+          webhookRetryingCount,
+          providerUnhealthyCount,
+        },
+      }),
+    };
+  }
+
   providerStatus() {
     const profile = (process.env.RUNTIME_PROFILE || process.env.NODE_ENV || 'development').toLowerCase();
     const productionLike = isProductionLikeProfile(profile);
@@ -25,16 +72,19 @@ export class OpsService {
         critical: true,
         productionLike,
         supportedModes: ['live', 'stub'],
-        missingEnv: this.collectMissing([
-          {
-            when: !this.hasEnv('STRIPE_SECRET_KEY'),
-            name: 'STRIPE_SECRET_KEY',
-          },
-          {
-            when: !this.hasEnv('STRIPE_WEBHOOK_SECRET'),
-            name: 'STRIPE_WEBHOOK_SECRET',
-          },
-        ], productionLike || this.hasEnv('STRIPE_SECRET_KEY')),
+        missingEnv: this.collectMissing(
+          [
+            {
+              when: !this.hasEnv('STRIPE_SECRET_KEY'),
+              name: 'STRIPE_SECRET_KEY',
+            },
+            {
+              when: !this.hasEnv('STRIPE_WEBHOOK_SECRET'),
+              name: 'STRIPE_WEBHOOK_SECRET',
+            },
+          ],
+          productionLike || this.hasEnv('STRIPE_SECRET_KEY'),
+        ),
         detail: `STRIPE_SECRET_KEY=${this.hasEnv('STRIPE_SECRET_KEY') ? 'set' : 'missing'}; STRIPE_WEBHOOK_SECRET=${
           this.hasEnv('STRIPE_WEBHOOK_SECRET') ? 'set' : 'missing'
         }`,
@@ -342,5 +392,17 @@ export class OpsService {
       return [];
     }
     return checks.filter((item) => item.when).map((item) => item.name);
+  }
+
+  private readInt(name: string, fallback: number, min: number, max: number): number {
+    const parsed = Number.parseInt(String(process.env[name] || ''), 10);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(max, Math.max(min, parsed));
+  }
+
+  private readFloat(name: string, fallback: number, min: number, max: number): number {
+    const parsed = Number.parseFloat(String(process.env[name] || ''));
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(max, Math.max(min, parsed));
   }
 }

--- a/apps/api/src/queue/queue.service.ts
+++ b/apps/api/src/queue/queue.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
 import { Queue, Worker, JobsOptions } from 'bullmq';
 
 @Injectable()
 export class QueueService implements OnModuleDestroy {
+  private readonly logger = new Logger(QueueService.name);
   private readonly connection = {
     url: process.env.REDIS_URL || 'redis://localhost:6379',
     maxRetriesPerRequest: null,
@@ -19,11 +20,48 @@ export class QueueService implements OnModuleDestroy {
 
   async addJob(queueName: string, name: string, data: unknown, opts?: JobsOptions) {
     const queue = this.getQueue(queueName);
-    return queue.add(name, data, opts);
+    try {
+      const job = await queue.add(name, data, opts);
+      this.logger.log(
+        JSON.stringify({
+          event: 'queue.job.enqueued',
+          queueName,
+          jobName: name,
+          jobId: job.id,
+          correlationId: this.readCorrelationId(data),
+        }),
+      );
+      return job;
+    } catch (error) {
+      this.logger.error(
+        JSON.stringify({
+          event: 'queue.job.enqueue_failed',
+          queueName,
+          jobName: name,
+          correlationId: this.readCorrelationId(data),
+          errorName: error instanceof Error ? error.name : 'UnknownError',
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }),
+      );
+      throw error;
+    }
   }
 
   createWorker(queueName: string, processor: any) {
     const worker = new Worker(queueName, processor, { connection: this.connection });
+    worker.on('failed', (job, error) => {
+      this.logger.error(
+        JSON.stringify({
+          event: 'queue.job.failed',
+          queueName,
+          jobName: job?.name,
+          jobId: job?.id,
+          correlationId: this.readCorrelationId(job?.data),
+          errorName: error?.name,
+          errorMessage: error?.message,
+        }),
+      );
+    });
     this.workers.push(worker);
     return worker;
   }
@@ -31,5 +69,14 @@ export class QueueService implements OnModuleDestroy {
   async onModuleDestroy(): Promise<void> {
     await Promise.all(this.workers.map((worker) => worker.close()));
     await Promise.all(Array.from(this.queues.values()).map((queue) => queue.close()));
+  }
+
+  private readCorrelationId(data: unknown) {
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      return undefined;
+    }
+    const row = data as Record<string, unknown>;
+    const candidate = row.correlationId || row.requestId;
+    return typeof candidate === 'string' ? candidate : undefined;
   }
 }

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { createHash, createHmac } from 'node:crypto';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
@@ -6,6 +6,7 @@ import { toJsonValue } from '../common/utils/json.util';
 
 @Injectable()
 export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
   private readonly maxAttempts = this.parsePositiveInt(process.env.WEBHOOK_DELIVERY_MAX_ATTEMPTS, 3);
   private readonly retryBaseDelayMs = this.parseNonNegativeInt(process.env.WEBHOOK_DELIVERY_RETRY_BASE_DELAY_MS, 100);
 
@@ -241,6 +242,7 @@ export class WebhooksService {
               responseCode: response.status,
             },
           });
+          this.logger.log(JSON.stringify({ event: 'webhook.delivery.succeeded', deliveryId: input.deliveryId, endpointId: input.endpoint.id, eventType: input.eventType, attempt, responseCode: response.status, idempotencyKey: input.idempotencyKey }));
           return;
         }
 
@@ -253,7 +255,8 @@ export class WebhooksService {
             responseCode: response.status,
           },
         });
-      } catch {
+        this.logger.warn(JSON.stringify({ event: 'webhook.delivery.response_not_ok', deliveryId: input.deliveryId, endpointId: input.endpoint.id, eventType: input.eventType, attempt, maxAttempts: this.maxAttempts, responseCode: response.status, willRetry: !isLastAttempt, idempotencyKey: input.idempotencyKey }));
+      } catch (error) {
         await this.prisma.webhookDelivery.update({
           where: { id: input.deliveryId },
           data: {
@@ -263,6 +266,7 @@ export class WebhooksService {
             responseCode: null,
           },
         });
+        this.logger.error(JSON.stringify({ event: 'webhook.delivery.request_failed', deliveryId: input.deliveryId, endpointId: input.endpoint.id, eventType: input.eventType, attempt, maxAttempts: this.maxAttempts, willRetry: !isLastAttempt, idempotencyKey: input.idempotencyKey, errorName: error instanceof Error ? error.name : 'UnknownError', errorMessage: error instanceof Error ? error.message : String(error) }));
       }
 
       if (!isLastAttempt) {

--- a/apps/api/test/ops-alert-baseline.spec.ts
+++ b/apps/api/test/ops-alert-baseline.spec.ts
@@ -1,0 +1,38 @@
+import { evaluateAlertBaseline } from '../src/ops/alert-baseline.util';
+
+describe('ops alert baseline evaluation', () => {
+  const thresholds = {
+    apiErrorRate: 0.05,
+    queueFailureCount: 5,
+    webhookFailureCount: 3,
+    webhookRetryingCount: 5,
+    providerUnhealthyCount: 1,
+  };
+
+  it('triggers each baseline alert when failure thresholds are exceeded', () => {
+    const alerts = evaluateAlertBaseline({
+      api: { totalRequests: 100, errorRequests: 9 },
+      queue: { totalJobs: 40, failedJobs: 7 },
+      webhooks: { totalDeliveries: 20, failedDeliveries: 4, retryingDeliveries: 2 },
+      providers: { criticalUnhealthyCount: 2 },
+      thresholds,
+    });
+
+    expect(alerts.find((alert) => alert.key === 'api_error_rate_spike')?.triggered).toBe(true);
+    expect(alerts.find((alert) => alert.key === 'queue_job_failures')?.triggered).toBe(true);
+    expect(alerts.find((alert) => alert.key === 'webhook_delivery_failures')?.triggered).toBe(true);
+    expect(alerts.find((alert) => alert.key === 'provider_health_failures')?.triggered).toBe(true);
+  });
+
+  it('stays clear when observed signals are under baseline thresholds', () => {
+    const alerts = evaluateAlertBaseline({
+      api: { totalRequests: 250, errorRequests: 5 },
+      queue: { totalJobs: 200, failedJobs: 1 },
+      webhooks: { totalDeliveries: 50, failedDeliveries: 0, retryingDeliveries: 1 },
+      providers: { criticalUnhealthyCount: 0 },
+      thresholds,
+    });
+
+    expect(alerts.every((alert) => !alert.triggered)).toBe(true);
+  });
+});

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -136,6 +136,34 @@ Key metrics to track:
 - auth failure/rate-limit spikes
 - webhook delivery failures and retry behavior
 
+
+## 7.1) Alerting Baseline (REQ-RC-010 / KAR-96)
+
+Alert baseline endpoint: `GET /ops/alerts/baseline`.
+
+Default lookback + thresholds (override with env vars when needed):
+
+- `api_error_rate_spike` (critical): trigger when `5xx` request rate is `>= 5%` over the last `15m`.
+- `queue_job_failures` (warning): trigger when failed async jobs are `>= 5` over the last `15m`.
+- `webhook_delivery_failures` (warning): trigger when webhook failures are `>= 3` OR retrying deliveries are `>= 5` over the last `15m`.
+- `provider_health_failures` (critical): trigger when unhealthy critical providers are `>= 1` from provider readiness checks.
+
+Operational response paths:
+
+1. API error rate spike
+   - Validate request-level logs (`event=http.request.completed`) using `x-request-id`/`x-correlation-id`.
+   - Triage top failing routes + impacted tenants.
+   - Escalate to API on-call; declare incident if sustained for >10 minutes.
+2. Queue/job failures
+   - Inspect queue worker failure logs (`event=queue.job.failed`) and dead-letter/retry state.
+   - Retry failed jobs if safe; escalate to owning subsystem (AI/import/export).
+3. Webhook retries/failures
+   - Inspect webhook delivery logs (`event=webhook.delivery.*`) for response codes and endpoint IDs.
+   - Coordinate with partner endpoint owner; use scoped manual retry once endpoint is healthy.
+4. Provider readiness failures
+   - Check `GET /ops/provider-status` for missing critical credentials/modes.
+   - Block deploy/traffic shift until provider status returns healthy.
+
 ## 8) Operational Ownership
 
 - Release owner: runs deploy + readiness checklist.


### PR DESCRIPTION
### Motivation
- Provide a minimal, non-invasive production observability and alerting baseline (REQ-RC-010) so on-call and ops have structured signals for request-level failures, queue/webhook failures, and provider readiness problems. 
- Add testable hooks and runbook guidance so alerts are verifiable and operators know escalation paths.

### Description
- Added a global HTTP observability interceptor that propagates/returns `x-request-id` and `x-correlation-id`, emits structured `http.request.completed` logs, and records rolling request metrics for alert evaluation (`apps/api/src/observability/request-observability.interceptor.ts`, `apps/api/src/observability/observability.service.ts`, `apps/api/src/observability/observability.module.ts`, wired into `apps/api/src/app.module.ts`).
- Standardized structured logging for queue and job lifecycle events (enqueue, enqueue failure, worker `failed`) including correlation IDs (`apps/api/src/queue/queue.service.ts`).
- Added structured webhook delivery logs for `succeeded`, `response_not_ok`, and `request_failed` including attempt and response/error metadata (`apps/api/src/webhooks/webhooks.service.ts`).
- Normalized provider dispatch logs and provider-accepted events to JSON payloads for operational triage (`apps/api/src/communications/providers/message-dispatch.service.ts`, `resend-email.provider.ts`, `twilio-sms.provider.ts`).
- Implemented alerting baseline evaluator and types for API error-rate spikes, queue/job failures, webhook retry/failure thresholds, and provider-health failures (`apps/api/src/ops/alert-baseline.util.ts`).
- Exposed a secured ops endpoint `GET /ops/alerts/baseline` and a service-side evaluation that aggregates request metrics, job counts, webhook delivery states, and provider readiness with configurable thresholds via env vars (`apps/api/src/ops/ops.controller.ts`, `apps/api/src/ops/ops.service.ts`).
- Added unit tests that simulate failing signals to verify alert triggers (`apps/api/test/ops-alert-baseline.spec.ts`).
- Updated deployment runbook with alert definitions, default thresholds, and operator response paths (`docs/DEPLOYMENT_RUNBOOK.md`).

### Testing
- ## Linear Issue
KAR-96

- ## Requirement ID
REQ-RC-010

- ## Validation Evidence
- Ran API test suite: `pnpm --filter api test` — all API tests passed (58 suites, 288 tests) ✅ (see test output showing webhook/provider dispatch logs and passing suites). 
- Build: `pnpm build` — workspace build completed TypeScript compilation but `apps/web` failed in this environment due to external Google Fonts fetch failures from `next/font` (network/font fetch issue unrelated to API observability changes); API build artifacts are unaffected ⚠️. 
- Verification hooks: added `apps/api/test/ops-alert-baseline.spec.ts` which asserts alerts trigger under simulated failure conditions and remain clear under healthy signals (tests included in `pnpm --filter api test`).
- Branch/commit: work done on branch `lin/KAR-96-observability-alerting-baseline` and committed as part of the PR; changed files include observability, queue, webhooks, communications providers, ops alert baseline, tests, and runbook updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a093e952e48325b9b91203e179aec7)