### PR TITLE
[KAR-100] Release smoke runner for core operator workflows

### DIFF
--- a/docs/DEPLOYMENT_RUNBOOK.md
+++ b/docs/DEPLOYMENT_RUNBOOK.md
@@ -278,3 +278,56 @@ Rollback execution must follow Section 5 and conclude with readiness + smoke che
 - Security reviewer: confirms final security sweep completion.
 
 Go-live is approved only when all required evidence items are present and both engineering + operations owners mark `APPROVED` in the generated signoff file.
+
+## 12) Release Smoke Runner (REQ-RC-014 / KAR-100)
+
+Use a single command to execute the minimum release smoke path and generate a machine-readable artifact:
+
+```bash
+pnpm ops:release:smoke -- --api-base http://127.0.0.1:4000 --out artifacts/ops/release-smoke-summary.json
+```
+
+### 12.1 Workflow coverage
+
+The smoke runner executes this exact sequence:
+
+1. `login` (`POST /auth/login`) or validates a pre-supplied session token.
+2. `matter create` (`POST /matters`).
+3. `doc upload` (`POST /documents/upload`).
+4. `invoice create` (`POST /billing/time-entries`, then `POST /billing/invoices`).
+5. `portal message` (`POST /portal/messages`).
+6. `AI job create` (`POST /ai/jobs`).
+
+### 12.2 Prerequisites
+
+- API service is reachable and healthy at `--api-base` (defaults to `http://127.0.0.1:4000`).
+- A release smoke user exists with permissions for:
+  - `matters:write`
+  - `documents:write`
+  - `billing:write`
+  - `ai:write`
+- Credentials are provided by one of:
+  - `--email` and `--password`, or
+  - `--token` / `OPS_SMOKE_SESSION_TOKEN`.
+- The configured document storage, database, and queue dependencies are available so write flows can complete.
+
+### 12.3 Artifact and failure interpretation
+
+The command writes JSON to `artifacts/ops/release-smoke-summary.json` (or `--out`) with:
+
+- `steps[]`: per-step status (`passed`, `failed`, `skipped`), status code, and details.
+- `ids`: identifiers captured for created entities.
+- `summary`: passed/failed/skipped totals.
+- `healthy`: final release-smoke boolean.
+
+Interpretation guidance:
+
+- `healthy=true`: all required smoke actions completed.
+- `failed > 0`: release is blocked until the failing step is triaged and re-run.
+- `skipped > 0`: usually indicates an upstream failure (for example, matter creation failed so dependent steps were skipped).
+- Common root causes:
+  - `401/403`: session or permission misconfiguration.
+  - `422/400`: invalid request payload due to API contract drift.
+  - `5xx`: service dependency or deployment instability.
+
+For incident handling and rollback criteria, continue with Sections 5, 6, and 11.4.

--- a/docs/parity/release-smoke-runner-verification.md
+++ b/docs/parity/release-smoke-runner-verification.md
@@ -1,0 +1,42 @@
+# Release Smoke Runner Verification (REQ-RC-014 / KAR-100)
+
+## Scope
+
+- Deliver a single-command release smoke runner under `tools/ops/**`.
+- Cover core operator workflows:
+  - login
+  - matter create
+  - document upload
+  - invoice create
+  - portal message
+  - AI job create
+- Emit a machine-readable summary artifact for release evidence.
+- Document prerequisites and failure interpretation in the deployment runbook.
+
+## Implementation
+
+- Added `tools/ops/run_release_smoke.mjs`.
+- Added workspace command: `pnpm ops:release:smoke`.
+- Updated deployment runbook with usage, prerequisites, and failure interpretation.
+
+## Artifact Contract
+
+Default artifact path: `artifacts/ops/release-smoke-summary.json`.
+
+The artifact includes:
+
+- `requirementId`, `startedAt`, `completedAt`, `apiBase`
+- `healthy`
+- `summary` counts (`passed`, `failed`, `skipped`)
+- `steps[]` with per-step status and HTTP evidence
+- `ids` for created entities (`matterId`, `documentId`, `invoiceId`, `portalMessageId`, `aiJobId`)
+
+## Verification Commands
+
+```bash
+pnpm test
+pnpm build
+pnpm ops:release:smoke -- --api-base http://127.0.0.1:4000 --out artifacts/ops/release-smoke-summary.json
+```
+
+If the API is unavailable, the smoke command exits non-zero and writes a failed artifact with runner error context.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "rc1:lane:a:verify": "pnpm --filter api lint && pnpm --filter api test:core-workflow && pnpm --filter api test && pnpm --filter web test && pnpm build",
     "rc1:lane:b:verify": "pnpm --filter web test && pnpm --filter api test && pnpm build",
     "rc1:orchestrator:post-merge": "pnpm backlog:sync && pnpm backlog:verify && pnpm backlog:snapshot && pnpm backlog:handoff:refresh && pnpm backlog:handoff:check",
-    "docs:req-ui-009:check": "node tools/backlog-sync/check_req_ui_009_docs.mjs"
+    "docs:req-ui-009:check": "node tools/backlog-sync/check_req_ui_009_docs.mjs",
+    "ops:release:smoke": "node tools/ops/run_release_smoke.mjs"
   },
   "devDependencies": {
     "concurrently": "^9.1.2",

--- a/tools/ops/run_release_smoke.mjs
+++ b/tools/ops/run_release_smoke.mjs
@@ -1,0 +1,383 @@
+#!/usr/bin/env node
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const args = parseArgs({
+  allowPositionals: true,
+  options: {
+    'api-base': { type: 'string', default: process.env.API_BASE_URL || 'http://127.0.0.1:4000' },
+    email: { type: 'string', default: process.env.OPS_SMOKE_USER_EMAIL || 'admin@lic-demo.local' },
+    password: { type: 'string', default: process.env.OPS_SMOKE_USER_PASSWORD || 'ChangeMe123!' },
+    token: { type: 'string', default: process.env.OPS_SMOKE_SESSION_TOKEN || '' },
+    out: { type: 'string', default: 'artifacts/ops/release-smoke-summary.json' },
+    'wait-ms': { type: 'string', default: '60000' },
+  },
+});
+
+const apiBase = String(args.values['api-base']).replace(/\/+$/, '');
+const outPath = resolve(String(args.values.out));
+const email = String(args.values.email || '').trim();
+const password = String(args.values.password || '').trim();
+let sessionToken = String(args.values.token || '').trim();
+const waitMs = Number.parseInt(String(args.values['wait-ms'] || '60000'), 10);
+
+if (!Number.isFinite(waitMs) || waitMs <= 0) {
+  throw new Error(`Invalid --wait-ms value: ${args.values['wait-ms']}`);
+}
+
+const startedAt = new Date().toISOString();
+const runStamp = stamp();
+const result = {
+  requirementId: 'REQ-RC-014',
+  startedAt,
+  completedAt: null,
+  apiBase,
+  outPath,
+  healthy: false,
+  summary: {
+    totalSteps: 6,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+  },
+  authUser: null,
+  ids: {
+    matterId: null,
+    documentId: null,
+    documentVersionId: null,
+    invoiceId: null,
+    portalMessageId: null,
+    aiJobId: null,
+  },
+  steps: [],
+};
+
+try {
+  await waitForHealth(`${apiBase}/health`, waitMs);
+
+  if (!sessionToken) {
+    const loginOutcome = await postJson(`${apiBase}/auth/login`, { email, password });
+    if (!loginOutcome.ok) {
+      throw new Error(`Login failed (${loginOutcome.status}): ${clip(loginOutcome.text)}`);
+    }
+
+    const payload = safeParse(loginOutcome.text);
+    sessionToken = String(payload.token || '').trim();
+    result.authUser = payload.user || null;
+    if (!sessionToken) {
+      throw new Error('Login succeeded but token was missing in response payload.');
+    }
+
+    pushStep(result.steps, {
+      step: 'login',
+      status: 'passed',
+      statusCode: loginOutcome.status,
+      details: { userId: result.authUser?.id ?? null },
+    });
+  } else {
+    pushStep(result.steps, {
+      step: 'login',
+      status: 'passed',
+      statusCode: 200,
+      details: { tokenSource: 'pre-supplied' },
+    });
+  }
+
+  const matterOutcome = await postJson(
+    `${apiBase}/matters`,
+    {
+      name: `RC014 Smoke Matter ${runStamp}`,
+      matterNumber: `RC014-${runStamp}`,
+      practiceArea: 'General Civil Litigation',
+      jurisdiction: 'California',
+      venue: 'Orange County Superior Court',
+    },
+    sessionToken,
+  );
+  handleEntityStep(result, 'matter_create', matterOutcome, 'matterId');
+
+  const matterId = result.ids.matterId;
+
+  const uploadOutcome = matterId
+    ? await uploadDocument(apiBase, sessionToken, matterId, runStamp)
+    : { ok: false, status: null, text: 'Skipped because matter creation failed.', payload: null, skipped: true };
+  handleEntityStep(result, 'doc_upload', uploadOutcome, 'documentId', ({ payload }) => ({
+    documentVersionId: payload?.version?.id ?? null,
+  }));
+
+  const invoiceOutcome = matterId
+    ? await createInvoice(apiBase, sessionToken, matterId, runStamp)
+    : { ok: false, status: null, text: 'Skipped because matter creation failed.', payload: null, skipped: true };
+  handleEntityStep(result, 'invoice_create', invoiceOutcome, 'invoiceId');
+
+  const portalOutcome = matterId
+    ? await postJson(
+        `${apiBase}/portal/messages`,
+        {
+          matterId,
+          subject: `RC014 portal check ${runStamp}`,
+          body: 'Release smoke portal message.',
+        },
+        sessionToken,
+      )
+    : { ok: false, status: null, text: 'Skipped because matter creation failed.', payload: null, skipped: true };
+  handleEntityStep(result, 'portal_message', portalOutcome, 'portalMessageId');
+
+  const aiOutcome = matterId
+    ? await postJson(
+        `${apiBase}/ai/jobs`,
+        {
+          matterId,
+          toolName: 'timeline.extract',
+          input: {
+            source: 'release-smoke',
+            runStamp,
+            notes: 'Smoke validation job payload.',
+          },
+        },
+        sessionToken,
+      )
+    : { ok: false, status: null, text: 'Skipped because matter creation failed.', payload: null, skipped: true };
+  handleEntityStep(result, 'ai_job_create', aiOutcome, 'aiJobId');
+
+  finalizeSummary(result);
+  result.completedAt = new Date().toISOString();
+  result.healthy = result.summary.failed === 0;
+  writeArtifact(outPath, result);
+
+  if (!result.healthy) {
+    process.exitCode = 1;
+  }
+
+  console.log(`Release smoke summary written -> ${outPath}`);
+  console.log(JSON.stringify(result.summary));
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  pushStep(result.steps, {
+    step: 'runner_error',
+    status: 'failed',
+    statusCode: null,
+    details: { error: message },
+  });
+  finalizeSummary(result);
+  result.completedAt = new Date().toISOString();
+  result.healthy = false;
+  writeArtifact(outPath, result);
+  console.error(`Release smoke run failed: ${message}`);
+  process.exitCode = 1;
+}
+
+async function createInvoice(apiBaseValue, token, matterId, runStampValue) {
+  const now = new Date();
+  const start = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+  const end = now.toISOString();
+
+  const timeEntry = await postJson(
+    `${apiBaseValue}/billing/time-entries`,
+    {
+      matterId,
+      description: `RC014 smoke time entry ${runStampValue}`,
+      startedAt: start,
+      endedAt: end,
+      billableRate: 300,
+      utbmsPhaseCode: 'L100',
+      utbmsTaskCode: 'L110',
+    },
+    token,
+  );
+
+  if (!timeEntry.ok) {
+    return timeEntry;
+  }
+
+  const payload = safeParse(timeEntry.text);
+  const timeEntryId = payload.id;
+  if (!timeEntryId) {
+    return {
+      ok: false,
+      status: timeEntry.status,
+      text: `Time entry response missing id: ${clip(timeEntry.text)}`,
+      payload: null,
+    };
+  }
+
+  const invoice = await postJson(
+    `${apiBaseValue}/billing/invoices`,
+    {
+      matterId,
+      notes: `RC014 smoke invoice ${runStampValue}`,
+      lineItems: [
+        {
+          description: 'Release smoke billing line item',
+          quantity: 1,
+          unitPrice: 300,
+          timeEntryId,
+          utbmsPhaseCode: 'L100',
+          utbmsTaskCode: 'L110',
+        },
+      ],
+    },
+    token,
+  );
+
+  return invoice;
+}
+
+async function uploadDocument(apiBaseValue, token, matterId, runStampValue) {
+  const form = new FormData();
+  form.set('matterId', matterId);
+  form.set('title', `RC014 Smoke Document ${runStampValue}`);
+  form.set('category', 'GENERAL');
+  form.set('tags', 'release-smoke,rc014');
+  form.set('file', new Blob(['release-smoke-content'], { type: 'text/plain' }), `rc014-smoke-${runStampValue}.txt`);
+
+  const response = await fetch(`${apiBaseValue}/documents/upload`, {
+    method: 'POST',
+    headers: {
+      'x-session-token': token,
+    },
+    body: form,
+  });
+  const text = await response.text();
+  return {
+    ok: response.ok,
+    status: response.status,
+    text,
+    payload: safeParse(text),
+  };
+}
+
+function handleEntityStep(resultValue, name, outcome, idKey, extraFn) {
+  if (outcome.skipped) {
+    pushStep(resultValue.steps, {
+      step: name,
+      status: 'skipped',
+      statusCode: null,
+      details: { reason: outcome.text },
+    });
+    return;
+  }
+
+  if (!outcome.ok) {
+    pushStep(resultValue.steps, {
+      step: name,
+      status: 'failed',
+      statusCode: outcome.status,
+      details: { error: clip(outcome.text) },
+    });
+    return;
+  }
+
+  const payload = outcome.payload ?? safeParse(outcome.text);
+  const id = payload?.id ?? payload?.document?.id ?? payload?.message?.id ?? payload?.job?.id ?? null;
+
+  resultValue.ids[idKey] = id;
+  if (extraFn) {
+    Object.assign(resultValue.ids, extraFn({ payload }));
+  }
+
+  pushStep(resultValue.steps, {
+    step: name,
+    status: id ? 'passed' : 'failed',
+    statusCode: outcome.status,
+    details: id ? { [idKey]: id } : { error: `Missing identifier in response: ${clip(outcome.text)}` },
+  });
+}
+
+function pushStep(steps, step) {
+  steps.push({
+    at: new Date().toISOString(),
+    ...step,
+  });
+}
+
+function finalizeSummary(resultValue) {
+  const summary = {
+    totalSteps: resultValue.steps.filter((step) => step.step !== 'runner_error').length,
+    passed: 0,
+    failed: 0,
+    skipped: 0,
+  };
+
+  for (const step of resultValue.steps) {
+    if (step.status === 'passed') summary.passed += 1;
+    if (step.status === 'failed') summary.failed += 1;
+    if (step.status === 'skipped') summary.skipped += 1;
+  }
+
+  resultValue.summary = summary;
+}
+
+async function postJson(url, payload, token) {
+  const headers = {
+    'content-type': 'application/json',
+  };
+  if (token) {
+    headers['x-session-token'] = token;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+  const text = await response.text();
+  return {
+    ok: response.ok,
+    status: response.status,
+    text,
+    payload: safeParse(text),
+  };
+}
+
+async function waitForHealth(url, timeoutMs) {
+  const started = Date.now();
+  let lastError = null;
+
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+      lastError = `Health check returned ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(1000);
+  }
+
+  throw new Error(`Timed out waiting for API health endpoint ${url}. Last error: ${lastError || 'unknown'}`);
+}
+
+function safeParse(text) {
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function writeArtifact(path, value) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value, null, 2));
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
+}
+
+function clip(value) {
+  const text = String(value || '').trim();
+  if (text.length <= 2000) {
+    return text;
+  }
+  return `${text.slice(0, 2000)}...<truncated>`;
+}


### PR DESCRIPTION
## Linear
- KAR-100
- Requirement ID: REQ-RC-014

## Summary
- Adds `tools/ops/run_release_smoke.mjs` and root script `pnpm ops:release:smoke`.
- Implements smoke flow coverage for login, matter create, document upload, invoice create, portal message, and AI job create with JSON artifact output.
- Documents usage, prerequisites, and failure interpretation in deployment runbook plus parity verification doc.

## Verification
- `node tools/ops/run_release_smoke.mjs --api-base http://127.0.0.1:9 --wait-ms 1000 --out /tmp/rc014-smoke-test.json`
- `pnpm test`
- `pnpm build`

## Notes
- Failure artifact path behavior is validated even when API is unavailable.
