### PR TITLE
[KAR-93] Validate Clio/MyCase OAuth sync and webhook staging readiness

### DIFF
--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -304,6 +304,40 @@ export class OpsService {
       }),
     );
 
+    providers.push(
+      this.connectorValidationRow({
+        key: 'connectors_clio_staging_validation',
+        providerName: 'clio',
+        oauthMode: clioMode,
+        syncLiveEnabled,
+        checkedAt,
+        productionLike,
+        hasClientId: this.hasLiveCredentialValue(process.env.CLIO_CLIENT_ID),
+        hasClientSecret: this.hasLiveCredentialValue(process.env.CLIO_CLIENT_SECRET),
+        hasWebhookRegistrationUrl: this.hasLiveCredentialValue(process.env.CLIO_WEBHOOK_REGISTER_URL),
+        clientIdEnv: 'CLIO_CLIENT_ID',
+        clientSecretEnv: 'CLIO_CLIENT_SECRET',
+        webhookEnv: 'CLIO_WEBHOOK_REGISTER_URL',
+      }),
+    );
+
+    providers.push(
+      this.connectorValidationRow({
+        key: 'connectors_mycase_staging_validation',
+        providerName: 'mycase',
+        oauthMode: mycaseMode,
+        syncLiveEnabled,
+        checkedAt,
+        productionLike,
+        hasClientId: this.hasLiveCredentialValue(process.env.MYCASE_CLIENT_ID),
+        hasClientSecret: this.hasLiveCredentialValue(process.env.MYCASE_CLIENT_SECRET),
+        hasWebhookRegistrationUrl: this.hasLiveCredentialValue(process.env.MYCASE_WEBHOOK_REGISTER_URL),
+        clientIdEnv: 'MYCASE_CLIENT_ID',
+        clientSecretEnv: 'MYCASE_CLIENT_SECRET',
+        webhookEnv: 'MYCASE_WEBHOOK_REGISTER_URL',
+      }),
+    );
+
     const healthy = providers.every((provider) => !provider.critical || provider.healthy);
 
     return {
@@ -312,6 +346,59 @@ export class OpsService {
       evaluatedAt: checkedAt,
       providers,
     };
+  }
+
+  private connectorValidationRow(input: {
+    key: string;
+    providerName: string;
+    oauthMode: string;
+    syncLiveEnabled: boolean;
+    productionLike: boolean;
+    checkedAt: string;
+    hasClientId: boolean;
+    hasClientSecret: boolean;
+    hasWebhookRegistrationUrl: boolean;
+    clientIdEnv: string;
+    clientSecretEnv: string;
+    webhookEnv: string;
+  }): ProviderStatusRow {
+    const validationMode = input.oauthMode === 'live' && input.syncLiveEnabled ? 'validated' : 'pending';
+    const missingEnv = this.collectMissing(
+      [
+        {
+          when: input.oauthMode !== 'live',
+          name: `${input.providerName.toUpperCase()}_LIVE_OAUTH|INTEGRATION_OAUTH_ENABLE_LIVE`,
+        },
+        {
+          when: !input.hasClientId,
+          name: input.clientIdEnv,
+        },
+        {
+          when: !input.hasClientSecret,
+          name: input.clientSecretEnv,
+        },
+        {
+          when: !input.syncLiveEnabled,
+          name: 'INTEGRATION_SYNC_ENABLE_LIVE',
+        },
+        {
+          when: !input.hasWebhookRegistrationUrl,
+          name: input.webhookEnv,
+        },
+      ],
+      input.productionLike,
+    );
+
+    return this.row({
+      key: input.key,
+      mode: validationMode,
+      critical: input.productionLike,
+      productionLike: input.productionLike,
+      checkedAt: input.checkedAt,
+      supportedModes: ['validated', 'pending'],
+      missingEnv,
+      detail: `${input.providerName} staging validation requires live OAuth, live incremental sync, and webhook registration`,
+    });
   }
 
   private row(input: {

--- a/apps/api/test/integrations.spec.ts
+++ b/apps/api/test/integrations.spec.ts
@@ -543,4 +543,46 @@ describe('IntegrationsService', () => {
       }),
     );
   });
+
+  it('returns existing webhook subscription for duplicate event and target', async () => {
+    const connector = connectorStub(IntegrationProvider.CLIO);
+    const prisma = {
+      integrationConnection: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'conn-1',
+          organizationId: 'org1',
+          provider: IntegrationProvider.CLIO,
+          encryptedAccessToken: null,
+          encryptedRefreshToken: null,
+          configJson: {},
+        }),
+      },
+      integrationWebhookSubscription: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'hook-existing',
+          connectionId: 'conn-1',
+          event: 'matter.updated',
+          targetUrl: 'https://firm.example/webhooks/clio',
+          externalId: 'clio-sub-existing',
+        }),
+      },
+    } as any;
+
+    const service = new IntegrationsService(
+      prisma,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      new IntegrationTokenCryptoService(),
+      [connector],
+    );
+
+    const result = await service.subscribeWebhook({
+      user: { id: 'u1', organizationId: 'org1' } as any,
+      connectionId: 'conn-1',
+      event: 'matter.updated',
+      targetUrl: 'https://firm.example/webhooks/clio',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ id: 'hook-existing', externalId: 'clio-sub-existing' }));
+    expect((connector.subscribeWebhooks as jest.Mock).mock.calls.length).toBe(0);
+  });
 });

--- a/apps/api/test/provider-live-validation.spec.ts
+++ b/apps/api/test/provider-live-validation.spec.ts
@@ -109,6 +109,20 @@ describe('provider live validation matrix', () => {
     expect(clio?.missingEnv).toContain('CLIO_CLIENT_SECRET');
   });
 
+  it('requires complete staging validation path for clio/mycase oauth + sync + webhooks', () => {
+    configureLiveBaseline();
+    delete process.env.INTEGRATION_SYNC_ENABLE_LIVE;
+
+    const status = new OpsService().providerStatus();
+    const clioValidation = status.providers.find((row) => row.key === 'connectors_clio_staging_validation');
+    const mycaseValidation = status.providers.find((row) => row.key === 'connectors_mycase_staging_validation');
+
+    expect(status.healthy).toBe(false);
+    expect(clioValidation?.missingEnv).toContain('INTEGRATION_SYNC_ENABLE_LIVE');
+    expect(mycaseValidation?.missingEnv).toContain('INTEGRATION_SYNC_ENABLE_LIVE');
+    expect(() => assertProviderReadiness(status.profile, status.providers)).toThrow('INTEGRATION_SYNC_ENABLE_LIVE');
+  });
+
   it('fails readiness when live sync mode is enabled without webhook registration urls', () => {
     configureLiveBaseline();
     delete process.env.CLIO_WEBHOOK_REGISTER_URL;

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -78,6 +78,8 @@ Operational readiness checklist:
 - queue workers and Redis connectivity are healthy.
 - document storage read/write path works.
 - provider readiness reports healthy (`/ops/provider-status`) with no missing critical env.
+- connector staging validation rows (`connectors_clio_staging_validation`, `connectors_mycase_staging_validation`) show `mode=validated` before enabling traffic.
+- verify incremental sync + webhook idempotency in staging (`pnpm --filter api test -- integrations.spec.ts provider-readiness.spec.ts provider-live-validation.spec.ts`).
 
 Post-start smoke tests (minimum):
 


### PR DESCRIPTION
### Motivation

- Implement a staging validation path to ensure Clio/MyCase integrations are fully ready before enabling traffic (live OAuth + incremental sync + webhook registration) as required by REQ-RC-007. 
- Keep behavior backward-compatible and surface actionable readiness hints for operators so staging/production toggles and credentials can be validated without changing public API contracts.

### Description

- Added connector-level staging validation rows to `OpsService.providerStatus()` via a new `connectorValidationRow` helper and registered `connectors_clio_staging_validation` and `connectors_mycase_staging_validation` rows that require live OAuth, non-stub credentials, `INTEGRATION_SYNC_ENABLE_LIVE`, and webhook registration URL. 
- Added test coverage: a gating test in `provider-live-validation.spec.ts` that asserts the staging validation rows fail when `INTEGRATION_SYNC_ENABLE_LIVE` is missing, and an idempotency test in `integrations.spec.ts` verifying existing webhook subscriptions are returned without calling the connector. 
- Updated operational docs in `docs/DEPLOYMENT_RUNBOOK.md` to require connector staging validation rows to show `mode=validated` and to include the staging verification test command. 
- Branch: `lin/KAR-93-clio-mycase-staging-validation`, Commit: `5bad42b`, PR title: `[KAR-93] Validate Clio/MyCase OAuth sync and webhook staging readiness`, PR URL: _not available in this environment_. Files changed: `apps/api/src/ops/ops.service.ts`, `apps/api/test/integrations.spec.ts`, `apps/api/test/provider-live-validation.spec.ts`, `docs/DEPLOYMENT_RUNBOOK.md`. 
- Requirement mapping: implements **REQ-RC-007** by adding staging readiness rows for Clio/MyCase that validate OAuth + incremental sync + webhook handling and by extending idempotency verification coverage. 
- Risks / follow-ups: repo-wide build fails in this environment due to Next.js fetching Google Fonts during `pnpm build` in `apps/web`, so consider vendoring fonts or adding an offline fallback to make deterministic CI builds; API-scope changes are self-contained.

### Testing

- Ran lint: `pnpm --filter api lint` — passed. 
- Ran targeted tests: `pnpm --filter api test -- integrations.spec.ts provider-readiness.spec.ts provider-live-validation.spec.ts` — all three suites passed. 
- Ran full API test suite: `pnpm --filter api test` — all API tests passed (`59` suites, `292` tests in this environment). 
- Repository build: `pnpm build` — failed due to external Google Fonts fetch errors during `apps/web` Next.js build, which is an environment/network-dependent failure unrelated to API changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a0a27026188325a8cb1b60eb162864)