### PR TITLE
[KAR-89] Finalize session/auth bootstrap hardening

### DIFF
--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { bootstrapSession, clearSessionToken, getSessionToken, logoutSession } from '../lib/api';
+import { bootstrapSession, clearSessionToken, logoutSession } from '../lib/api';
 import { useEffect, useState, type ReactNode } from 'react';
 
 const LINKS = [
@@ -50,7 +50,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const path = usePathname() || '';
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [authReady, setAuthReady] = useState(() => path.startsWith('/login') || Boolean(getSessionToken()));
+  const [authReady, setAuthReady] = useState(() => path.startsWith('/login'));
   const [shellMode, setShellMode] = useState<ShellViewportMode>(() => {
     if (typeof window === 'undefined') {
       return 'desktop';
@@ -66,10 +66,6 @@ export function AppShell({ children }: { children: ReactNode }) {
   useEffect(() => {
     let cancelled = false;
     if (path.startsWith('/login')) {
-      setAuthReady(true);
-      return undefined;
-    }
-    if (getSessionToken()) {
       setAuthReady(true);
       return undefined;
     }

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -91,12 +91,15 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   let token = getSessionToken();
   let response = await execute(token);
 
-  if (response.status === 401 && !shouldSkipSessionBootstrap(path)) {
+  if (response.status === 401) {
     clearSessionToken();
-    const recovered = await bootstrapSession();
-    if (recovered) {
-      token = getSessionToken();
-      response = await execute(token);
+
+    if (!shouldSkipSessionBootstrap(path)) {
+      const recovered = await bootstrapSession();
+      if (recovered) {
+        token = getSessionToken();
+        response = await execute(token);
+      }
     }
   }
 

--- a/apps/web/test/api-fetch.spec.ts
+++ b/apps/web/test/api-fetch.spec.ts
@@ -25,6 +25,25 @@ describe('apiFetch', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+
+  it('clears token on auth-route 401 without attempting bootstrap retry', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => 'invalid credentials',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    setSessionToken('stale-session-token');
+
+    await expect(apiFetch('/auth/login', { method: 'POST', body: '{}' })).rejects.toThrow(
+      '401 Unauthorized: invalid credentials',
+    );
+
+    expect(window.localStorage.getItem('session_token')).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('adds session token and default headers on successful requests', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/web/test/app-shell-auth-bootstrap.spec.tsx
+++ b/apps/web/test/app-shell-auth-bootstrap.spec.tsx
@@ -54,6 +54,50 @@ describe('AppShell auth bootstrap', () => {
     expect(window.localStorage.getItem('session_token')).toBe('restored-token');
   });
 
+
+  it('revalidates stale local token against server session before rendering protected content', async () => {
+    window.localStorage.setItem('session_token', 'stale-token');
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      json: async () => ({}),
+      text: async () => 'invalid session',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const replace = vi.fn();
+    vi.spyOn(nextNavigation, 'usePathname').mockReturnValue('/dashboard');
+    vi.spyOn(nextNavigation, 'useRouter').mockReturnValue({
+      push: vi.fn(),
+      replace,
+      prefetch: vi.fn(),
+    } as any);
+
+    render(
+      <AppShell>
+        <div>Protected content</div>
+      </AppShell>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/auth/session',
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'include',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/login?next=%2Fdashboard');
+    });
+    expect(window.localStorage.getItem('session_token')).toBeNull();
+    expect(screen.queryByText('Protected content')).not.toBeInTheDocument();
+  });
+
   it('redirects to login when bootstrap session fails', async () => {
     window.localStorage.removeItem('session_token');
     const replace = vi.fn();


### PR DESCRIPTION
### Motivation
- Implement deterministic handling for stale/invalid sessions to satisfy REQ-RC-003 by ensuring local session state is never trusted over server truth. 
- Ensure protected-route bootstrap validates cookie-backed server session before rendering instead of relying on a possibly stale local token. 
- Limit retry behavior to a single recovery attempt and make token clearing consistent so clients do not race or persist invalid tokens.

### Description
- Change `apiFetch` to always clear the local `session_token` on any `401` response and only perform a single bootstrap+retry when the path is not an `/auth/*` route, preserving the single-attempt retry semantics. (apps/web/lib/api.ts)
- Change `AppShell` readiness logic to stop treating a local session token as authoritative and always call `bootstrapSession` for protected routes, redirecting to login and clearing tokens when server validation fails. (apps/web/components/app-shell.tsx)
- Add focused tests that assert auth-route 401 behavior (no bootstrap retry), stale-token revalidation and redirect behavior, and the deterministic failure path. (apps/web/test/api-fetch.spec.ts, apps/web/test/app-shell-auth-bootstrap.spec.tsx)
- Metadata: branch `lin/KAR-89-session-bootstrap-finalize`, commit `538d473d6d083b32aca6b66150d814ac22e5fe49`, PR title "[KAR-89] Finalize session/auth bootstrap hardening", changed files `apps/web/lib/api.ts`, `apps/web/components/app-shell.tsx`, `apps/web/test/api-fetch.spec.ts`, and `apps/web/test/app-shell-auth-bootstrap.spec.tsx`; this implements REQ-RC-003 (deterministic clearing, server-truth bootstrap, single retry).

### Testing
- Ran `pnpm --filter web test test/api-fetch.spec.ts test/app-shell-auth-bootstrap.spec.tsx` and both spec files passed (2 files, 8 tests passed). 
- Ran `pnpm --filter web test` and the full web test suite failed due to unrelated, pre-existing UI/component tests across multiple pages (multiple failures and render errors not related to session bootstrap). 
- Ran `pnpm --filter api test` and the API test suite passed (all test suites and tests passed). 
- Ran `pnpm build` and it failed during `next build` due to environment/network font fetch errors from Google Fonts (external dependency causing build to fail), not due to session/auth code changes.

Ready-to-merge: scoped changes implementing REQ-RC-003 are validated by the focused tests and API suite and are functionally ready to merge, with the caveat that the full web suite and Next.js build failures are caused by unrelated test data/CI environment issues (to be triaged separately).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a0a2699eec8325914dec58d9209391)