### PR TITLE
[KAR-101] Launch blockers API and admin dashboard card

### DIFF
--- a/apps/api/src/ops/ops.controller.ts
+++ b/apps/api/src/ops/ops.controller.ts
@@ -20,4 +20,10 @@ export class OpsController {
   alertBaseline() {
     return this.opsService.alertBaseline();
   }
+
+  @Get('launch-blockers')
+  @RequirePermissions('organizations:read')
+  launchBlockers() {
+    return this.opsService.launchBlockers();
+  }
 }

--- a/apps/api/src/ops/ops.service.ts
+++ b/apps/api/src/ops/ops.service.ts
@@ -18,6 +18,18 @@ type ProviderStatusRow = {
   missingEnv?: string[];
 };
 
+type LaunchBlockerSeverity = 'critical' | 'warning';
+
+type LaunchBlocker = {
+  key: 'provider_readiness' | 'webhook_retries' | 'queue_backlog' | 'backup_restore_freshness';
+  title: string;
+  severity: LaunchBlockerSeverity;
+  status: 'blocked' | 'warning';
+  observedAt: string;
+  summary: string;
+  runbookUrl: string;
+};
+
 @Injectable()
 export class OpsService {
   constructor(
@@ -61,6 +73,91 @@ export class OpsService {
           providerUnhealthyCount,
         },
       }),
+    };
+  }
+
+  async launchBlockers() {
+    const now = new Date();
+    const providerStatus = this.providerStatus();
+    const blockers: LaunchBlocker[] = [];
+
+    const criticalProviderFailures = providerStatus.providers.filter((provider) => provider.critical && !provider.healthy);
+    if (criticalProviderFailures.length > 0) {
+      blockers.push({
+        key: 'provider_readiness',
+        title: 'Provider readiness',
+        severity: 'critical',
+        status: 'blocked',
+        observedAt: providerStatus.evaluatedAt,
+        summary: `${criticalProviderFailures.length} critical provider checks failing (${criticalProviderFailures
+          .map((provider) => provider.key)
+          .join(', ')})`,
+        runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#4-startup-readiness-checks',
+      });
+    }
+
+    const webhookRetryThreshold = this.readInt('OPS_LAUNCH_BLOCKER_WEBHOOK_RETRY_THRESHOLD', 5, 1, 10_000);
+    const queueBacklogThreshold = this.readInt('OPS_LAUNCH_BLOCKER_QUEUE_BACKLOG_THRESHOLD', 20, 1, 100_000);
+    const backupFreshnessHours = this.readInt('OPS_LAUNCH_BLOCKER_BACKUP_FRESHNESS_HOURS', 24, 1, 24 * 30);
+
+    const [retryingDeliveries, queuedJobs, oldestQueuedJob, latestBackupJob] = await Promise.all([
+      this.prisma?.webhookDelivery.count({ where: { status: 'RETRYING' } }) || Promise.resolve(0),
+      this.prisma?.aiJob.count({ where: { status: 'QUEUED' } }) || Promise.resolve(0),
+      this.prisma?.aiJob.findFirst({ where: { status: 'QUEUED' }, orderBy: { createdAt: 'asc' }, select: { createdAt: true } }) ||
+        Promise.resolve(null),
+      this.prisma?.exportJob.findFirst({
+        where: { exportType: 'full_backup', status: 'COMPLETED' },
+        orderBy: { finishedAt: 'desc' },
+        select: { finishedAt: true, createdAt: true },
+      }) || Promise.resolve(null),
+    ]);
+
+    if (retryingDeliveries >= webhookRetryThreshold) {
+      blockers.push({
+        key: 'webhook_retries',
+        title: 'Webhook retries',
+        severity: 'warning',
+        status: 'warning',
+        observedAt: now.toISOString(),
+        summary: `${retryingDeliveries} deliveries currently retrying (threshold ${webhookRetryThreshold})`,
+        runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#6-incident-response',
+      });
+    }
+
+    if (queuedJobs >= queueBacklogThreshold) {
+      blockers.push({
+        key: 'queue_backlog',
+        title: 'Queue backlog',
+        severity: 'warning',
+        status: 'warning',
+        observedAt: oldestQueuedJob?.createdAt?.toISOString() || now.toISOString(),
+        summary: `${queuedJobs} queued AI jobs (threshold ${queueBacklogThreshold})`,
+        runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#7-baseline-slos-and-metrics',
+      });
+    }
+
+    const latestBackupAt = latestBackupJob?.finishedAt || latestBackupJob?.createdAt;
+    const backupAgeMs = latestBackupAt ? now.getTime() - latestBackupAt.getTime() : Number.POSITIVE_INFINITY;
+    const backupAgeHours = backupAgeMs / 3_600_000;
+
+    if (!Number.isFinite(backupAgeHours) || backupAgeHours > backupFreshnessHours) {
+      blockers.push({
+        key: 'backup_restore_freshness',
+        title: 'Backup/restore freshness',
+        severity: 'critical',
+        status: 'blocked',
+        observedAt: latestBackupAt?.toISOString() || now.toISOString(),
+        summary: latestBackupAt
+          ? `Most recent completed full backup is ${backupAgeHours.toFixed(1)}h old (max ${backupFreshnessHours}h)`
+          : 'No completed full backup found for backup/restore verification',
+        runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#5-rollback-procedure',
+      });
+    }
+
+    return {
+      evaluatedAt: now.toISOString(),
+      healthy: blockers.length === 0,
+      blockers,
     };
   }
 

--- a/apps/api/test/ops-launch-blockers.spec.ts
+++ b/apps/api/test/ops-launch-blockers.spec.ts
@@ -1,0 +1,104 @@
+import { OpsService } from '../src/ops/ops.service';
+
+describe('OpsService launch blockers', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('aggregates unresolved launch blockers with severity and runbooks', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.MESSAGE_EMAIL_PROVIDER = 'stub';
+    process.env.MESSAGE_SMS_PROVIDER = 'twilio';
+    process.env.TWILIO_ACCOUNT_SID = 'AC123';
+    process.env.TWILIO_AUTH_TOKEN = 'token';
+    process.env.TWILIO_FROM_PHONE = '+15555550123';
+    process.env.MALWARE_SCANNER_PROVIDER = 'clamav';
+    process.env.CLAMAV_HOST = 'clamav.internal';
+    process.env.MALWARE_SCANNER_FAIL_OPEN = 'false';
+    process.env.ESIGN_PROVIDER = 'sandbox';
+    process.env.ESIGN_SANDBOX_WEBHOOK_SECRET = 'esign_whsec';
+    process.env.CLIO_LIVE_OAUTH = 'true';
+    process.env.CLIO_CLIENT_ID = 'clio_client';
+    process.env.CLIO_CLIENT_SECRET = 'clio_secret';
+    process.env.MYCASE_LIVE_OAUTH = 'true';
+    process.env.MYCASE_CLIENT_ID = 'mycase_client';
+    process.env.MYCASE_CLIENT_SECRET = 'mycase_secret';
+    process.env.STRIPE_SECRET_KEY = 'sk_live';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_live';
+
+    const prisma = {
+      webhookDelivery: {
+        count: jest.fn().mockResolvedValue(9),
+      },
+      aiJob: {
+        count: jest.fn().mockResolvedValue(31),
+        findFirst: jest.fn().mockResolvedValue({ createdAt: new Date('2026-02-20T10:00:00.000Z') }),
+      },
+      exportJob: {
+        findFirst: jest.fn().mockResolvedValue({
+          createdAt: new Date('2026-02-18T09:00:00.000Z'),
+          finishedAt: new Date('2026-02-18T09:10:00.000Z'),
+        }),
+      },
+    };
+
+    const service = new OpsService(prisma as never);
+    const snapshot = await service.launchBlockers();
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.blockers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'provider_readiness',
+          severity: 'critical',
+          status: 'blocked',
+          runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#4-startup-readiness-checks',
+        }),
+        expect.objectContaining({
+          key: 'webhook_retries',
+          severity: 'warning',
+          status: 'warning',
+          runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#6-incident-response',
+        }),
+        expect.objectContaining({
+          key: 'queue_backlog',
+          severity: 'warning',
+          status: 'warning',
+          runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#7-baseline-slos-and-metrics',
+        }),
+        expect.objectContaining({
+          key: 'backup_restore_freshness',
+          severity: 'critical',
+          status: 'blocked',
+          runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#5-rollback-procedure',
+        }),
+      ]),
+    );
+  });
+
+  it('reports healthy when no blocker thresholds are exceeded', async () => {
+    process.env.NODE_ENV = 'development';
+
+    const now = new Date();
+    const prisma = {
+      webhookDelivery: {
+        count: jest.fn().mockResolvedValue(0),
+      },
+      aiJob: {
+        count: jest.fn().mockResolvedValue(0),
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      exportJob: {
+        findFirst: jest.fn().mockResolvedValue({ createdAt: now, finishedAt: now }),
+      },
+    };
+
+    const service = new OpsService(prisma as never);
+    const snapshot = await service.launchBlockers();
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.blockers).toEqual([]);
+  });
+});

--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -46,6 +46,23 @@ type ProviderStatusSnapshot = {
   providers: ProviderStatusRow[];
 };
 
+
+type LaunchBlocker = {
+  key: string;
+  title: string;
+  severity: 'critical' | 'warning';
+  status: 'blocked' | 'warning';
+  observedAt: string;
+  summary: string;
+  runbookUrl: string;
+};
+
+type LaunchBlockersSnapshot = {
+  evaluatedAt: string;
+  healthy: boolean;
+  blockers: LaunchBlocker[];
+};
+
 export default function AdminPage() {
   const [org, setOrg] = useState<{ name: string; slug: string } | null>(null);
   const [users, setUsers] = useState<Array<{ id: string; user: { email: string }; role?: { name: string } }>>([]);
@@ -92,6 +109,8 @@ export default function AdminPage() {
   const [retryingDeliveryId, setRetryingDeliveryId] = useState<string | null>(null);
   const [providerStatus, setProviderStatus] = useState<ProviderStatusSnapshot | null>(null);
   const [providerStatusError, setProviderStatusError] = useState<string | null>(null);
+  const [launchBlockers, setLaunchBlockers] = useState<LaunchBlockersSnapshot | null>(null);
+  const [launchBlockersError, setLaunchBlockersError] = useState<string | null>(null);
 
   useEffect(() => {
     Promise.all([
@@ -149,6 +168,15 @@ export default function AdminPage() {
       })
       .catch(() => {
         setProviderStatusError('Provider diagnostics unavailable.');
+      });
+
+    apiFetch<LaunchBlockersSnapshot>('/ops/launch-blockers')
+      .then((snapshot) => {
+        setLaunchBlockers(snapshot);
+        setLaunchBlockersError(null);
+      })
+      .catch(() => {
+        setLaunchBlockersError('Launch blocker diagnostics unavailable.');
       });
   }, []);
 
@@ -607,6 +635,58 @@ export default function AdminPage() {
             <p style={{ color: 'var(--lic-text-muted)', marginTop: 0 }}>{providerStatusError || 'Loading provider diagnostics...'}</p>
           )}
         </div>
+
+        <div className="card" style={{ gridColumn: '1 / -1' }}>
+          <h3 style={{ marginTop: 0 }}>Production Launch Blockers</h3>
+          {launchBlockers ? (
+            <>
+              <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginBottom: 12 }}>
+                <span className="badge">{launchBlockers.healthy ? 'CLEAR' : 'ACTION REQUIRED'}</span>
+                <span style={{ color: 'var(--lic-text-muted)' }}>
+                  Evaluated: {new Date(launchBlockers.evaluatedAt).toLocaleString()}
+                </span>
+              </div>
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Blocker</th>
+                    <th>Severity</th>
+                    <th>Status</th>
+                    <th>Observed</th>
+                    <th>Summary</th>
+                    <th>Runbook</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {launchBlockers.blockers.map((blocker) => (
+                    <tr key={blocker.key}>
+                      <td>{blocker.title}</td>
+                      <td>{blocker.severity.toUpperCase()}</td>
+                      <td>{blocker.status.toUpperCase()}</td>
+                      <td>{new Date(blocker.observedAt).toLocaleString()}</td>
+                      <td>{blocker.summary}</td>
+                      <td>
+                        <a href={blocker.runbookUrl} target="_blank" rel="noreferrer">
+                          Open runbook
+                        </a>
+                      </td>
+                    </tr>
+                  ))}
+                  {launchBlockers.blockers.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} style={{ color: 'var(--lic-text-muted)' }}>
+                        No unresolved launch blockers.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </>
+          ) : (
+            <p style={{ color: 'var(--lic-text-muted)', marginTop: 0 }}>{launchBlockersError || 'Loading launch blockers...'}</p>
+          )}
+        </div>
+
 
         <div className="card" style={{ gridColumn: '1 / -1' }}>
           <h3 style={{ marginTop: 0 }}>Webhook Delivery Monitor</h3>

--- a/apps/web/test/admin-page.spec.tsx
+++ b/apps/web/test/admin-page.spec.tsx
@@ -87,6 +87,23 @@ describe('AdminPage webhook delivery monitor', () => {
       ],
     };
 
+
+    const launchBlockers = {
+      evaluatedAt: '2026-02-26T18:30:00.000Z',
+      healthy: false,
+      blockers: [
+        {
+          key: 'provider_readiness',
+          title: 'Provider readiness',
+          severity: 'critical',
+          status: 'blocked',
+          observedAt: '2026-02-26T18:30:00.000Z',
+          summary: '1 critical provider checks failing (email)',
+          runbookUrl: '/docs/DEPLOYMENT_RUNBOOK.md#4-startup-readiness-checks',
+        },
+      ],
+    };
+
     const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       const method = init?.method || 'GET';
@@ -102,6 +119,7 @@ describe('AdminPage webhook delivery monitor', () => {
       if (url.endsWith('/admin/conflict-rule-profiles')) return jsonResponse([]);
       if (url.endsWith('/admin/conflict-checks?limit=15')) return jsonResponse([]);
       if (url.endsWith('/ops/provider-status')) return jsonResponse(providerStatus);
+      if (url.endsWith('/ops/launch-blockers')) return jsonResponse(launchBlockers);
       if (url.endsWith('/webhooks/endpoints')) return jsonResponse(endpoints);
 
       if (url.includes('/webhooks/deliveries?') && method === 'GET') {
@@ -131,6 +149,13 @@ describe('AdminPage webhook delivery monitor', () => {
     expect(await screen.findByText('Provider Readiness')).toBeInTheDocument();
     expect(screen.getByText('Profile: STAGING')).toBeInTheDocument();
     expect(screen.getByText('Critical provider cannot run in stub mode for production-like profiles')).toBeInTheDocument();
+    expect(screen.getByText('Production Launch Blockers')).toBeInTheDocument();
+    expect(screen.getByText('Provider readiness')).toBeInTheDocument();
+    expect(screen.getByText('ACTION REQUIRED')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open runbook' })).toHaveAttribute(
+      'href',
+      '/docs/DEPLOYMENT_RUNBOOK.md#4-startup-readiness-checks',
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
 


### PR DESCRIPTION
## Linear
- KAR-101
- Requirement ID: REQ-RC-015

## Summary
- Adds `GET /ops/launch-blockers` endpoint aggregating unresolved launch blockers with severity/status/runbook links.
- Introduces API coverage for healthy/unhealthy blocker snapshots.
- Adds admin page panel to display launch blockers and runbook actions.

## Verification
- `pnpm --filter api test apps/api/test/ops-launch-blockers.spec.ts`
- `pnpm --filter web test test/admin-page.spec.tsx`
- `pnpm test`
- `pnpm build`

## Notes
- Existing admin diagnostics behavior is preserved; launch blockers are additive.
