### PR TITLE
[KAR-92] Add live validation suite for critical providers

### DIFF
--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -10,6 +10,8 @@ type ProviderStatusRow = {
   provider: string;
   critical: boolean;
   healthy: boolean;
+  diagnosticStatus: 'pass' | 'fail';
+  diagnostics: string[];
   issues: string[];
   checkedAt: string;
   detail: string;
@@ -305,11 +307,20 @@ export class OpsService {
     );
 
     const healthy = providers.every((provider) => !provider.critical || provider.healthy);
+    const diagnostics = providers
+      .filter((provider) => provider.critical)
+      .map((provider) => ({
+        key: provider.key,
+        mode: provider.mode,
+        status: provider.diagnosticStatus,
+        detail: provider.diagnostics.join('; '),
+      }));
 
     return {
       profile,
       healthy,
       evaluatedAt: checkedAt,
+      diagnostics,
       providers,
     };
   }
@@ -341,6 +352,9 @@ export class OpsService {
     }
 
     const healthy = issues.length === 0;
+    const diagnostics = healthy
+      ? [`PASS: ${input.key} configured for mode=${mode}`]
+      : [`FAIL: ${input.key} configured for mode=${mode}`, ...issues];
 
     const detailParts = [input.detail];
     if (issues.length > 0) {
@@ -353,6 +367,8 @@ export class OpsService {
       provider: mode,
       critical: input.critical,
       healthy,
+      diagnosticStatus: healthy ? 'pass' : 'fail',
+      diagnostics,
       issues,
       checkedAt: input.checkedAt,
       detail: detailParts.join('. '),

--- a/apps/api/src/ops/provider-readiness.util.ts
+++ b/apps/api/src/ops/provider-readiness.util.ts
@@ -4,6 +4,8 @@ type ProviderStatusRow = {
   provider?: string;
   critical: boolean;
   healthy: boolean;
+  diagnosticStatus?: 'pass' | 'fail';
+  diagnostics?: string[];
   issues?: string[];
   checkedAt?: string;
   detail: string;
@@ -28,7 +30,9 @@ export function assertProviderReadiness(profile: string, providers: ProviderStat
     .map((provider) => {
       const missing = provider.missingEnv && provider.missingEnv.length > 0 ? ` missing=${provider.missingEnv.join('|')}` : '';
       const issues = provider.issues && provider.issues.length > 0 ? ` issues=${provider.issues.join('|')}` : '';
-      return `${provider.key} (mode=${provider.mode}${missing}${issues})`;
+      const diagnostics =
+        provider.diagnostics && provider.diagnostics.length > 0 ? ` diagnostics=${provider.diagnostics.join('|')}` : '';
+      return `${provider.key} (mode=${provider.mode}${missing}${issues}${diagnostics})`;
     })
     .join('; ');
   throw new Error(

--- a/apps/api/test/ops-provider-status.spec.ts
+++ b/apps/api/test/ops-provider-status.spec.ts
@@ -24,6 +24,9 @@ describe('OpsService provider status', () => {
     expect(status.providers.every((row) => typeof row.checkedAt === 'string')).toBe(true);
     expect(status.providers.some((row) => row.key === 'stripe' && row.healthy === false)).toBe(true);
     expect(status.providers.some((row) => row.key === 'email' && (row.issues || []).length > 0)).toBe(true);
+    expect(status.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'stripe', status: 'fail' })]),
+    );
   });
 
   it('marks providers healthy when live mode is configured', () => {
@@ -57,6 +60,15 @@ describe('OpsService provider status', () => {
 
     expect(status.healthy).toBe(true);
     expect(status.providers.every((row) => row.healthy)).toBe(true);
+    expect(status.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'stripe', status: 'pass' }),
+        expect.objectContaining({ key: 'email', status: 'pass' }),
+        expect.objectContaining({ key: 'sms', status: 'pass' }),
+        expect.objectContaining({ key: 'malware_scanner', status: 'pass' }),
+        expect.objectContaining({ key: 'esign', status: 'pass' }),
+      ]),
+    );
   });
 
   it('uses global oauth live toggle when provider-specific flags are not set', () => {
@@ -88,5 +100,21 @@ describe('OpsService provider status', () => {
 
     expect(clio?.mode).toBe('live');
     expect(mycase?.mode).toBe('live');
+  });
+
+  it('keeps development fallback behavior for stub providers', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.MESSAGE_EMAIL_PROVIDER = 'stub';
+    process.env.MESSAGE_SMS_PROVIDER = 'stub';
+    process.env.MALWARE_SCANNER_PROVIDER = 'stub';
+    process.env.ESIGN_PROVIDER = 'stub';
+    delete process.env.STRIPE_SECRET_KEY;
+
+    const service = new OpsService();
+    const status = service.providerStatus();
+
+    expect(status.profile).toBe('development');
+    expect(status.healthy).toBe(true);
+    expect(status.providers.some((row) => row.key === 'email' && row.healthy === true)).toBe(true);
   });
 });

--- a/apps/api/test/provider-live-validation.spec.ts
+++ b/apps/api/test/provider-live-validation.spec.ts
@@ -50,6 +50,15 @@ describe('provider live validation matrix', () => {
     const status = new OpsService().providerStatus();
     expect(status.profile).toBe('staging');
     expect(status.healthy).toBe(true);
+    expect(status.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'stripe', status: 'pass' }),
+        expect.objectContaining({ key: 'email', status: 'pass' }),
+        expect.objectContaining({ key: 'sms', status: 'pass' }),
+        expect.objectContaining({ key: 'malware_scanner', status: 'pass' }),
+        expect.objectContaining({ key: 'esign', status: 'pass' }),
+      ]),
+    );
     expect(() => assertProviderReadiness(status.profile, status.providers)).not.toThrow();
   });
 
@@ -61,8 +70,10 @@ describe('provider live validation matrix', () => {
     const status = new OpsService().providerStatus();
     expect(status.healthy).toBe(false);
 
+    const emailDiagnostic = status.diagnostics.find((row) => row.key === 'email');
     const email = status.providers.find((row) => row.key === 'email');
     const clio = status.providers.find((row) => row.key === 'clio');
+    expect(emailDiagnostic?.status).toBe('fail');
     expect(email?.missingEnv).toContain('RESEND_API_KEY');
     expect(clio?.missingEnv).toContain('CLIO_CLIENT_SECRET');
     expect(() => assertProviderReadiness(status.profile, status.providers)).toThrow('RESEND_API_KEY');


### PR DESCRIPTION
### Motivation

- Implement REQ-RC-006 by providing explicit live validation coverage for Stripe, email, SMS, malware scanner and e-sign with clear pass/fail diagnostics suitable for staging/production readiness gating.
- Surface actionable, diagnostic messages (missing envs / issues) so readiness failures are prescriptive for deploy blockers.
- Preserve existing development fallback behavior while enforcing stricter production/staging checks for critical providers.

### Description

- Added per-provider `diagnosticStatus` (`pass`/`fail`) and `diagnostics` string array to the provider status rows and returned a top-level `diagnostics` array on `/ops/provider-status` to summarize critical-provider pass/fail diagnostics (`apps/api/src/ops/ops.service.ts`).
- Enhanced readiness failure composition to include diagnostic strings so `assertProviderReadiness` throws errors containing both missing env hints and diagnostic messages when production-like profiles fail (`apps/api/src/ops/provider-readiness.util.ts`).
- Expanded and updated tests to assert diagnostics and behavior: `provider-live-validation.spec.ts` validates pass/fail diagnostics across stripe/email/sms/malware/esign and missing-credential scenarios, and `ops-provider-status.spec.ts` asserts diagnostic emission plus a development fallback test to ensure dev profile remains permissive while production-like is strict (`apps/api/test/provider-live-validation.spec.ts`, `apps/api/test/ops-provider-status.spec.ts`).
- Files changed: `apps/api/src/ops/ops.service.ts`, `apps/api/src/ops/provider-readiness.util.ts`, `apps/api/test/provider-live-validation.spec.ts`, `apps/api/test/ops-provider-status.spec.ts`; branch `lin/KAR-92-provider-live-validation-suite`, commit `de54f5a9efbf7c37118357afd0d21369e6e09413`, PR title as above (PR URL not returned by tooling in this environment).

### Testing

- Ran `pnpm --filter api lint` and it passed successfully.
- Ran `pnpm --filter api test -- provider-live-validation.spec.ts ops-provider-status.spec.ts` and both targeted suites passed.
- Ran full API test suite with `pnpm --filter api test` and all API tests passed (59 suites, 291 tests) with the new assertions included.
- Attempted `pnpm build` for the workspace which failed due to `apps/web` being unable to fetch Google Fonts in this environment, while API build/test/lint steps completed successfully; the failure is environmental and unrelated to the API changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a0a2b6063c832588b9283b3d4cc397)