### PR TITLE
[KAR-104] Enforce Leads API workflow gates and transition auditing

### DIFF
--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AuditController } from './audit.controller';
 import { AuditService } from './audit.service';
+import { LeadsModule } from '../leads/leads.module';
 
 @Module({
+  imports: [LeadsModule],
   providers: [AuditService],
   controllers: [AuditController],
   exports: [AuditService],

--- a/apps/api/src/leads/dto/convert-lead.dto.ts
+++ b/apps/api/src/leads/dto/convert-lead.dto.ts
@@ -1,0 +1,20 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class ConvertLeadDto {
+  @IsString()
+  name!: string;
+
+  @IsString()
+  matterNumber!: string;
+
+  @IsString()
+  practiceArea!: string;
+
+  @IsString()
+  @IsOptional()
+  jurisdiction?: string;
+
+  @IsString()
+  @IsOptional()
+  venue?: string;
+}

--- a/apps/api/src/leads/dto/create-intake-draft.dto.ts
+++ b/apps/api/src/leads/dto/create-intake-draft.dto.ts
@@ -1,0 +1,13 @@
+import { IsObject, IsOptional, IsString } from 'class-validator';
+
+export class CreateIntakeDraftDto {
+  @IsString()
+  intakeFormDefinitionId!: string;
+
+  @IsObject()
+  dataJson!: Record<string, unknown>;
+
+  @IsString()
+  @IsOptional()
+  submittedByContactId?: string;
+}

--- a/apps/api/src/leads/dto/create-lead.dto.ts
+++ b/apps/api/src/leads/dto/create-lead.dto.ts
@@ -1,0 +1,18 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateLeadDto {
+  @IsString()
+  source!: string;
+
+  @IsString()
+  @IsOptional()
+  referralContactId?: string;
+
+  @IsString()
+  @IsOptional()
+  assignedToUserId?: string;
+
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}

--- a/apps/api/src/leads/dto/generate-engagement.dto.ts
+++ b/apps/api/src/leads/dto/generate-engagement.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class GenerateEngagementDto {
+  @IsString()
+  engagementLetterTemplateId!: string;
+
+  @IsString()
+  @IsOptional()
+  provider?: string;
+
+  @IsOptional()
+  payloadJson?: Record<string, unknown>;
+}

--- a/apps/api/src/leads/dto/resolve-conflict.dto.ts
+++ b/apps/api/src/leads/dto/resolve-conflict.dto.ts
@@ -1,0 +1,10 @@
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class ResolveConflictDto {
+  @IsBoolean()
+  resolved!: boolean;
+
+  @IsString()
+  @IsOptional()
+  resolutionNotes?: string;
+}

--- a/apps/api/src/leads/dto/run-conflict-check.dto.ts
+++ b/apps/api/src/leads/dto/run-conflict-check.dto.ts
@@ -1,0 +1,9 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class RunConflictCheckDto {
+  @IsString()
+  queryText!: string;
+
+  @IsOptional()
+  resultJson?: Record<string, unknown>;
+}

--- a/apps/api/src/leads/dto/send-engagement.dto.ts
+++ b/apps/api/src/leads/dto/send-engagement.dto.ts
@@ -1,0 +1,10 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class SendEngagementDto {
+  @IsString()
+  envelopeId!: string;
+
+  @IsString()
+  @IsOptional()
+  externalId?: string;
+}

--- a/apps/api/src/leads/dto/update-lead.dto.ts
+++ b/apps/api/src/leads/dto/update-lead.dto.ts
@@ -1,0 +1,24 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { LeadStage } from '@prisma/client';
+
+export class UpdateLeadDto {
+  @IsString()
+  @IsOptional()
+  source?: string;
+
+  @IsString()
+  @IsOptional()
+  referralContactId?: string;
+
+  @IsString()
+  @IsOptional()
+  assignedToUserId?: string;
+
+  @IsString()
+  @IsOptional()
+  notes?: string;
+
+  @IsEnum(LeadStage)
+  @IsOptional()
+  stage?: LeadStage;
+}

--- a/apps/api/src/leads/leads.controller.ts
+++ b/apps/api/src/leads/leads.controller.ts
@@ -1,0 +1,87 @@
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { LeadsService } from './leads.service';
+import { SessionAuthGuard } from '../common/guards/session-auth.guard';
+import { PermissionGuard } from '../common/guards/permission.guard';
+import { RequirePermissions } from '../common/decorators/permissions.decorator';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { AuthenticatedUser } from '../common/types';
+import { CreateLeadDto } from './dto/create-lead.dto';
+import { UpdateLeadDto } from './dto/update-lead.dto';
+import { CreateIntakeDraftDto } from './dto/create-intake-draft.dto';
+import { RunConflictCheckDto } from './dto/run-conflict-check.dto';
+import { ResolveConflictDto } from './dto/resolve-conflict.dto';
+import { GenerateEngagementDto } from './dto/generate-engagement.dto';
+import { SendEngagementDto } from './dto/send-engagement.dto';
+import { ConvertLeadDto } from './dto/convert-lead.dto';
+
+@Controller('leads')
+@UseGuards(SessionAuthGuard, PermissionGuard)
+export class LeadsController {
+  constructor(private readonly leadsService: LeadsService) {}
+
+  @Get()
+  @RequirePermissions('leads:read')
+  list(@CurrentUser() user: AuthenticatedUser) {
+    return this.leadsService.list(user.organizationId);
+  }
+
+  @Post()
+  @RequirePermissions('leads:write')
+  create(@CurrentUser() user: AuthenticatedUser, @Body() dto: CreateLeadDto) {
+    return this.leadsService.create(user.organizationId, user.id, dto);
+  }
+
+  @Get(':id')
+  @RequirePermissions('leads:read')
+  getById(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string) {
+    return this.leadsService.getById(user.organizationId, id);
+  }
+
+  @Patch(':id')
+  @RequirePermissions('leads:write')
+  update(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: UpdateLeadDto) {
+    return this.leadsService.update(user.organizationId, user.id, id, dto);
+  }
+
+  @Post(':id/intake-drafts')
+  @RequirePermissions('leads:write')
+  createIntakeDraft(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: CreateIntakeDraftDto) {
+    return this.leadsService.createIntakeDraft(user.organizationId, user.id, id, dto);
+  }
+
+  @Post(':id/conflict-check')
+  @RequirePermissions('leads:write')
+  runConflictCheck(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: RunConflictCheckDto) {
+    return this.leadsService.runConflictCheck(user.organizationId, user.id, id, dto);
+  }
+
+  @Post(':id/conflict-resolution')
+  @RequirePermissions('leads:write')
+  resolveConflict(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: ResolveConflictDto) {
+    return this.leadsService.resolveConflict(user.organizationId, user.id, id, dto);
+  }
+
+  @Post(':id/engagement/generate')
+  @RequirePermissions('leads:write')
+  generateEngagement(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: GenerateEngagementDto) {
+    return this.leadsService.generateEngagement(user.organizationId, user.id, id, dto);
+  }
+
+  @Post(':id/engagement/send')
+  @RequirePermissions('leads:write')
+  sendEngagement(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: SendEngagementDto) {
+    return this.leadsService.sendEngagement(user.organizationId, user.id, id, dto);
+  }
+
+  @Post(':id/convert')
+  @RequirePermissions('leads:write')
+  convert(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string, @Body() dto: ConvertLeadDto) {
+    return this.leadsService.convert(user.organizationId, user.id, id, dto);
+  }
+
+  @Get(':id/setup-checklist')
+  @RequirePermissions('leads:read')
+  setupChecklist(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string) {
+    return this.leadsService.setupChecklist(user.organizationId, id);
+  }
+}

--- a/apps/api/src/leads/leads.module.ts
+++ b/apps/api/src/leads/leads.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { LeadsService } from './leads.service';
+import { LeadsController } from './leads.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuditService } from '../audit/audit.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [LeadsController],
+  providers: [LeadsService, AuditService],
+})
+export class LeadsModule {}

--- a/apps/api/src/leads/leads.service.ts
+++ b/apps/api/src/leads/leads.service.ts
@@ -1,0 +1,389 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { LeadStage, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { CreateLeadDto } from './dto/create-lead.dto';
+import { UpdateLeadDto } from './dto/update-lead.dto';
+import { CreateIntakeDraftDto } from './dto/create-intake-draft.dto';
+import { RunConflictCheckDto } from './dto/run-conflict-check.dto';
+import { ResolveConflictDto } from './dto/resolve-conflict.dto';
+import { GenerateEngagementDto } from './dto/generate-engagement.dto';
+import { SendEngagementDto } from './dto/send-engagement.dto';
+import { ConvertLeadDto } from './dto/convert-lead.dto';
+
+@Injectable()
+export class LeadsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  list(organizationId: string) {
+    return this.prisma.lead.findMany({
+      where: { organizationId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async create(organizationId: string, actorUserId: string, dto: CreateLeadDto) {
+    const lead = await this.prisma.lead.create({
+      data: {
+        organizationId,
+        source: dto.source,
+        referralContactId: dto.referralContactId,
+        assignedToUserId: dto.assignedToUserId,
+        notes: dto.notes,
+      },
+    });
+
+    await this.appendTransitionEvent(organizationId, actorUserId, lead.id, 'lead.created', {
+      toStage: lead.stage,
+      source: lead.source,
+    });
+
+    return lead;
+  }
+
+  async getById(organizationId: string, id: string) {
+    return this.requireLead(organizationId, id);
+  }
+
+  async update(organizationId: string, actorUserId: string, id: string, dto: UpdateLeadDto) {
+    const existing = await this.requireLead(organizationId, id);
+    const lead = await this.prisma.lead.update({
+      where: { id: existing.id },
+      data: {
+        source: dto.source,
+        referralContactId: dto.referralContactId,
+        assignedToUserId: dto.assignedToUserId,
+        notes: dto.notes,
+        stage: dto.stage,
+      },
+    });
+
+    if (dto.stage && dto.stage !== existing.stage) {
+      await this.appendTransitionEvent(organizationId, actorUserId, lead.id, 'lead.stage.transitioned', {
+        fromStage: existing.stage,
+        toStage: dto.stage,
+      });
+    } else {
+      await this.appendTransitionEvent(organizationId, actorUserId, lead.id, 'lead.updated', {
+        fields: Object.keys(dto),
+      });
+    }
+
+    return lead;
+  }
+
+  async createIntakeDraft(organizationId: string, actorUserId: string, leadId: string, dto: CreateIntakeDraftDto) {
+    const lead = await this.requireLead(organizationId, leadId);
+    const submission = await this.prisma.intakeSubmission.create({
+      data: {
+        organizationId,
+        leadId: lead.id,
+        intakeFormDefinitionId: dto.intakeFormDefinitionId,
+        submittedByContactId: dto.submittedByContactId,
+        dataJson: dto.dataJson as Prisma.InputJsonValue,
+      },
+    });
+
+    await this.transitionStage(organizationId, actorUserId, lead.id, lead.stage, LeadStage.SCREENING, 'lead.intake_draft.created', {
+      intakeSubmissionId: submission.id,
+    });
+
+    return submission;
+  }
+
+  async runConflictCheck(organizationId: string, actorUserId: string, leadId: string, dto: RunConflictCheckDto) {
+    const lead = await this.requireLead(organizationId, leadId);
+    const conflictCheck = await this.prisma.conflictCheckResult.create({
+      data: {
+        organizationId,
+        queryText: dto.queryText,
+        searchedByUserId: actorUserId,
+        resultJson: {
+          ...(dto.resultJson ?? {}),
+          resolved: false,
+          leadId,
+        },
+      },
+    });
+
+    await this.transitionStage(
+      organizationId,
+      actorUserId,
+      lead.id,
+      lead.stage,
+      LeadStage.CONFLICT_CHECK,
+      'lead.conflict_check.completed',
+      { conflictCheckId: conflictCheck.id },
+    );
+
+    return conflictCheck;
+  }
+
+  async resolveConflict(organizationId: string, actorUserId: string, leadId: string, dto: ResolveConflictDto) {
+    const lead = await this.requireLead(organizationId, leadId);
+    const latest = await this.getLatestConflictCheck(organizationId, leadId);
+
+    if (!latest) {
+      throw new BadRequestException('Conflict check must be run before resolution');
+    }
+
+    const mergedResult = this.asObject(latest.resultJson);
+    const conflictCheck = await this.prisma.conflictCheckResult.update({
+      where: { id: latest.id },
+      data: {
+        resultJson: {
+          ...mergedResult,
+          resolved: dto.resolved,
+          resolutionNotes: dto.resolutionNotes ?? null,
+          resolvedAt: new Date().toISOString(),
+        },
+      },
+    });
+
+    await this.transitionStage(
+      organizationId,
+      actorUserId,
+      lead.id,
+      lead.stage,
+      dto.resolved ? LeadStage.CONSULTATION : LeadStage.CONFLICT_CHECK,
+      'lead.conflict_resolution.recorded',
+      { conflictCheckId: conflictCheck.id, resolved: dto.resolved },
+    );
+
+    return conflictCheck;
+  }
+
+  async generateEngagement(organizationId: string, actorUserId: string, leadId: string, dto: GenerateEngagementDto) {
+    const lead = await this.requireLead(organizationId, leadId);
+    const envelope = await this.prisma.eSignEnvelope.create({
+      data: {
+        organizationId,
+        engagementLetterTemplateId: dto.engagementLetterTemplateId,
+        provider: dto.provider ?? 'INTERNAL',
+        status: 'DRAFT',
+        payloadJson: {
+          ...((dto.payloadJson ?? {}) as Prisma.InputJsonObject),
+          leadId: lead.id,
+          generatedByUserId: actorUserId,
+        },
+      },
+    });
+
+    await this.appendTransitionEvent(organizationId, actorUserId, lead.id, 'lead.engagement.generated', {
+      envelopeId: envelope.id,
+      stage: lead.stage,
+    });
+
+    return envelope;
+  }
+
+  async sendEngagement(organizationId: string, actorUserId: string, leadId: string, dto: SendEngagementDto) {
+    await this.requireLead(organizationId, leadId);
+    const isConflictResolved = await this.isConflictResolved(organizationId, leadId);
+    if (!isConflictResolved) {
+      throw new BadRequestException('Conflict resolution is required before sending engagement');
+    }
+
+    const envelope = await this.prisma.eSignEnvelope.findFirst({
+      where: {
+        id: dto.envelopeId,
+        organizationId,
+        payloadJson: {
+          path: ['leadId'],
+          equals: leadId,
+        },
+      },
+    });
+
+    if (!envelope) {
+      throw new NotFoundException('Engagement envelope not found');
+    }
+
+    const updated = await this.prisma.eSignEnvelope.update({
+      where: { id: envelope.id },
+      data: {
+        status: 'SENT',
+        externalId: dto.externalId,
+        payloadJson: {
+          ...this.asObject(envelope.payloadJson),
+          sentAt: new Date().toISOString(),
+          sentByUserId: actorUserId,
+        },
+      },
+    });
+
+    await this.appendTransitionEvent(organizationId, actorUserId, leadId, 'lead.engagement.sent', {
+      envelopeId: updated.id,
+    });
+
+    return updated;
+  }
+
+  async convert(organizationId: string, actorUserId: string, leadId: string, dto: ConvertLeadDto) {
+    const lead = await this.requireLead(organizationId, leadId);
+
+    const signedEnvelope = await this.prisma.eSignEnvelope.findFirst({
+      where: {
+        organizationId,
+        status: 'SIGNED',
+        payloadJson: {
+          path: ['leadId'],
+          equals: leadId,
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (!signedEnvelope) {
+      throw new BadRequestException('Signed engagement is required before converting lead');
+    }
+
+    const matter = await this.prisma.matter.create({
+      data: {
+        organizationId,
+        name: dto.name,
+        matterNumber: dto.matterNumber,
+        practiceArea: dto.practiceArea,
+        jurisdiction: dto.jurisdiction,
+        venue: dto.venue,
+      },
+    });
+
+    await this.prisma.lead.update({
+      where: { id: lead.id },
+      data: {
+        stage: LeadStage.RETAINED,
+      },
+    });
+
+    await this.appendTransitionEvent(organizationId, actorUserId, leadId, 'lead.converted', {
+      fromStage: lead.stage,
+      toStage: LeadStage.RETAINED,
+      matterId: matter.id,
+      envelopeId: signedEnvelope.id,
+    });
+
+    return {
+      leadId,
+      matter,
+    };
+  }
+
+  async setupChecklist(organizationId: string, leadId: string) {
+    await this.requireLead(organizationId, leadId);
+
+    const [intakeCount, conflict, engagementEnvelope] = await Promise.all([
+      this.prisma.intakeSubmission.count({ where: { organizationId, leadId } }),
+      this.getLatestConflictCheck(organizationId, leadId),
+      this.prisma.eSignEnvelope.findFirst({
+        where: {
+          organizationId,
+          payloadJson: { path: ['leadId'], equals: leadId },
+        },
+        orderBy: { createdAt: 'desc' },
+      }),
+    ]);
+
+    const conflictResult = conflict ? this.asObject(conflict.resultJson) : null;
+    const conflictResolved = Boolean(conflictResult?.resolved);
+    const engagementSent = engagementEnvelope?.status === 'SENT' || engagementEnvelope?.status === 'SIGNED';
+    const engagementSigned = engagementEnvelope?.status === 'SIGNED';
+
+    return {
+      leadId,
+      intakeDraftCreated: intakeCount > 0,
+      conflictChecked: Boolean(conflict),
+      conflictResolved,
+      engagementGenerated: Boolean(engagementEnvelope),
+      engagementSent,
+      engagementSigned,
+      convertible: engagementSigned,
+    };
+  }
+
+  private async requireLead(organizationId: string, leadId: string) {
+    const lead = await this.prisma.lead.findFirst({
+      where: { id: leadId, organizationId },
+    });
+
+    if (!lead) {
+      throw new NotFoundException('Lead not found');
+    }
+
+    return lead;
+  }
+
+  private async transitionStage(
+    organizationId: string,
+    actorUserId: string,
+    leadId: string,
+    fromStage: LeadStage,
+    toStage: LeadStage,
+    action: string,
+    metadata: Record<string, unknown>,
+  ) {
+    if (fromStage !== toStage) {
+      await this.prisma.lead.update({
+        where: { id: leadId },
+        data: { stage: toStage },
+      });
+    }
+
+    await this.appendTransitionEvent(organizationId, actorUserId, leadId, action, {
+      ...metadata,
+      fromStage,
+      toStage,
+    });
+  }
+
+  private async appendTransitionEvent(
+    organizationId: string,
+    actorUserId: string,
+    leadId: string,
+    action: string,
+    metadata: Record<string, unknown>,
+  ) {
+    await this.audit.appendEvent({
+      organizationId,
+      actorUserId,
+      action,
+      entityType: 'lead',
+      entityId: leadId,
+      metadata,
+    });
+  }
+
+  private async getLatestConflictCheck(organizationId: string, leadId: string) {
+    return this.prisma.conflictCheckResult.findFirst({
+      where: {
+        organizationId,
+        resultJson: {
+          path: ['leadId'],
+          equals: leadId,
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  private async isConflictResolved(organizationId: string, leadId: string) {
+    const latest = await this.getLatestConflictCheck(organizationId, leadId);
+    if (!latest) {
+      return false;
+    }
+
+    const result = this.asObject(latest.resultJson);
+    return result.resolved === true;
+  }
+
+  private asObject(value: Prisma.JsonValue | null | undefined): Record<string, any> {
+    if (!value || Array.isArray(value) || typeof value !== 'object') {
+      return {};
+    }
+
+    return value as Record<string, any>;
+  }
+}

--- a/apps/api/test/leads.service.spec.ts
+++ b/apps/api/test/leads.service.spec.ts
@@ -1,0 +1,104 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { LeadStage } from '@prisma/client';
+import { LeadsService } from '../src/leads/leads.service';
+
+describe('LeadsService', () => {
+  const organizationId = 'org-1';
+  const actorUserId = 'user-1';
+
+  const buildService = () => {
+    const prisma = {
+      lead: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      intakeSubmission: {
+        create: jest.fn(),
+        count: jest.fn(),
+      },
+      conflictCheckResult: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      eSignEnvelope: {
+        create: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      matter: {
+        create: jest.fn(),
+      },
+    } as any;
+
+    const audit = {
+      appendEvent: jest.fn(),
+    } as any;
+
+    const service = new LeadsService(prisma, audit);
+    return { service, prisma, audit };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('blocks engagement send when conflict is unresolved', async () => {
+    const { service, prisma } = buildService();
+    prisma.lead.findFirst.mockResolvedValue({ id: 'lead-1', organizationId, stage: LeadStage.CONFLICT_CHECK });
+    prisma.conflictCheckResult.findFirst.mockResolvedValue({
+      id: 'check-1',
+      resultJson: { leadId: 'lead-1', resolved: false },
+    });
+
+    await expect(
+      service.sendEngagement(organizationId, actorUserId, 'lead-1', { envelopeId: 'env-1' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('blocks convert when engagement is not signed', async () => {
+    const { service, prisma } = buildService();
+    prisma.lead.findFirst.mockResolvedValue({ id: 'lead-1', organizationId, stage: LeadStage.CONSULTATION });
+    prisma.eSignEnvelope.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.convert(organizationId, actorUserId, 'lead-1', {
+        name: 'Matter',
+        matterNumber: 'M-1',
+        practiceArea: 'Family',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('records audit events for state transitions', async () => {
+    const { service, prisma, audit } = buildService();
+    prisma.lead.findFirst.mockResolvedValue({ id: 'lead-1', organizationId, stage: LeadStage.NEW });
+    prisma.intakeSubmission.create.mockResolvedValue({ id: 'intake-1' });
+    prisma.lead.update.mockResolvedValue({ id: 'lead-1', stage: LeadStage.SCREENING });
+
+    await service.createIntakeDraft(organizationId, actorUserId, 'lead-1', {
+      intakeFormDefinitionId: 'intake-def-1',
+      dataJson: { firstName: 'Taylor' },
+    });
+
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId,
+        actorUserId,
+        action: 'lead.intake_draft.created',
+        entityType: 'lead',
+        entityId: 'lead-1',
+      }),
+    );
+  });
+
+  it('enforces tenant isolation for getById', async () => {
+    const { service, prisma } = buildService();
+    prisma.lead.findFirst.mockResolvedValue(null);
+
+    await expect(service.getById('org-2', 'lead-1')).rejects.toBeInstanceOf(NotFoundException);
+    expect(prisma.lead.findFirst).toHaveBeenCalledWith({ where: { id: 'lead-1', organizationId: 'org-2' } });
+  });
+});


### PR DESCRIPTION
## Linear Issue
- KAR-104: https://linear.app/karenap/issue/KAR-104/implement-leads-api-with-conflictengagementconvert-gates-setup

## Requirement ID
- REQ-EVE2-002

## Summary
- Implements Leads API workflow gates for conflict/engagement/convert lifecycle.
- Emits audit events for lead state transitions and preserves tenant isolation.

## Validation
- `pnpm --filter api lint` PASS
- `pnpm --filter api test` PASS
- `pnpm --filter api build` PASS

## Files Changed
- `apps/api/src/leads/*`
- `apps/api/test/leads.service.spec.ts`
- `apps/api/src/audit/audit.module.ts`
