### PR TITLE
[KAR-92] Add live validation suite for critical providers

### DIFF
--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -10,6 +10,8 @@ type ProviderStatusRow = {
   provider: string;
   critical: boolean;
   healthy: boolean;
+  diagnosticStatus: 'pass' | 'fail';
+  diagnostics: string[];
   issues: string[];
   checkedAt: string;
   detail: string;
@@ -305,11 +307,20 @@ export class OpsService {
     );
 
     const healthy = providers.every((provider) => !provider.critical || provider.healthy);
+    const diagnostics = providers
+      .filter((provider) => provider.critical)
+      .map((provider) => ({
+        key: provider.key,
+        mode: provider.mode,
+        status: provider.diagnosticStatus,
+        detail: provider.diagnostics.join('; '),
+      }));
 
     return {
       profile,
       healthy,
       evaluatedAt: checkedAt,
+      diagnostics,
       providers,
     };
   }
@@ -341,6 +352,9 @@ export class OpsService {
     }
 
     const healthy = issues.length === 0;
+    const diagnostics = healthy
+      ? [`PASS: ${input.key} configured for mode=${mode}`]
+      : [`FAIL: ${input.key} configured for mode=${mode}`, ...issues];
 
     const detailParts = [input.detail];
     if (issues.length > 0) {
@@ -353,6 +367,8 @@ export class OpsService {
       provider: mode,
       critical: input.critical,
       healthy,
+      diagnosticStatus: healthy ? 'pass' : 'fail',
+      diagnostics,
       issues,
       checkedAt: input.checkedAt,
       detail: detailParts.join('. '),

--- a/apps/api/src/ops/provider-readiness.util.ts
+++ b/apps/api/src/ops/provider-readiness.util.ts
@@ -4,6 +4,8 @@ type ProviderStatusRow = {
   provider?: string;
   critical: boolean;
   healthy: boolean;
+  diagnosticStatus?: 'pass' | 'fail';
+  diagnostics?: string[];
   issues?: string[];
   checkedAt?: string;
   detail: string;
@@ -28,7 +30,9 @@ export function assertProviderReadiness(profile: string, providers: ProviderStat
     .map((provider) => {
       const missing = provider.missingEnv && provider.missingEnv.length > 0 ? ` missing=${provider.missingEnv.join('|')}` : '';
       const issues = provider.issues && provider.issues.length > 0 ? ` issues=${provider.issues.join('|')}` : '';
-      return `${provider.key} (mode=${provider.mode}${missing}${issues})`;
+      const diagnostics =
+        provider.diagnostics && provider.diagnostics.length > 0 ? ` diagnostics=${provider.diagnostics.join('|')}` : '';
+      return `${provider.key} (mode=${provider.mode}${missing}${issues}${diagnostics})`;
     })
     .join('; ');
   throw new Error(

--- a/apps/api/test/ops-provider-status.spec.ts
+++ b/apps/api/test/ops-provider-status.spec.ts
@@ -24,6 +24,9 @@ describe('OpsService provider status', () => {
     expect(status.providers.every((row) => typeof row.checkedAt === 'string')).toBe(true);
     expect(status.providers.some((row) => row.key === 'stripe' && row.healthy === false)).toBe(true);
     expect(status.providers.some((row) => row.key === 'email' && (row.issues || []).length > 0)).toBe(true);
+    expect(status.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ key: 'stripe', status: 'fail' })]),
+    );
   });
 
   it('marks providers healthy when live mode is configured', () => {
@@ -57,6 +60,15 @@ describe('OpsService provider status', () => {
 
     expect(status.healthy).toBe(true);
     expect(status.providers.every((row) => row.healthy)).toBe(true);
+    expect(status.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'stripe', status: 'pass' }),
+        expect.objectContaining({ key: 'email', status: 'pass' }),
+        expect.objectContaining({ key: 'sms', status: 'pass' }),
+        expect.objectContaining({ key: 'malware_scanner', status: 'pass' }),
+        expect.objectContaining({ key: 'esign', status: 'pass' }),
+      ]),
+    );
   });
 
   it('uses global oauth live toggle when provider-specific flags are not set', () => {
@@ -88,5 +100,21 @@ describe('OpsService provider status', () => {
 
     expect(clio?.mode).toBe('live');
     expect(mycase?.mode).toBe('live');
+  });
+
+  it('keeps development fallback behavior for stub providers', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.MESSAGE_EMAIL_PROVIDER = 'stub';
+    process.env.MESSAGE_SMS_PROVIDER = 'stub';
+    process.env.MALWARE_SCANNER_PROVIDER = 'stub';
+    process.env.ESIGN_PROVIDER = 'stub';
+    delete process.env.STRIPE_SECRET_KEY;
+
+    const service = new OpsService();
+    const status = service.providerStatus();
+
+    expect(status.profile).toBe('development');
+    expect(status.healthy).toBe(true);
+    expect(status.providers.some((row) => row.key === 'email' && row.healthy === true)).toBe(true);
   });
 });

--- a/apps/api/test/provider-live-validation.spec.ts
+++ b/apps/api/test/provider-live-validation.spec.ts
@@ -50,6 +50,15 @@ describe('provider live validation matrix', () => {
     const status = new OpsService().providerStatus();
     expect(status.profile).toBe('staging');
     expect(status.healthy).toBe(true);
+    expect(status.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'stripe', status: 'pass' }),
+        expect.objectContaining({ key: 'email', status: 'pass' }),
+        expect.objectContaining({ key: 'sms', status: 'pass' }),
+        expect.objectContaining({ key: 'malware_scanner', status: 'pass' }),
+        expect.objectContaining({ key: 'esign', status: 'pass' }),
+      ]),
+    );
     expect(() => assertProviderReadiness(status.profile, status.providers)).not.toThrow();
   });
 
@@ -61,8 +70,10 @@ describe('provider live validation matrix', () => {
     const status = new OpsService().providerStatus();
     expect(status.healthy).toBe(false);
 
+    const emailDiagnostic = status.diagnostics.find((row) => row.key === 'email');
     const email = status.providers.find((row) => row.key === 'email');
     const clio = status.providers.find((row) => row.key === 'clio');
+    expect(emailDiagnostic?.status).toBe('fail');
     expect(email?.missingEnv).toContain('RESEND_API_KEY');
     expect(clio?.missingEnv).toContain('CLIO_CLIENT_SECRET');
     expect(() => assertProviderReadiness(status.profile, status.providers)).toThrow('RESEND_API_KEY');


### PR DESCRIPTION
## Linear Issue
- Key: KAR-92
- URL: https://linear.app/karenap/issue/KAR-92

## Requirement ID
- REQ-RC-006

## Summary
- Added per-provider diagnostics to `/ops/provider-status` for live validation visibility.
- Extended readiness failure reporting to include diagnostic causes in production-like enforcement errors.
- Added and expanded tests for provider live validation diagnostics and dev-vs-production strictness.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- `pnpm --filter api lint`
- `pnpm --filter api test -- provider-live-validation.spec.ts ops-provider-status.spec.ts`
- `pnpm --filter api test`
- `pnpm build`

## Notes
- Supersedes #222 from non-policy branch naming.
