### PR TITLE
[KAR-113] Implement analyst metrics pipeline snapshot aggregates

### DIFF
--- a/apps/api/src/reporting/reporting.service.ts
+++ b/apps/api/src/reporting/reporting.service.ts
@@ -2,9 +2,272 @@ import { Injectable } from '@nestjs/common';
 import { stringify } from 'csv-stringify/sync';
 import { PrismaService } from '../prisma/prisma.service';
 
+type AnalystMetricOptions = {
+  asOf?: Date;
+  windowDays?: number;
+};
+
+type AnalystSummary = {
+  userId: string;
+  userName: string;
+  userEmail: string;
+};
+
 @Injectable()
 export class ReportingService {
   constructor(private readonly prisma: PrismaService) {}
+
+  private toHours(milliseconds: number): number {
+    return milliseconds / (1000 * 60 * 60);
+  }
+
+  private round(value: number, decimals = 2): number {
+    return Number(value.toFixed(decimals));
+  }
+
+  private percentile(sortedValues: number[], quantile: number): number {
+    if (sortedValues.length === 0) return 0;
+    if (sortedValues.length === 1) return sortedValues[0];
+    const position = (sortedValues.length - 1) * quantile;
+    const lowerIndex = Math.floor(position);
+    const upperIndex = Math.ceil(position);
+    if (lowerIndex === upperIndex) return sortedValues[lowerIndex];
+    const lower = sortedValues[lowerIndex];
+    const upper = sortedValues[upperIndex];
+    return lower + (upper - lower) * (position - lowerIndex);
+  }
+
+  private summarizeMembers(
+    memberships: Array<{ user: { id: string; fullName: string | null; email: string } }>,
+  ): Map<string, AnalystSummary> {
+    return new Map(
+      memberships.map(({ user }) => [
+        user.id,
+        {
+          userId: user.id,
+          userName: user.fullName ?? user.email,
+          userEmail: user.email,
+        },
+      ]),
+    );
+  }
+
+  async analystMetricsSnapshot(organizationId: string, options: AnalystMetricOptions = {}) {
+    const asOf = options.asOf ?? new Date();
+    const windowDays = options.windowDays ?? 90;
+    const windowStart = new Date(asOf.getTime() - windowDays * 24 * 60 * 60 * 1000);
+
+    const [memberships, completedTasks, openTasksByAssignee, timeByAssignee, leads, invoices] = await Promise.all([
+      this.prisma.membership.findMany({
+        where: { organizationId },
+        select: { user: { select: { id: true, fullName: true, email: true } } },
+        orderBy: [{ user: { fullName: 'asc' } }, { user: { email: 'asc' } }, { user: { id: 'asc' } }],
+      }),
+      this.prisma.task.findMany({
+        where: {
+          organizationId,
+          status: 'DONE',
+          createdAt: { gte: windowStart, lte: asOf },
+          updatedAt: { lte: asOf },
+        },
+        select: { assigneeUserId: true, createdAt: true, updatedAt: true },
+        orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
+      }),
+      this.prisma.task.groupBy({
+        by: ['assigneeUserId'],
+        where: {
+          organizationId,
+          status: { not: 'DONE' },
+          createdAt: { lte: asOf },
+        },
+        _count: { assigneeUserId: true },
+      }),
+      this.prisma.timeEntry.groupBy({
+        by: ['userId'],
+        where: {
+          organizationId,
+          startedAt: { gte: windowStart, lte: asOf },
+        },
+        _sum: {
+          durationMinutes: true,
+          amount: true,
+        },
+      }),
+      this.prisma.lead.findMany({
+        where: {
+          organizationId,
+          createdAt: { gte: windowStart, lte: asOf },
+        },
+        select: {
+          source: true,
+          stage: true,
+          referralContactId: true,
+          referralContact: { select: { displayName: true } },
+        },
+        orderBy: [{ source: 'asc' }, { referralContactId: 'asc' }, { id: 'asc' }],
+      }),
+      this.prisma.invoice.findMany({
+        where: {
+          organizationId,
+          issuedAt: { gte: windowStart, lte: asOf },
+        },
+        select: {
+          matterId: true,
+          total: true,
+          balanceDue: true,
+          matter: {
+            select: {
+              teamMembers: {
+                select: {
+                  userId: true,
+                },
+              },
+            },
+          },
+        },
+        orderBy: [{ issuedAt: 'asc' }, { id: 'asc' }],
+      }),
+    ]);
+
+    const memberSummary = this.summarizeMembers(memberships);
+    const cycleBuckets = new Map<string, number[]>();
+    for (const task of completedTasks) {
+      if (!task.assigneeUserId) continue;
+      const durationHours = this.toHours(task.updatedAt.getTime() - task.createdAt.getTime());
+      if (durationHours < 0) continue;
+      const current = cycleBuckets.get(task.assigneeUserId) ?? [];
+      current.push(durationHours);
+      cycleBuckets.set(task.assigneeUserId, current);
+    }
+
+    const cycleTime = Array.from(cycleBuckets.entries())
+      .map(([userId, values]) => {
+        const sorted = [...values].sort((a, b) => a - b);
+        const summary =
+          memberSummary.get(userId) ??
+          ({ userId, userName: userId, userEmail: `${userId}@unknown.invalid` } satisfies AnalystSummary);
+        return {
+          ...summary,
+          completedTaskCount: sorted.length,
+          averageCycleHours: this.round(sorted.reduce((sum, value) => sum + value, 0) / sorted.length),
+          medianCycleHours: this.round(this.percentile(sorted, 0.5)),
+        };
+      })
+      .sort(
+        (a, b) =>
+          b.averageCycleHours - a.averageCycleHours ||
+          b.completedTaskCount - a.completedTaskCount ||
+          a.userId.localeCompare(b.userId),
+      );
+
+    const turnaround = Array.from(cycleBuckets.entries())
+      .map(([userId, values]) => {
+        const sorted = [...values].sort((a, b) => a - b);
+        const summary =
+          memberSummary.get(userId) ??
+          ({ userId, userName: userId, userEmail: `${userId}@unknown.invalid` } satisfies AnalystSummary);
+        return {
+          ...summary,
+          completedTaskCount: sorted.length,
+          averageTurnaroundHours: this.round(sorted.reduce((sum, value) => sum + value, 0) / sorted.length),
+          p90TurnaroundHours: this.round(this.percentile(sorted, 0.9)),
+        };
+      })
+      .sort(
+        (a, b) =>
+          b.p90TurnaroundHours - a.p90TurnaroundHours ||
+          b.completedTaskCount - a.completedTaskCount ||
+          a.userId.localeCompare(b.userId),
+      );
+
+    const taskCountByAssignee = new Map(openTasksByAssignee.map((row) => [row.assigneeUserId ?? '', row._count.assigneeUserId]));
+    const timeByUser = new Map(
+      timeByAssignee.map((row) => [row.userId ?? '', { billedMinutes: row._sum.durationMinutes ?? 0, billedAmount: row._sum.amount ?? 0 }]),
+    );
+    const capacity = memberships
+      .map(({ user }) => {
+        const openTaskCount = taskCountByAssignee.get(user.id) ?? 0;
+        const billedMinutes = timeByUser.get(user.id)?.billedMinutes ?? 0;
+        const billedAmount = timeByUser.get(user.id)?.billedAmount ?? 0;
+        return {
+          userId: user.id,
+          userName: user.fullName ?? user.email,
+          userEmail: user.email,
+          openTaskCount,
+          billedMinutes,
+          billedAmount: this.round(billedAmount),
+          utilizationScore: this.round((billedMinutes / Math.max(1, windowDays * 8 * 60)) * 100),
+        };
+      })
+      .sort((a, b) => b.utilizationScore - a.utilizationScore || b.openTaskCount - a.openTaskCount || a.userId.localeCompare(b.userId));
+
+    const referralBuckets = new Map<string, { source: string; referralContactId: string | null; referralLabel: string; leadCount: number; retainedLeadCount: number }>();
+    for (const lead of leads) {
+      const key = `${lead.source}::${lead.referralContactId ?? ''}`;
+      const existing = referralBuckets.get(key) ?? {
+        source: lead.source,
+        referralContactId: lead.referralContactId,
+        referralLabel: lead.referralContact?.displayName ?? 'Direct/Unknown',
+        leadCount: 0,
+        retainedLeadCount: 0,
+      };
+      existing.leadCount += 1;
+      if (lead.stage === 'RETAINED') existing.retainedLeadCount += 1;
+      referralBuckets.set(key, existing);
+    }
+    const referral = Array.from(referralBuckets.values())
+      .map((row) => ({
+        ...row,
+        retentionRate: this.round((row.retainedLeadCount / Math.max(1, row.leadCount)) * 100),
+      }))
+      .sort((a, b) => b.leadCount - a.leadCount || b.retentionRate - a.retentionRate || a.source.localeCompare(b.source) || (a.referralContactId ?? '').localeCompare(b.referralContactId ?? ''));
+
+    const valueByUser = new Map<string, { invoicedAmount: number; collectedAmount: number; matters: Set<string> }>();
+    for (const invoice of invoices) {
+      const teamMemberUserIds = Array.from(new Set(invoice.matter.teamMembers.map((member) => member.userId))).sort((a, b) => a.localeCompare(b));
+      if (teamMemberUserIds.length === 0) continue;
+      const apportionedTotal = invoice.total / teamMemberUserIds.length;
+      const apportionedCollected = (invoice.total - invoice.balanceDue) / teamMemberUserIds.length;
+      for (const userId of teamMemberUserIds) {
+        const existing = valueByUser.get(userId) ?? { invoicedAmount: 0, collectedAmount: 0, matters: new Set<string>() };
+        existing.invoicedAmount += apportionedTotal;
+        existing.collectedAmount += apportionedCollected;
+        existing.matters.add(invoice.matterId);
+        valueByUser.set(userId, existing);
+      }
+    }
+
+    const value = memberships
+      .map(({ user }) => {
+        const summary = valueByUser.get(user.id);
+        const invoicedAmount = summary?.invoicedAmount ?? 0;
+        const collectedAmount = summary?.collectedAmount ?? 0;
+        const timeAmount = timeByUser.get(user.id)?.billedAmount ?? 0;
+        return {
+          userId: user.id,
+          userName: user.fullName ?? user.email,
+          userEmail: user.email,
+          matterCount: summary?.matters.size ?? 0,
+          timeEntryAmount: this.round(timeAmount),
+          invoicedAmount: this.round(invoicedAmount),
+          collectedAmount: this.round(collectedAmount),
+          totalValue: this.round(invoicedAmount + timeAmount),
+        };
+      })
+      .sort((a, b) => b.totalValue - a.totalValue || b.matterCount - a.matterCount || a.userId.localeCompare(b.userId));
+
+    return {
+      organizationId,
+      asOf: asOf.toISOString(),
+      windowStart: windowStart.toISOString(),
+      windowDays,
+      cycleTime,
+      turnaround,
+      capacity,
+      referral,
+      value,
+    };
+  }
 
   async bottlenecks(organizationId: string) {
     const now = new Date();

--- a/apps/api/test/reporting-analyst-metrics-pipeline.spec.ts
+++ b/apps/api/test/reporting-analyst-metrics-pipeline.spec.ts
@@ -1,0 +1,241 @@
+import { ReportingService } from '../src/reporting/reporting.service';
+
+describe('ReportingService analystMetricsSnapshot', () => {
+  it('computes scoped analyst metrics with deterministic ordering and window bounds', async () => {
+    const prisma = {
+      membership: {
+        findMany: jest.fn().mockResolvedValue([
+          { user: { id: 'user-b', fullName: 'Beta', email: 'beta@example.com' } },
+          { user: { id: 'user-a', fullName: 'Alpha', email: 'alpha@example.com' } },
+        ]),
+      },
+      task: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            assigneeUserId: 'user-a',
+            createdAt: new Date('2026-03-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-03-01T06:00:00.000Z'),
+          },
+          {
+            assigneeUserId: 'user-a',
+            createdAt: new Date('2026-03-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-03-01T03:00:00.000Z'),
+          },
+          {
+            assigneeUserId: 'user-b',
+            createdAt: new Date('2026-03-01T00:00:00.000Z'),
+            updatedAt: new Date('2026-03-01T10:00:00.000Z'),
+          },
+        ]),
+        groupBy: jest.fn().mockResolvedValue([
+          { assigneeUserId: 'user-a', _count: { assigneeUserId: 3 } },
+          { assigneeUserId: 'user-b', _count: { assigneeUserId: 1 } },
+        ]),
+      },
+      timeEntry: {
+        groupBy: jest.fn().mockResolvedValue([
+          { userId: 'user-a', _sum: { durationMinutes: 300, amount: 500 } },
+          { userId: 'user-b', _sum: { durationMinutes: 200, amount: 200 } },
+        ]),
+      },
+      lead: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            source: 'Partner',
+            stage: 'RETAINED',
+            referralContactId: 'contact-1',
+            referralContact: { displayName: 'Ref Partner' },
+          },
+          {
+            source: 'Partner',
+            stage: 'NEW',
+            referralContactId: 'contact-1',
+            referralContact: { displayName: 'Ref Partner' },
+          },
+          {
+            source: 'Web',
+            stage: 'RETAINED',
+            referralContactId: null,
+            referralContact: null,
+          },
+        ]),
+      },
+      invoice: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            matterId: 'matter-1',
+            total: 1000,
+            balanceDue: 400,
+            matter: {
+              teamMembers: [{ userId: 'user-a' }, { userId: 'user-b' }],
+            },
+          },
+          {
+            matterId: 'matter-2',
+            total: 500,
+            balanceDue: 0,
+            matter: {
+              teamMembers: [{ userId: 'user-a' }],
+            },
+          },
+        ]),
+      },
+    } as any;
+
+    const service = new ReportingService(prisma);
+    const snapshot = await service.analystMetricsSnapshot('org-1', {
+      asOf: new Date('2026-03-20T00:00:00.000Z'),
+      windowDays: 30,
+    });
+
+    expect(prisma.membership.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { organizationId: 'org-1' } }));
+    expect(prisma.task.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          organizationId: 'org-1',
+          createdAt: {
+            gte: new Date('2026-02-18T00:00:00.000Z'),
+            lte: new Date('2026-03-20T00:00:00.000Z'),
+          },
+        }),
+      }),
+    );
+
+    expect(snapshot.cycleTime).toEqual([
+      {
+        userId: 'user-b',
+        userName: 'Beta',
+        userEmail: 'beta@example.com',
+        completedTaskCount: 1,
+        averageCycleHours: 10,
+        medianCycleHours: 10,
+      },
+      {
+        userId: 'user-a',
+        userName: 'Alpha',
+        userEmail: 'alpha@example.com',
+        completedTaskCount: 2,
+        averageCycleHours: 4.5,
+        medianCycleHours: 4.5,
+      },
+    ]);
+
+    expect(snapshot.turnaround).toEqual([
+      {
+        userId: 'user-b',
+        userName: 'Beta',
+        userEmail: 'beta@example.com',
+        completedTaskCount: 1,
+        averageTurnaroundHours: 10,
+        p90TurnaroundHours: 10,
+      },
+      {
+        userId: 'user-a',
+        userName: 'Alpha',
+        userEmail: 'alpha@example.com',
+        completedTaskCount: 2,
+        averageTurnaroundHours: 4.5,
+        p90TurnaroundHours: 5.7,
+      },
+    ]);
+
+    expect(snapshot.referral).toEqual([
+      {
+        source: 'Partner',
+        referralContactId: 'contact-1',
+        referralLabel: 'Ref Partner',
+        leadCount: 2,
+        retainedLeadCount: 1,
+        retentionRate: 50,
+      },
+      {
+        source: 'Web',
+        referralContactId: null,
+        referralLabel: 'Direct/Unknown',
+        leadCount: 1,
+        retainedLeadCount: 1,
+        retentionRate: 100,
+      },
+    ]);
+
+    expect(snapshot.value).toEqual([
+      {
+        userId: 'user-a',
+        userName: 'Alpha',
+        userEmail: 'alpha@example.com',
+        matterCount: 2,
+        timeEntryAmount: 500,
+        invoicedAmount: 1000,
+        collectedAmount: 800,
+        totalValue: 1500,
+      },
+      {
+        userId: 'user-b',
+        userName: 'Beta',
+        userEmail: 'beta@example.com',
+        matterCount: 1,
+        timeEntryAmount: 200,
+        invoicedAmount: 500,
+        collectedAmount: 300,
+        totalValue: 700,
+      },
+    ]);
+  });
+
+  it('returns reproducible results for the same as-of input despite unsorted source rows', async () => {
+    const prisma = {
+      membership: {
+        findMany: jest.fn().mockResolvedValue([
+          { user: { id: 'user-2', fullName: null, email: 'b@example.com' } },
+          { user: { id: 'user-1', fullName: null, email: 'a@example.com' } },
+        ]),
+      },
+      task: {
+        findMany: jest
+          .fn()
+          .mockResolvedValueOnce([
+            {
+              assigneeUserId: 'user-1',
+              createdAt: new Date('2026-02-01T00:00:00.000Z'),
+              updatedAt: new Date('2026-02-01T04:00:00.000Z'),
+            },
+            {
+              assigneeUserId: 'user-2',
+              createdAt: new Date('2026-02-01T00:00:00.000Z'),
+              updatedAt: new Date('2026-02-01T02:00:00.000Z'),
+            },
+          ])
+          .mockResolvedValueOnce([
+            {
+              assigneeUserId: 'user-2',
+              createdAt: new Date('2026-02-01T00:00:00.000Z'),
+              updatedAt: new Date('2026-02-01T02:00:00.000Z'),
+            },
+            {
+              assigneeUserId: 'user-1',
+              createdAt: new Date('2026-02-01T00:00:00.000Z'),
+              updatedAt: new Date('2026-02-01T04:00:00.000Z'),
+            },
+          ]),
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+      timeEntry: {
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+      lead: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      invoice: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    } as any;
+
+    const service = new ReportingService(prisma);
+    const asOf = new Date('2026-02-15T00:00:00.000Z');
+
+    const first = await service.analystMetricsSnapshot('org-repro', { asOf });
+    const second = await service.analystMetricsSnapshot('org-repro', { asOf });
+
+    expect(first).toEqual(second);
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a reproducible analyst metrics snapshot that computes cycle time, turnaround, capacity, referral, and value for a tenant-scoped snapshot window to support deterministic reporting and downstream pipelines.
- The change enforces tenant scoping and deterministic ordering/tie-breaks and supplies explicit snapshot controls (`asOf`, `windowDays`) for reproducible aggregates.

## Linear Issue
- KAR-113

## Requirement ID
- REQ-EVE2-009

### Description
- Implemented a new `analystMetricsSnapshot` method on `ReportingService` with helper utilities (`toHours`, `round`, `percentile`, `summarizeMembers`) and options `asOf` and `windowDays` to bound source queries for reproducible snapshots.
- Source queries gather memberships, completed tasks, open task counts, time entries, leads, and invoices with explicit `organizationId` filters and stable `orderBy` clauses; per-user aggregations compute cycle time, turnaround (including p90), capacity (utilization), referral retention, and apportioned invoice value.
- Added deterministic sorting and tie-break keys across outputs and equal-split invoice apportionment across matter team members (not weighted by role) to produce stable ordering and values.
- Files/branch/commit: branch `lin/KAR-113-analyst-metrics-pipeline`, commit `b531f51a9656410ca68e12f7f2b803587760dfb9`, modified `apps/api/src/reporting/reporting.service.ts` and added test `apps/api/test/reporting-analyst-metrics-pipeline.spec.ts`.
- Known risks: invoice value is currently split equally across team members which may need business-rule refinement; snapshot storage/persistence was not added in this change (in-memory snapshot response only).
- Ready-to-merge decision: Yes, change is self-contained with tests and validations passing.

### Testing
- Ran the new focused spec `apps/api/test/reporting-analyst-metrics-pipeline.spec.ts` which validates aggregation correctness and reproducibility and it passed (2 tests).
- Ran full API test suite: `pnpm --filter api test` — all test suites passed (64 passed, 0 failed) in this environment.
- Lint and build validations succeeded: `pnpm --filter api lint` passed and `pnpm --filter api build` (TypeScript build) passed.
- Validation commands executed: `pnpm --filter api lint`, `pnpm --filter api test`, `pnpm --filter api build` (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1aad3d1a883259cf3560cd5cc5916)