### PR TITLE
[KAR-98] Deterministic auth bootstrap test harness

### DIFF
--- a/apps/web/test/app-shell-auth-bootstrap.spec.tsx
+++ b/apps/web/test/app-shell-auth-bootstrap.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import * as nextNavigation from 'next/navigation';
 import { AppShell } from '../components/app-shell';
+import { getAuthBootstrapFetchMock, useStrictAuthBootstrapMode } from './setup';
 
 describe('AppShell auth bootstrap', () => {
   afterEach(() => {
@@ -10,30 +11,8 @@ describe('AppShell auth bootstrap', () => {
   });
 
   it('bootstraps from cookie-backed session and restores local token', async () => {
-    window.localStorage.removeItem('session_token');
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.endsWith('/auth/session')) {
-        return {
-          ok: true,
-          status: 200,
-          statusText: 'OK',
-          json: async () => ({
-            user: { id: 'user-1' },
-            token: 'restored-token',
-          }),
-          text: async () => '',
-        } as Response;
-      }
-      return {
-        ok: false,
-        status: 500,
-        statusText: 'Unexpected',
-        json: async () => ({}),
-        text: async () => 'Unexpected request',
-      } as Response;
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    useStrictAuthBootstrapMode({ token: 'restored-token' });
+    const fetchMock = getAuthBootstrapFetchMock();
 
     render(
       <AppShell>
@@ -55,7 +34,7 @@ describe('AppShell auth bootstrap', () => {
   });
 
   it('redirects to login when bootstrap session fails', async () => {
-    window.localStorage.removeItem('session_token');
+    useStrictAuthBootstrapMode({ status: 401, token: null, includeUser: false });
     const replace = vi.fn();
     vi.spyOn(nextNavigation, 'usePathname').mockReturnValue('/documents');
     vi.spyOn(nextNavigation, 'useRouter').mockReturnValue({
@@ -64,14 +43,7 @@ describe('AppShell auth bootstrap', () => {
       prefetch: vi.fn(),
     } as any);
 
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      statusText: 'Unauthorized',
-      json: async () => ({}),
-      text: async () => 'unauthorized',
-    });
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = getAuthBootstrapFetchMock();
 
     render(
       <AppShell>

--- a/apps/web/test/app-shell-responsive.spec.tsx
+++ b/apps/web/test/app-shell-responsive.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { AppShell } from '../components/app-shell';
+import { useStrictAuthBootstrapMode } from './setup';
 
 function setViewport(width: number) {
   Object.defineProperty(window, 'innerWidth', {
@@ -12,35 +13,10 @@ function setViewport(width: number) {
   window.dispatchEvent(new Event('resize'));
 }
 
-function mockSessionBootstrapSuccess() {
-  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-    const url = String(input);
-    if (url.endsWith('/auth/session')) {
-      return {
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => ({
-          user: { id: 'user-1' },
-          token: 'test-session-token',
-        }),
-        text: async () => '',
-      } as Response;
-    }
-    return {
-      ok: false,
-      status: 500,
-      statusText: 'Unexpected',
-      json: async () => ({}),
-      text: async () => 'Unexpected request',
-    } as Response;
-  });
-  vi.stubGlobal('fetch', fetchMock);
-}
 
 describe('AppShell responsive behavior matrix', () => {
   it('uses full desktop mode at >=1280px', async () => {
-    mockSessionBootstrapSuccess();
+    useStrictAuthBootstrapMode();
     setViewport(1366);
     render(
       <AppShell>
@@ -55,7 +31,7 @@ describe('AppShell responsive behavior matrix', () => {
   });
 
   it('uses compact desktop mode at 1024-1279px', async () => {
-    mockSessionBootstrapSuccess();
+    useStrictAuthBootstrapMode();
     setViewport(1120);
     render(
       <AppShell>
@@ -71,7 +47,7 @@ describe('AppShell responsive behavior matrix', () => {
   });
 
   it('uses drawer behavior at tablet widths', async () => {
-    mockSessionBootstrapSuccess();
+    useStrictAuthBootstrapMode();
     setViewport(900);
     render(
       <AppShell>
@@ -91,7 +67,7 @@ describe('AppShell responsive behavior matrix', () => {
   });
 
   it('shows unsupported notice below 768px', () => {
-    mockSessionBootstrapSuccess();
+    useStrictAuthBootstrapMode();
     setViewport(640);
     render(
       <AppShell>

--- a/apps/web/test/app-shell.spec.tsx
+++ b/apps/web/test/app-shell.spec.tsx
@@ -2,37 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { AppShell } from '../components/app-shell';
+import { useStrictAuthBootstrapMode } from './setup';
 
 describe('AppShell', () => {
   beforeEach(() => {
-    window.localStorage.setItem('session_token', 'test-session-token');
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.endsWith('/auth/session')) {
-        return {
-          ok: true,
-          status: 200,
-          statusText: 'OK',
-          json: async () => ({
-            user: { id: 'user-1' },
-            token: 'test-session-token',
-          }),
-          text: async () => '',
-        } as Response;
-      }
-      return {
-        ok: false,
-        status: 500,
-        statusText: 'Unexpected',
-        json: async () => ({}),
-        text: async () => 'Unexpected request',
-      } as Response;
-    });
-    vi.stubGlobal('fetch', fetchMock);
-  });
-
-  afterEach(() => {
-    window.localStorage.removeItem('session_token');
+    useStrictAuthBootstrapMode();
   });
 
   it('renders standardized sidebar navigation with active route semantics', async () => {

--- a/apps/web/test/setup.tsx
+++ b/apps/web/test/setup.tsx
@@ -3,6 +3,68 @@ import { cleanup } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, vi } from 'vitest';
 
+type AuthBootstrapHarnessConfig = {
+  status: number;
+  token: string | null;
+  includeUser: boolean;
+};
+
+const DEFAULT_AUTH_BOOTSTRAP_HARNESS: AuthBootstrapHarnessConfig = {
+  status: 200,
+  token: 'test-session-token',
+  includeUser: true,
+};
+
+const authBootstrapHarnessState: { config: AuthBootstrapHarnessConfig } = {
+  config: { ...DEFAULT_AUTH_BOOTSTRAP_HARNESS },
+};
+
+function createAuthSessionResponse(config: AuthBootstrapHarnessConfig): Response {
+  const ok = config.status >= 200 && config.status < 300;
+  return {
+    ok,
+    status: config.status,
+    statusText: ok ? 'OK' : 'Unauthorized',
+    json: async () => ({
+      ...(config.includeUser ? { user: { id: 'user-1' } } : {}),
+      ...(config.token ? { token: config.token } : {}),
+    }),
+    text: async () => (ok ? '' : 'unauthorized'),
+  } as Response;
+}
+
+function installAuthBootstrapHarness() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method?.toUpperCase() ?? 'GET';
+    if (url.endsWith('/auth/session') && method === 'GET') {
+      return createAuthSessionResponse(authBootstrapHarnessState.config);
+    }
+    return {
+      ok: false,
+      status: 500,
+      statusText: 'Unexpected',
+      json: async () => ({}),
+      text: async () => 'Unexpected request',
+    } as Response;
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+export function useStrictAuthBootstrapMode(overrides?: Partial<AuthBootstrapHarnessConfig>) {
+  window.localStorage.removeItem('session_token');
+  authBootstrapHarnessState.config = {
+    ...DEFAULT_AUTH_BOOTSTRAP_HARNESS,
+    ...overrides,
+  };
+}
+
+export function getAuthBootstrapFetchMock() {
+  return globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+}
+
 vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
     <a href={href} {...props}>
@@ -26,7 +88,9 @@ vi.mock('next/navigation', () => ({
 }));
 
 beforeEach(() => {
+  authBootstrapHarnessState.config = { ...DEFAULT_AUTH_BOOTSTRAP_HARNESS };
   window.localStorage.setItem('session_token', 'test-session-token');
+  installAuthBootstrapHarness();
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Linear
- KAR-98
- Requirement ID: REQ-RC-012

## Summary
- Consolidates auth bootstrap fetch mocking into a strict shared harness in web test setup.
- Updates app shell auth/bootstrap test suites to use the harness and remove ad-hoc duplicated mocks.

## Verification
- `pnpm --filter web test test/app-shell-auth-bootstrap.spec.tsx test/app-shell-responsive.spec.tsx test/app-shell.spec.tsx`
- `pnpm --filter web test`

## Notes
- Runtime behavior unchanged; this is deterministic test hardening only.
