### PR TITLE
feat(api): add analyst insight reporting APIs and CSV export

### DIFF
--- a/apps/api/src/reporting/reporting.controller.ts
+++ b/apps/api/src/reporting/reporting.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Query, Res, UseGuards } from '@nestjs/common';
 import { Response } from 'express';
 import { ReportingService } from './reporting.service';
 import { SessionAuthGuard } from '../common/guards/session-auth.guard';
@@ -11,6 +11,15 @@ import { AuthenticatedUser } from '../common/types';
 @UseGuards(SessionAuthGuard, PermissionGuard)
 export class ReportingController {
   constructor(private readonly reportingService: ReportingService) {}
+
+  private async getAnalystRows(
+    organizationId: string,
+    report: 'bottlenecks' | 'capacity' | 'growth',
+  ): Promise<object[]> {
+    if (report === 'bottlenecks') return this.reportingService.bottlenecks(organizationId);
+    if (report === 'capacity') return this.reportingService.capacity(organizationId);
+    return this.reportingService.growth(organizationId);
+  }
 
   @Get('matters-by-stage')
   @RequirePermissions('reporting:read')
@@ -52,6 +61,47 @@ export class ReportingController {
     const csv = this.reportingService.toCsv(rows);
     res.setHeader('content-type', 'text/csv');
     res.setHeader('content-disposition', `attachment; filename="${report}.csv"`);
+    res.send(csv);
+  }
+
+  @Get('analyst/bottlenecks')
+  @RequirePermissions('reporting:read')
+  analystBottlenecks(@CurrentUser() user: AuthenticatedUser) {
+    return this.reportingService.bottlenecks(user.organizationId);
+  }
+
+  @Get('analyst/capacity')
+  @RequirePermissions('reporting:read')
+  analystCapacity(@CurrentUser() user: AuthenticatedUser) {
+    return this.reportingService.capacity(user.organizationId);
+  }
+
+  @Get('analyst/growth')
+  @RequirePermissions('reporting:read')
+  analystGrowth(@CurrentUser() user: AuthenticatedUser) {
+    return this.reportingService.growth(user.organizationId);
+  }
+
+  @Get('analyst/csv')
+  @RequirePermissions('reporting:read')
+  async analystCsv(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query('report') report: string,
+    @Res() res: Response,
+  ) {
+    if (report !== 'bottlenecks' && report !== 'capacity' && report !== 'growth') {
+      throw new BadRequestException('report must be one of: bottlenecks, capacity, growth');
+    }
+
+    const columns: Record<'bottlenecks' | 'capacity' | 'growth', string[]> = {
+      bottlenecks: ['matterId', 'matterName', 'stageName', 'overdueTaskCount', 'openTaskCount'],
+      capacity: ['userId', 'userName', 'userEmail', 'openTaskCount', 'billedMinutes', 'billedAmount'],
+      growth: ['month', 'mattersOpened', 'cumulativeMatters'],
+    };
+    const rows = await this.getAnalystRows(user.organizationId, report);
+    const csv = this.reportingService.toCsv(rows, columns[report]);
+    res.setHeader('content-type', 'text/csv');
+    res.setHeader('content-disposition', `attachment; filename="analyst-${report}.csv"`);
     res.send(csv);
   }
 }

--- a/apps/api/src/reporting/reporting.service.ts
+++ b/apps/api/src/reporting/reporting.service.ts
@@ -6,6 +6,118 @@ import { PrismaService } from '../prisma/prisma.service';
 export class ReportingService {
   constructor(private readonly prisma: PrismaService) {}
 
+  async bottlenecks(organizationId: string) {
+    const now = new Date();
+    const [overdueByMatter, openByMatter] = await Promise.all([
+      this.prisma.task.groupBy({
+        by: ['matterId'],
+        where: {
+          organizationId,
+          dueAt: { lt: now },
+          status: { not: 'DONE' },
+        },
+        _count: { matterId: true },
+      }),
+      this.prisma.task.groupBy({
+        by: ['matterId'],
+        where: {
+          organizationId,
+          status: { not: 'DONE' },
+        },
+        _count: { matterId: true },
+      }),
+    ]);
+
+    const matterIds = Array.from(new Set([...overdueByMatter.map((row) => row.matterId), ...openByMatter.map((row) => row.matterId)]));
+    const matters =
+      matterIds.length === 0
+        ? []
+        : await this.prisma.matter.findMany({
+            where: { organizationId, id: { in: matterIds } },
+            include: { stage: true },
+          });
+
+    const overdueMap = new Map(overdueByMatter.map((row) => [row.matterId, row._count.matterId]));
+    const openMap = new Map(openByMatter.map((row) => [row.matterId, row._count.matterId]));
+
+    return matters
+      .map((matter) => ({
+        matterId: matter.id,
+        matterName: matter.name,
+        stageName: matter.stage?.name ?? 'Unassigned',
+        overdueTaskCount: overdueMap.get(matter.id) ?? 0,
+        openTaskCount: openMap.get(matter.id) ?? 0,
+      }))
+      .sort((a, b) => b.overdueTaskCount - a.overdueTaskCount || b.openTaskCount - a.openTaskCount || a.matterId.localeCompare(b.matterId));
+  }
+
+  async capacity(organizationId: string) {
+    const [tasksByAssignee, timeByAssignee, memberships] = await Promise.all([
+      this.prisma.task.groupBy({
+        by: ['assigneeUserId'],
+        where: {
+          organizationId,
+          status: { not: 'DONE' },
+        },
+        _count: { assigneeUserId: true },
+      }),
+      this.prisma.timeEntry.groupBy({
+        by: ['userId'],
+        where: { organizationId },
+        _sum: {
+          durationMinutes: true,
+          amount: true,
+        },
+      }),
+      this.prisma.membership.findMany({
+        where: { organizationId },
+        select: { user: { select: { id: true, fullName: true, email: true } } },
+      }),
+    ]);
+
+    const taskCountByAssignee = new Map(tasksByAssignee.map((row) => [row.assigneeUserId ?? null, row._count.assigneeUserId]));
+    const timeByUser = new Map(
+      timeByAssignee.map((row) => [row.userId ?? null, { billedMinutes: row._sum.durationMinutes ?? 0, billedAmount: row._sum.amount ?? 0 }]),
+    );
+
+    return memberships
+      .map(({ user }) => ({
+        userId: user.id,
+        userName: user.fullName ?? user.email,
+        userEmail: user.email,
+        openTaskCount: taskCountByAssignee.get(user.id) ?? 0,
+        billedMinutes: timeByUser.get(user.id)?.billedMinutes ?? 0,
+        billedAmount: timeByUser.get(user.id)?.billedAmount ?? 0,
+      }))
+      .sort((a, b) => b.openTaskCount - a.openTaskCount || b.billedMinutes - a.billedMinutes || a.userId.localeCompare(b.userId));
+  }
+
+  async growth(organizationId: string) {
+    const matters = await this.prisma.matter.findMany({
+      where: { organizationId },
+      select: { openedAt: true },
+      orderBy: { openedAt: 'asc' },
+    });
+
+    const monthlyCount = new Map<string, number>();
+    for (const matter of matters) {
+      const month = matter.openedAt.toISOString().slice(0, 7);
+      monthlyCount.set(month, (monthlyCount.get(month) ?? 0) + 1);
+    }
+
+    let cumulativeMatters = 0;
+    return Array.from(monthlyCount.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([month, mattersOpened]) => {
+        cumulativeMatters += mattersOpened;
+        return {
+          month,
+          mattersOpened,
+          cumulativeMatters,
+        };
+      });
+  }
+
   async mattersByStage(organizationId: string) {
     const rows = await this.prisma.matter.groupBy({
       by: ['stageId'],
@@ -74,11 +186,12 @@ export class ReportingService {
     });
   }
 
-  toCsv(rows: object[]): string {
+  toCsv(rows: object[], columns?: string[]): string {
     if (rows.length === 0) return '';
+    const csvColumns = columns ?? Object.keys(rows[0]);
     return stringify(rows, {
       header: true,
-      columns: Object.keys(rows[0]),
+      columns: csvColumns,
       cast: {
         object: (value) => JSON.stringify(value),
       },

--- a/apps/api/test/reporting-analyst.spec.ts
+++ b/apps/api/test/reporting-analyst.spec.ts
@@ -1,0 +1,180 @@
+import { BadRequestException } from '@nestjs/common';
+import { ReportingController } from '../src/reporting/reporting.controller';
+import { ReportingService } from '../src/reporting/reporting.service';
+
+describe('Reporting analyst APIs', () => {
+  describe('ReportingService analyst datasets', () => {
+    it('returns bottlenecks shape and enforces organization scope in prisma queries', async () => {
+      const prisma = {
+        task: {
+          groupBy: jest
+            .fn()
+            .mockResolvedValueOnce([{ matterId: 'matter-1', _count: { matterId: 2 } }])
+            .mockResolvedValueOnce([
+              { matterId: 'matter-1', _count: { matterId: 4 } },
+              { matterId: 'matter-2', _count: { matterId: 1 } },
+            ]),
+        },
+        matter: {
+          findMany: jest.fn().mockResolvedValue([
+            { id: 'matter-2', name: 'Matter Two', stage: null },
+            { id: 'matter-1', name: 'Matter One', stage: { name: 'Discovery' } },
+          ]),
+        },
+      } as any;
+
+      const service = new ReportingService(prisma);
+      const rows = await service.bottlenecks('org-a');
+
+      expect(prisma.task.groupBy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ where: expect.objectContaining({ organizationId: 'org-a' }) }),
+      );
+      expect(prisma.task.groupBy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ where: expect.objectContaining({ organizationId: 'org-a' }) }),
+      );
+      expect(prisma.matter.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ organizationId: 'org-a' }) }),
+      );
+      expect(rows).toEqual([
+        {
+          matterId: 'matter-1',
+          matterName: 'Matter One',
+          stageName: 'Discovery',
+          overdueTaskCount: 2,
+          openTaskCount: 4,
+        },
+        {
+          matterId: 'matter-2',
+          matterName: 'Matter Two',
+          stageName: 'Unassigned',
+          overdueTaskCount: 0,
+          openTaskCount: 1,
+        },
+      ]);
+    });
+
+    it('returns capacity shape and scoped aggregation by organization', async () => {
+      const prisma = {
+        task: {
+          groupBy: jest
+            .fn()
+            .mockResolvedValue([{ assigneeUserId: 'user-2', _count: { assigneeUserId: 3 } }]),
+        },
+        timeEntry: {
+          groupBy: jest.fn().mockResolvedValue([
+            { userId: 'user-1', _sum: { durationMinutes: 60, amount: 100 } },
+            { userId: 'user-2', _sum: { durationMinutes: 30, amount: 50 } },
+          ]),
+        },
+        membership: {
+          findMany: jest.fn().mockResolvedValue([
+            { user: { id: 'user-1', fullName: 'A User', email: 'a@example.com' } },
+            { user: { id: 'user-2', fullName: 'B User', email: 'b@example.com' } },
+          ]),
+        },
+      } as any;
+
+      const service = new ReportingService(prisma);
+      const rows = await service.capacity('org-b');
+
+      expect(prisma.task.groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ organizationId: 'org-b' }) }),
+      );
+      expect(prisma.timeEntry.groupBy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ organizationId: 'org-b' }) }),
+      );
+      expect(prisma.membership.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { organizationId: 'org-b' } }),
+      );
+      expect(rows).toEqual([
+        {
+          userId: 'user-2',
+          userName: 'B User',
+          userEmail: 'b@example.com',
+          openTaskCount: 3,
+          billedMinutes: 30,
+          billedAmount: 50,
+        },
+        {
+          userId: 'user-1',
+          userName: 'A User',
+          userEmail: 'a@example.com',
+          openTaskCount: 0,
+          billedMinutes: 60,
+          billedAmount: 100,
+        },
+      ]);
+    });
+
+    it('returns growth dataset in ascending month order', async () => {
+      const prisma = {
+        matter: {
+          findMany: jest.fn().mockResolvedValue([
+            { openedAt: new Date('2026-01-12T00:00:00.000Z') },
+            { openedAt: new Date('2026-01-20T00:00:00.000Z') },
+            { openedAt: new Date('2026-02-05T00:00:00.000Z') },
+          ]),
+        },
+      } as any;
+
+      const service = new ReportingService(prisma);
+      const rows = await service.growth('org-c');
+
+      expect(prisma.matter.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { organizationId: 'org-c' } }),
+      );
+      expect(rows).toEqual([
+        { month: '2026-01', mattersOpened: 2, cumulativeMatters: 2 },
+        { month: '2026-02', mattersOpened: 1, cumulativeMatters: 3 },
+      ]);
+    });
+  });
+
+  describe('ReportingController analyst CSV', () => {
+    it('uses tenant-scoped analyst report and returns deterministic CSV columns + content', async () => {
+      const service = {
+        bottlenecks: jest.fn().mockResolvedValue([
+          {
+            matterId: 'matter-1',
+            matterName: 'Matter One',
+            stageName: 'Discovery',
+            overdueTaskCount: 2,
+            openTaskCount: 4,
+          },
+        ]),
+        capacity: jest.fn(),
+        growth: jest.fn(),
+        toCsv: jest.fn().mockReturnValue('matterId,matterName,stageName,overdueTaskCount,openTaskCount\nmatter-1,Matter One,Discovery,2,4\n'),
+      } as any;
+      const controller = new ReportingController(service);
+
+      const res = {
+        setHeader: jest.fn(),
+        send: jest.fn(),
+      } as any;
+
+      await controller.analystCsv({ organizationId: 'org-csv' } as any, 'bottlenecks', res);
+
+      expect(service.bottlenecks).toHaveBeenCalledWith('org-csv');
+      expect(service.toCsv).toHaveBeenCalledWith(
+        expect.any(Array),
+        ['matterId', 'matterName', 'stageName', 'overdueTaskCount', 'openTaskCount'],
+      );
+      expect(res.setHeader).toHaveBeenCalledWith('content-type', 'text/csv');
+      expect(res.setHeader).toHaveBeenCalledWith('content-disposition', 'attachment; filename="analyst-bottlenecks.csv"');
+      expect(res.send).toHaveBeenCalledWith(
+        'matterId,matterName,stageName,overdueTaskCount,openTaskCount\nmatter-1,Matter One,Discovery,2,4\n',
+      );
+    });
+
+    it('rejects analyst CSV requests with an unsupported report value', async () => {
+      const controller = new ReportingController({} as ReportingService);
+
+      await expect(
+        controller.analystCsv({ organizationId: 'org-x' } as any, 'invalid', { setHeader: jest.fn(), send: jest.fn() } as any),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide analyst-facing reporting endpoints and a deterministic CSV export for bottlenecks, capacity, and growth while keeping tenant scoping strict.
- Make CSV output testable and stable by controlling header ordering and preserving backward compatibility of existing reporting CSV functionality.

### Description
- Added analyst endpoints under `/reporting/analyst`: `GET /reporting/analyst/bottlenecks`, `GET /reporting/analyst/capacity`, `GET /reporting/analyst/growth`, and `GET /reporting/analyst/csv?report=bottlenecks|capacity|growth` with validation for the `report` parameter and strict `CurrentUser.organizationId` scoping.
- Implemented `ReportingService` methods `bottlenecks`, `capacity`, and `growth` using organization-scoped Prisma queries and deterministic sorting, and extended `toCsv(rows, columns?)` to accept explicit columns for deterministic CSV headers.
- Added unit tests in `apps/api/test/reporting-analyst.spec.ts` to validate response shapes, tenant isolation, deterministic CSV headers/content, and invalid `report` handling.
- Files changed: `apps/api/src/reporting/reporting.controller.ts`, `apps/api/src/reporting/reporting.service.ts`, `apps/api/test/reporting-analyst.spec.ts`; Branch: `work` (requested branch not present locally); Commit: `99d4970ca9ecf93eb3d81a0cf95db12db66ec13b`; Requirement IDs: `KAR-114`, `REQ-EVE2-010`.

### Testing
- Ran linter with `pnpm --filter api lint` — passed.
- Ran focused tests with `pnpm --filter api test -- reporting-analyst.spec.ts` — passed (5 tests).
- Ran full API test suite with `pnpm --filter api test` — passed (62 test suites, 301 tests passed).
- Built API with `pnpm --filter api build` — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1a35ed3108325a23a270e55779e26)