### PR TITLE
[KAR-93] Validate Clio/MyCase OAuth sync and webhook staging readiness

### DIFF
--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -304,6 +304,40 @@ export class OpsService {
       }),
     );
 
+    providers.push(
+      this.connectorValidationRow({
+        key: 'connectors_clio_staging_validation',
+        providerName: 'clio',
+        oauthMode: clioMode,
+        syncLiveEnabled,
+        checkedAt,
+        productionLike,
+        hasClientId: this.hasLiveCredentialValue(process.env.CLIO_CLIENT_ID),
+        hasClientSecret: this.hasLiveCredentialValue(process.env.CLIO_CLIENT_SECRET),
+        hasWebhookRegistrationUrl: this.hasLiveCredentialValue(process.env.CLIO_WEBHOOK_REGISTER_URL),
+        clientIdEnv: 'CLIO_CLIENT_ID',
+        clientSecretEnv: 'CLIO_CLIENT_SECRET',
+        webhookEnv: 'CLIO_WEBHOOK_REGISTER_URL',
+      }),
+    );
+
+    providers.push(
+      this.connectorValidationRow({
+        key: 'connectors_mycase_staging_validation',
+        providerName: 'mycase',
+        oauthMode: mycaseMode,
+        syncLiveEnabled,
+        checkedAt,
+        productionLike,
+        hasClientId: this.hasLiveCredentialValue(process.env.MYCASE_CLIENT_ID),
+        hasClientSecret: this.hasLiveCredentialValue(process.env.MYCASE_CLIENT_SECRET),
+        hasWebhookRegistrationUrl: this.hasLiveCredentialValue(process.env.MYCASE_WEBHOOK_REGISTER_URL),
+        clientIdEnv: 'MYCASE_CLIENT_ID',
+        clientSecretEnv: 'MYCASE_CLIENT_SECRET',
+        webhookEnv: 'MYCASE_WEBHOOK_REGISTER_URL',
+      }),
+    );
+
     const healthy = providers.every((provider) => !provider.critical || provider.healthy);
 
     return {
@@ -312,6 +346,59 @@ export class OpsService {
       evaluatedAt: checkedAt,
       providers,
     };
+  }
+
+  private connectorValidationRow(input: {
+    key: string;
+    providerName: string;
+    oauthMode: string;
+    syncLiveEnabled: boolean;
+    productionLike: boolean;
+    checkedAt: string;
+    hasClientId: boolean;
+    hasClientSecret: boolean;
+    hasWebhookRegistrationUrl: boolean;
+    clientIdEnv: string;
+    clientSecretEnv: string;
+    webhookEnv: string;
+  }): ProviderStatusRow {
+    const validationMode = input.oauthMode === 'live' && input.syncLiveEnabled ? 'validated' : 'pending';
+    const missingEnv = this.collectMissing(
+      [
+        {
+          when: input.oauthMode !== 'live',
+          name: `${input.providerName.toUpperCase()}_LIVE_OAUTH|INTEGRATION_OAUTH_ENABLE_LIVE`,
+        },
+        {
+          when: !input.hasClientId,
+          name: input.clientIdEnv,
+        },
+        {
+          when: !input.hasClientSecret,
+          name: input.clientSecretEnv,
+        },
+        {
+          when: !input.syncLiveEnabled,
+          name: 'INTEGRATION_SYNC_ENABLE_LIVE',
+        },
+        {
+          when: !input.hasWebhookRegistrationUrl,
+          name: input.webhookEnv,
+        },
+      ],
+      input.productionLike,
+    );
+
+    return this.row({
+      key: input.key,
+      mode: validationMode,
+      critical: input.productionLike,
+      productionLike: input.productionLike,
+      checkedAt: input.checkedAt,
+      supportedModes: ['validated', 'pending'],
+      missingEnv,
+      detail: `${input.providerName} staging validation requires live OAuth, live incremental sync, and webhook registration`,
+    });
   }
 
   private row(input: {

--- a/apps/api/test/integrations.spec.ts
+++ b/apps/api/test/integrations.spec.ts
@@ -543,4 +543,46 @@ describe('IntegrationsService', () => {
       }),
     );
   });
+
+  it('returns existing webhook subscription for duplicate event and target', async () => {
+    const connector = connectorStub(IntegrationProvider.CLIO);
+    const prisma = {
+      integrationConnection: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'conn-1',
+          organizationId: 'org1',
+          provider: IntegrationProvider.CLIO,
+          encryptedAccessToken: null,
+          encryptedRefreshToken: null,
+          configJson: {},
+        }),
+      },
+      integrationWebhookSubscription: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'hook-existing',
+          connectionId: 'conn-1',
+          event: 'matter.updated',
+          targetUrl: 'https://firm.example/webhooks/clio',
+          externalId: 'clio-sub-existing',
+        }),
+      },
+    } as any;
+
+    const service = new IntegrationsService(
+      prisma,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      new IntegrationTokenCryptoService(),
+      [connector],
+    );
+
+    const result = await service.subscribeWebhook({
+      user: { id: 'u1', organizationId: 'org1' } as any,
+      connectionId: 'conn-1',
+      event: 'matter.updated',
+      targetUrl: 'https://firm.example/webhooks/clio',
+    });
+
+    expect(result).toEqual(expect.objectContaining({ id: 'hook-existing', externalId: 'clio-sub-existing' }));
+    expect((connector.subscribeWebhooks as jest.Mock).mock.calls.length).toBe(0);
+  });
 });

--- a/apps/api/test/provider-live-validation.spec.ts
+++ b/apps/api/test/provider-live-validation.spec.ts
@@ -109,6 +109,20 @@ describe('provider live validation matrix', () => {
     expect(clio?.missingEnv).toContain('CLIO_CLIENT_SECRET');
   });
 
+  it('requires complete staging validation path for clio/mycase oauth + sync + webhooks', () => {
+    configureLiveBaseline();
+    delete process.env.INTEGRATION_SYNC_ENABLE_LIVE;
+
+    const status = new OpsService().providerStatus();
+    const clioValidation = status.providers.find((row) => row.key === 'connectors_clio_staging_validation');
+    const mycaseValidation = status.providers.find((row) => row.key === 'connectors_mycase_staging_validation');
+
+    expect(status.healthy).toBe(false);
+    expect(clioValidation?.missingEnv).toContain('INTEGRATION_SYNC_ENABLE_LIVE');
+    expect(mycaseValidation?.missingEnv).toContain('INTEGRATION_SYNC_ENABLE_LIVE');
+    expect(() => assertProviderReadiness(status.profile, status.providers)).toThrow('INTEGRATION_SYNC_ENABLE_LIVE');
+  });
+
   it('fails readiness when live sync mode is enabled without webhook registration urls', () => {
     configureLiveBaseline();
     delete process.env.CLIO_WEBHOOK_REGISTER_URL;

--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -78,6 +78,8 @@ Operational readiness checklist:
 - queue workers and Redis connectivity are healthy.
 - document storage read/write path works.
 - provider readiness reports healthy (`/ops/provider-status`) with no missing critical env.
+- connector staging validation rows (`connectors_clio_staging_validation`, `connectors_mycase_staging_validation`) show `mode=validated` before enabling traffic.
+- verify incremental sync + webhook idempotency in staging (`pnpm --filter api test -- integrations.spec.ts provider-readiness.spec.ts provider-live-validation.spec.ts`).
 
 Post-start smoke tests (minimum):
 


### PR DESCRIPTION
## Linear Issue
- Key: KAR-93
- URL: https://linear.app/karenap/issue/KAR-93

## Requirement ID
- REQ-RC-007

## Summary
- Added Clio/MyCase staging validation provider rows in `/ops/provider-status` for OAuth + incremental sync + webhook readiness gating.
- Added idempotency verification for connector webhook subscription behavior.
- Updated deployment runbook with connector staging validation expectations.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- `pnpm --filter api lint`
- `pnpm --filter api test -- integrations.spec.ts provider-readiness.spec.ts provider-live-validation.spec.ts`
- `pnpm --filter api test`
- `pnpm build`

## Notes
- Supersedes #220 from non-policy branch naming.
