### PR TITLE
KAR-110: Auditor operations queue UI with review drawer and actions

### DIFF
--- a/apps/web/app/auditor/page.tsx
+++ b/apps/web/app/auditor/page.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AppShell } from '../../components/app-shell';
+import { PageHeader } from '../../components/page-header';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { Drawer } from '../../components/ui/drawer';
+import { Select } from '../../components/ui/select';
+import { Table, TableWrapper } from '../../components/ui/table';
+import { getSessionToken } from '../../lib/api';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
+
+type QueueStatus = 'PROPOSED' | 'IN REVIEW' | 'APPROVED' | 'EXECUTED' | 'RETURNED';
+type QueueAction = 'APPROVE' | 'RETURN' | 'EXECUTE';
+
+type AuditorSignal = {
+  id: string;
+  severity: string;
+  signalType: string;
+  matterLabel: string;
+  status: QueueStatus;
+  updatedAt: string;
+  summary: string;
+  detail: string;
+};
+
+function toIsoOrPending(value: string | null | undefined): string {
+  if (!value) return 'pending';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return 'invalid';
+  return parsed.toISOString();
+}
+
+function formatUtcTimestamp(value: string | null | undefined): string {
+  const iso = toIsoOrPending(value);
+  if (iso === 'pending') return 'PENDING';
+  if (iso === 'invalid') return 'INVALID';
+  return iso.replace('T', ' ').replace('Z', ' UTC');
+}
+
+function normalizeStatus(value: unknown): QueueStatus {
+  const raw = String(value || '')
+    .replaceAll('_', ' ')
+    .trim()
+    .toUpperCase();
+  if (raw === 'APPROVED') return 'APPROVED';
+  if (raw === 'EXECUTED') return 'EXECUTED';
+  if (raw === 'RETURNED' || raw === 'REJECTED') return 'RETURNED';
+  if (raw === 'IN REVIEW') return 'IN REVIEW';
+  return 'PROPOSED';
+}
+
+function parseSignals(payload: unknown): AuditorSignal[] {
+  const rows = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as { items?: unknown[] } | null)?.items)
+      ? (payload as { items: unknown[] }).items
+      : [];
+
+  return rows.map((row, index) => {
+    const item = (row || {}) as Record<string, unknown>;
+    return {
+      id: String(item.id || item.signalId || `signal-${index}`),
+      severity: String(item.severity || 'LOW').toUpperCase(),
+      signalType: String(item.signalType || item.type || 'UNSPECIFIED').replaceAll('_', ' '),
+      matterLabel: String(item.matterLabel || item.matterName || item.matterId || 'UNASSIGNED MATTER'),
+      status: normalizeStatus(item.status || item.reviewStatus || item.reviewedStatus),
+      updatedAt: String(item.updatedAt || item.reviewedAt || item.createdAt || ''),
+      summary: String(item.summary || item.title || 'Audit signal requires review.'),
+      detail: String(item.detail || item.description || 'No additional signal detail returned by endpoint.'),
+    };
+  });
+}
+
+async function fetchSignals(): Promise<AuditorSignal[]> {
+  const token = getSessionToken();
+  const response = await fetch(`${API_BASE}/auditor/signals`, {
+    method: 'GET',
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { 'x-session-token': token } : {}),
+    },
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error(`QUEUE_FETCH_FAILED:${response.status}`);
+  }
+  const payload = await response.json().catch(() => []);
+  return parseSignals(payload);
+}
+
+async function reviewSignal(signalId: string, action: QueueAction): Promise<void> {
+  const token = getSessionToken();
+  const baseHeaders = {
+    'content-type': 'application/json',
+    ...(token ? { 'x-session-token': token } : {}),
+  };
+
+  const attempts: Array<{ path: string; body: Record<string, string> }> = [
+    { path: `/auditor/signals/${signalId}/review`, body: { action } },
+    { path: `/auditor/signals/${signalId}/review`, body: { decision: action } },
+    { path: `/auditor/signals/${signalId}/${action.toLowerCase()}`, body: { notes: `Operator decision: ${action}.` } },
+  ];
+
+  let lastStatus = 500;
+  for (const attempt of attempts) {
+    const response = await fetch(`${API_BASE}${attempt.path}`, {
+      method: 'POST',
+      headers: baseHeaders,
+      body: JSON.stringify(attempt.body),
+      credentials: 'include',
+    }).catch(() => null);
+
+    if (response?.ok) {
+      return;
+    }
+    lastStatus = response?.status || 500;
+  }
+
+  throw new Error(`QUEUE_ACTION_FAILED:${lastStatus}`);
+}
+
+export default function AuditorPage() {
+  const [signals, setSignals] = useState<AuditorSignal[]>([]);
+  const [selectedSignalId, setSelectedSignalId] = useState<string | null>(null);
+  const [severityFilter, setSeverityFilter] = useState<'ALL' | string>('ALL');
+  const [statusFilter, setStatusFilter] = useState<'ALL' | QueueStatus>('ALL');
+  const [loading, setLoading] = useState(true);
+  const [actionBusy, setActionBusy] = useState<QueueAction | null>(null);
+  const [errorText, setErrorText] = useState('');
+  const [feedbackText, setFeedbackText] = useState('');
+
+  const selectedSignal = useMemo(
+    () => signals.find((signal) => signal.id === selectedSignalId) || null,
+    [selectedSignalId, signals],
+  );
+
+  const visibleSignals = useMemo(
+    () =>
+      signals.filter((signal) => {
+        const severityMatches = severityFilter === 'ALL' || signal.severity === severityFilter;
+        const statusMatches = statusFilter === 'ALL' || signal.status === statusFilter;
+        return severityMatches && statusMatches;
+      }),
+    [severityFilter, signals, statusFilter],
+  );
+
+  const uniqueSeverities = useMemo(() => ['ALL', ...new Set(signals.map((signal) => signal.severity))], [signals]);
+
+  async function loadQueue() {
+    setLoading(true);
+    setErrorText('');
+    try {
+      const nextSignals = await fetchSignals();
+      setSignals(nextSignals);
+      if (selectedSignalId && !nextSignals.some((signal) => signal.id === selectedSignalId)) {
+        setSelectedSignalId(null);
+      }
+    } catch {
+      setErrorText('Unable to load auditor queue. Verify API connectivity and retry.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadQueue().catch(() => undefined);
+  }, []);
+
+  async function executeAction(action: QueueAction) {
+    if (!selectedSignal) return;
+    setActionBusy(action);
+    setErrorText('');
+    setFeedbackText('');
+    try {
+      await reviewSignal(selectedSignal.id, action);
+      await loadQueue();
+      setFeedbackText(`${action} recorded for ${selectedSignal.id} at ${formatUtcTimestamp(new Date().toISOString())}.`);
+      setSelectedSignalId(null);
+    } catch {
+      setErrorText(`Unable to ${action.toLowerCase()} signal ${selectedSignal.id}. No transition applied.`);
+    } finally {
+      setActionBusy(null);
+    }
+  }
+
+  return (
+    <AppShell>
+      <PageHeader
+        title="Auditor Queue"
+        subtitle="Table queue for daily case monitoring decisions. Actions require explicit operator confirmation."
+      />
+
+      <div className="card" style={{ marginBottom: 14, display: 'grid', gap: 12 }}>
+        <div className="row-between">
+          <p className="mono-meta">Operations Queue</p>
+          <Button tone="secondary" onClick={() => loadQueue()} disabled={loading}>
+            Refresh Queue
+          </Button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, minmax(180px, 220px))', gap: 8 }}>
+          <label>
+            Severity Filter
+            <Select aria-label="Severity Filter" value={severityFilter} onChange={(event) => setSeverityFilter(event.target.value)}>
+              {uniqueSeverities.map((severity) => (
+                <option key={severity} value={severity}>
+                  {severity}
+                </option>
+              ))}
+            </Select>
+          </label>
+
+          <label>
+            Status Filter
+            <Select
+              aria-label="Status Filter"
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as 'ALL' | QueueStatus)}
+            >
+              <option value="ALL">ALL</option>
+              <option value="PROPOSED">PROPOSED</option>
+              <option value="IN REVIEW">IN REVIEW</option>
+              <option value="APPROVED">APPROVED</option>
+              <option value="EXECUTED">EXECUTED</option>
+              <option value="RETURNED">RETURNED</option>
+            </Select>
+          </label>
+        </div>
+
+        {feedbackText ? (
+          <p className="notice" role="status" aria-live="polite">
+            {feedbackText}
+          </p>
+        ) : null}
+        {errorText ? (
+          <p className="error" role="alert">
+            {errorText}
+          </p>
+        ) : null}
+
+        <TableWrapper>
+          <Table>
+            <thead>
+              <tr>
+                <th scope="col">Severity</th>
+                <th scope="col">Signal Type</th>
+                <th scope="col">Matter Label</th>
+                <th scope="col">Status</th>
+                <th scope="col">Updated Timestamp</th>
+                <th scope="col">Review</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleSignals.map((signal) => (
+                <tr key={signal.id}>
+                  <td>{signal.severity}</td>
+                  <td>{signal.signalType}</td>
+                  <td>{signal.matterLabel}</td>
+                  <td>
+                    <Badge className={`status-${signal.status.toLowerCase().replaceAll(' ', '-')}`}>{signal.status}</Badge>
+                  </td>
+                  <td>{formatUtcTimestamp(signal.updatedAt)}</td>
+                  <td>
+                    <Button
+                      tone="secondary"
+                      aria-label={`Review ${signal.id}`}
+                      onClick={() => setSelectedSignalId(signal.id)}
+                    >
+                      Review
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+              {!loading && visibleSignals.length === 0 ? (
+                <tr>
+                  <td colSpan={6}>
+                    No signals matched current filters. Adjust filters or refresh queue.
+                  </td>
+                </tr>
+              ) : null}
+              {loading ? (
+                <tr>
+                  <td colSpan={6}>Loading queue records...</td>
+                </tr>
+              ) : null}
+            </tbody>
+          </Table>
+        </TableWrapper>
+      </div>
+
+      <Drawer open={Boolean(selectedSignal)} side="right" title="Review Signal" onClose={() => setSelectedSignalId(null)}>
+        {selectedSignal ? (
+          <div className="inline-stack">
+            <p className="mono-meta">Signal ID: {selectedSignal.id}</p>
+            <p>{selectedSignal.summary}</p>
+            <p>{selectedSignal.detail}</p>
+            <p className="mono-meta">Last Updated: {formatUtcTimestamp(selectedSignal.updatedAt)}</p>
+            <p className="mono-meta">Review Gate: PROPOSED → IN REVIEW → APPROVED → EXECUTED / RETURNED</p>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr', gap: 8 }}>
+              <Button onClick={() => executeAction('APPROVE')} disabled={Boolean(actionBusy)}>
+                {actionBusy === 'APPROVE' ? 'Recording...' : 'Approve'}
+              </Button>
+              <Button tone="danger" onClick={() => executeAction('RETURN')} disabled={Boolean(actionBusy)}>
+                {actionBusy === 'RETURN' ? 'Recording...' : 'Return'}
+              </Button>
+              <Button tone="secondary" onClick={() => executeAction('EXECUTE')} disabled={Boolean(actionBusy)}>
+                {actionBusy === 'EXECUTE' ? 'Recording...' : 'Execute'}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </Drawer>
+    </AppShell>
+  );
+}

--- a/apps/web/test/auditor-page.spec.tsx
+++ b/apps/web/test/auditor-page.spec.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import AuditorPage from '../app/auditor/page';
+
+function jsonResponse<T>(payload: T, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}
+
+const fixtureSignals = [
+  {
+    id: 'sig-1',
+    severity: 'critical',
+    signalType: 'deadline_risk',
+    matterLabel: 'Acme v. Dawson',
+    status: 'IN_REVIEW',
+    updatedAt: '2026-02-27T12:00:00.000Z',
+    summary: 'Critical deadline risk requires review.',
+    detail: 'Pleading deadline is overdue by 2 days.',
+  },
+];
+
+describe('AuditorPage', () => {
+  it('renders queue table with required columns', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method?.toUpperCase() ?? 'GET';
+      if (url.endsWith('/auditor/signals') && method === 'GET') {
+        return jsonResponse(fixtureSignals);
+      }
+      return jsonResponse({}, 500);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<AuditorPage />);
+
+    expect(await screen.findByRole('columnheader', { name: 'Severity' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Signal Type' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Matter Label' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Updated Timestamp' })).toBeInTheDocument();
+    expect(screen.getAllByText('CRITICAL').length).toBeGreaterThan(0);
+  });
+
+  it('opens and closes review drawer while preserving queue context', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(fixtureSignals)));
+
+    render(<AuditorPage />);
+
+    const reviewButton = await screen.findByRole('button', { name: 'Review sig-1' });
+    fireEvent.click(reviewButton);
+
+    expect(screen.getByText('Signal ID: sig-1')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Signal ID: sig-1')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Acme v. Dawson')).toBeInTheDocument();
+  });
+
+  it('supports keyboard focus flow with interactive controls using focus-visible-compatible classes', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => jsonResponse(fixtureSignals)));
+
+    render(<AuditorPage />);
+
+    const severityFilter = await screen.findByRole('combobox', { name: 'Severity Filter' });
+    const reviewButton = screen.getByRole('button', { name: 'Review sig-1' });
+
+    severityFilter.focus();
+    expect(severityFilter).toHaveFocus();
+    expect(severityFilter).toHaveClass('select');
+
+    reviewButton.focus();
+    expect(reviewButton).toHaveFocus();
+    expect(reviewButton).toHaveClass('button');
+  });
+
+  it('shows success and error feedback for action transitions', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method?.toUpperCase() ?? 'GET';
+
+      if (url.endsWith('/auditor/signals') && method === 'GET') {
+        return jsonResponse(fixtureSignals);
+      }
+      if (url.endsWith('/auditor/signals/sig-1/review') && method === 'POST') {
+        return jsonResponse({ ok: true });
+      }
+      return jsonResponse({}, 500);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<AuditorPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review sig-1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    expect(await screen.findByRole('status')).toHaveTextContent(/APPROVE recorded for sig-1/i);
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method?.toUpperCase() ?? 'GET';
+      if (url.endsWith('/auditor/signals') && method === 'GET') {
+        return jsonResponse(fixtureSignals);
+      }
+      if (url.includes('/auditor/signals/sig-1/')) {
+        return jsonResponse({ message: 'transition blocked' }, 500);
+      }
+      return jsonResponse({}, 500);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review sig-1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Execute' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to execute signal sig-1. No transition applied.');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a table-first `/auditor` queue to surface operational signals with severity, signal type, matter label, status, and updated timestamp so operators can triage high-risk items.
- Preserve queue context during review by using an in-context drawer and require explicit operator decisions (Approve / Return / Execute) wired to existing auditor endpoints or adapter fallbacks.
- Align UI with LIC rules (no shadows/gradients/rounded corners, strong borders, focus-visible for interactives) and ensure keyboard accessibility and procedural copy.

### Description
- New route and tests added: `apps/web/app/auditor/page.tsx` implements the queue, filters, review drawer, and three action flows, and `apps/web/test/auditor-page.spec.tsx` adds tests for rendering, drawer behavior, keyboard focus, and action feedback. 
- Action wiring uses `fetch` to call `/auditor/signals` for list retrieval and attempts adapter fallbacks for actions (`POST /auditor/signals/:id/review` with `{ action }` or `{ decision }`, then `/auditor/signals/:id/{approve|return|execute}`) to match existing backend variants. 
- Branch/commit/PR/traceability: branch `lin/KAR-110-auditor-queue-ui`, commit `a3e72653a96ce7dacee07c09a18b71f4b217aab2`, PR URL: N/A (not provided by automation), Requirements: `KAR-110`, `REQ-EVE2-007`, Files changed: `apps/web/app/auditor/page.tsx`, `apps/web/test/auditor-page.spec.tsx`. 
- Accessibility and visual tokens: focus-visible-compatible primitives and LIC tokens/classes were used and the drawer preserves context per design guidance. 

### Testing
- Ran the targeted spec with `pnpm --filter web test -- auditor-page.spec.tsx` and the spec passed. 
- Ran the full web test suite with `pnpm --filter web test` and the suite passed in this environment. 
- Attempted a production build with `pnpm --filter web build` which failed due to `next/font` failing to fetch IBM Plex fonts from Google Fonts in this environment, so build verification is blocked by an external font fetch issue. 
- Note: the dev server compiled the new route and a Playwright snapshot of `/auditor` was produced to show the rendered UI, and the UI compiled with fallback fonts when `next dev` ran.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1a3545ef483259178a9c4e4eec8e7)