### PR TITLE
[KAR-115] Add analyst dashboard with table drilldowns and CSV export

### DIFF
--- a/apps/web/app/analyst/page.tsx
+++ b/apps/web/app/analyst/page.tsx
@@ -32,8 +32,14 @@ type AnalystPayload = {
 };
 
 function normalizePayload(raw: unknown): AnalystPayload {
-  const payload = raw as { rows?: unknown[]; items?: unknown[]; detailsById?: Record<string, unknown[]> };
-  const sourceRows = Array.isArray(payload?.rows) ? payload.rows : Array.isArray(payload?.items) ? payload.items : [];
+  const payload = raw as { rows?: unknown[]; items?: unknown[]; detailsById?: Record<string, unknown[]> } | unknown[];
+  const sourceRows = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.rows)
+      ? payload.rows
+      : Array.isArray(payload?.items)
+        ? payload.items
+        : [];
 
   const rows = sourceRows.map((item, index) => {
     const row = item as Record<string, unknown>;
@@ -52,7 +58,7 @@ function normalizePayload(raw: unknown): AnalystPayload {
   });
 
   const detailsById = Object.fromEntries(
-    Object.entries(payload?.detailsById || {}).map(([key, entries]) => [
+    Object.entries(Array.isArray(payload) ? {} : payload?.detailsById || {}).map(([key, entries]) => [
       key,
       (entries || []).map((entry, index) => {
         const detail = entry as Record<string, unknown>;
@@ -73,6 +79,7 @@ function normalizePayload(raw: unknown): AnalystPayload {
 function csvHref(filters: { stage: string; bucket: string; query: string }) {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:4000';
   const query = new URLSearchParams();
+  query.set('report', 'bottlenecks');
   if (filters.stage !== 'all') query.set('stage', filters.stage);
   if (filters.bucket !== 'all') query.set('bucket', filters.bucket);
   if (filters.query.trim()) query.set('q', filters.query.trim());
@@ -95,7 +102,7 @@ export default function AnalystPage() {
     setLoading(true);
     setError(null);
 
-    apiFetch<unknown>('/reporting/analyst')
+    apiFetch<unknown>('/reporting/analyst/bottlenecks')
       .then((result) => {
         if (cancelled) return;
         const normalized = normalizePayload(result);

--- a/apps/web/test/analyst-page.spec.tsx
+++ b/apps/web/test/analyst-page.spec.tsx
@@ -75,7 +75,10 @@ describe('AnalystPage', () => {
     fireEvent.change(screen.getByLabelText('Matter, client, owner, or recent activity'), { target: { value: 'cline' } });
 
     const exportLink = screen.getByRole('link', { name: 'Export CSV' });
-    expect(exportLink).toHaveAttribute('href', 'http://localhost:4000/reporting/analyst/csv?stage=Intake&bucket=Current&q=cline');
+    expect(exportLink).toHaveAttribute(
+      'href',
+      'http://localhost:4000/reporting/analyst/csv?report=bottlenecks&stage=Intake&bucket=Current&q=cline',
+    );
 
     await waitFor(() => {
       expect(screen.queryByText('Ortega v. Kelvin')).not.toBeInTheDocument();


### PR DESCRIPTION
## Linear Issue
- KAR-115: https://linear.app/karenap/issue/KAR-115/build-analyst-dashboard-analyst-with-table-first-drilldowns

## Requirement ID
- REQ-EVE2-011

## Summary
- Adds `/analyst` dashboard with table-first drilldowns and CSV export wiring.
- Keeps procedural LIC styling and accessibility semantics.

## UI Interaction Checklist
- [x] Keyboard navigation verified for filters, table row selection, and export action.
- [x] Focus-visible states are present on interactive controls.
- [x] Labels and status messaging are present for loading/empty/error paths.
- [x] No console errors observed during manual smoke interaction.

## Screenshot Evidence
- Analyst dashboard table + drilldown states captured in Codex Cloud run evidence.

## Validation
- `pnpm --filter web test` PASS
- `pnpm --filter web build` blocked in cloud environment by external `next/font` fetch to Google Fonts

## Files Changed
- `apps/web/app/analyst/page.tsx`
- `apps/web/test/analyst-page.spec.tsx`
