### PR TITLE
[KAR-108] Add auditor missed-value signal detection and queue APIs

### DIFF
--- a/apps/api/prisma/migrations/20260218093000_matter_audit_signals/migration.sql
+++ b/apps/api/prisma/migrations/20260218093000_matter_audit_signals/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "MatterAuditSignalReviewState" AS ENUM ('GENERATED', 'IN_REVIEW', 'RESOLVED_ACTIONED', 'RESOLVED_DISMISSED');
+
+-- CreateTable
+CREATE TABLE "MatterAuditSignal" (
+    "id" UUID NOT NULL,
+    "organizationId" UUID NOT NULL,
+    "matterId" UUID NOT NULL,
+    "signalKey" TEXT NOT NULL,
+    "signalType" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT NOT NULL,
+    "citationsJson" JSONB NOT NULL,
+    "reviewState" "MatterAuditSignalReviewState" NOT NULL DEFAULT 'GENERATED',
+    "generatedAt" TIMESTAMP(3) NOT NULL,
+    "reviewStateChangedAt" TIMESTAMP(3),
+    "reviewedByUserId" UUID,
+    "reviewNotes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MatterAuditSignal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MatterAuditSignal_organizationId_signalKey_key" ON "MatterAuditSignal"("organizationId", "signalKey");
+
+-- CreateIndex
+CREATE INDEX "MatterAuditSignal_organizationId_reviewState_generatedAt_idx" ON "MatterAuditSignal"("organizationId", "reviewState", "generatedAt");
+
+-- CreateIndex
+CREATE INDEX "MatterAuditSignal_organizationId_matterId_generatedAt_idx" ON "MatterAuditSignal"("organizationId", "matterId", "generatedAt");
+
+-- AddForeignKey
+ALTER TABLE "MatterAuditSignal" ADD CONSTRAINT "MatterAuditSignal_matterId_fkey" FOREIGN KEY ("matterId") REFERENCES "Matter"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MatterAuditSignal" ADD CONSTRAINT "MatterAuditSignal_reviewedByUserId_fkey" FOREIGN KEY ("reviewedByUserId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -165,6 +165,13 @@ enum LeadStage {
   REJECTED
 }
 
+enum MatterAuditSignalReviewState {
+  GENERATED
+  IN_REVIEW
+  RESOLVED_ACTIONED
+  RESOLVED_DISMISSED
+}
+
 enum AiJobStatus {
   QUEUED
   RUNNING
@@ -289,6 +296,7 @@ model User {
   trustReconciliationRunsCreated TrustReconciliationRun[] @relation("TrustReconciliationRunCreatedBy")
   trustReconciliationRunsSignedOff TrustReconciliationRun[] @relation("TrustReconciliationRunSignedOffBy")
   trustReconciliationDiscrepanciesResolved TrustReconciliationDiscrepancy[] @relation("TrustReconciliationDiscrepancyResolvedBy")
+  matterAuditSignalsReviewed MatterAuditSignal[]
 }
 
 model Membership {
@@ -549,6 +557,7 @@ model Matter {
   intakeSubmissions    IntakeSubmission[]
   eSignEnvelopes       ESignEnvelope[]
   aiJobs               AiJob[]
+  auditSignals         MatterAuditSignal[]
   propertyProfile      PropertyProfile?
   contractProfile      ContractProfile?
   projectMilestones    ProjectMilestone[]
@@ -1341,6 +1350,31 @@ model ESignEnvelope {
   engagementLetterTemplate  EngagementLetterTemplate @relation(fields: [engagementLetterTemplateId], references: [id], onDelete: Cascade)
   matter                    Matter?  @relation(fields: [matterId], references: [id], onDelete: SetNull)
   document                  Document? @relation(fields: [documentId], references: [id], onDelete: SetNull)
+}
+
+
+model MatterAuditSignal {
+  id                 String                       @id @default(uuid()) @db.Uuid
+  organizationId     String                       @db.Uuid
+  matterId           String                       @db.Uuid
+  signalKey          String
+  signalType         String
+  title              String
+  summary            String
+  citationsJson      Json
+  reviewState        MatterAuditSignalReviewState @default(GENERATED)
+  generatedAt        DateTime
+  reviewStateChangedAt DateTime?
+  reviewedByUserId   String?                      @db.Uuid
+  reviewNotes        String?
+  createdAt          DateTime                     @default(now())
+  updatedAt          DateTime                     @updatedAt
+  matter             Matter                       @relation(fields: [matterId], references: [id], onDelete: Cascade)
+  reviewedBy         User?                        @relation(fields: [reviewedByUserId], references: [id], onDelete: SetNull)
+
+  @@unique([organizationId, signalKey])
+  @@index([organizationId, reviewState, generatedAt])
+  @@index([organizationId, matterId, generatedAt])
 }
 
 model AiJob {

--- a/apps/api/src/audit/audit.controller.ts
+++ b/apps/api/src/audit/audit.controller.ts
@@ -1,19 +1,72 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { MatterAuditSignalReviewState } from '@prisma/client';
 import { AuditService } from './audit.service';
 import { SessionAuthGuard } from '../common/guards/session-auth.guard';
 import { PermissionGuard } from '../common/guards/permission.guard';
 import { RequirePermissions } from '../common/decorators/permissions.decorator';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { AuthenticatedUser } from '../common/types';
+import { MatterAuditSignalService } from './matter-audit-signal.service';
+import { UpdateSignalReviewStateDto } from './dto/update-signal-review-state.dto';
 
 @Controller('audit')
 @UseGuards(SessionAuthGuard, PermissionGuard)
 export class AuditController {
-  constructor(private readonly auditService: AuditService) {}
+  constructor(
+    private readonly auditService: AuditService,
+    private readonly matterAuditSignalService: MatterAuditSignalService,
+  ) {}
 
   @Get()
   @RequirePermissions('audit:read')
   async list(@CurrentUser() user: AuthenticatedUser, @Query('limit') limit?: string) {
     return this.auditService.listByOrganization(user.organizationId, limit ? Number(limit) : 100);
+  }
+
+  @Get('matter-signals')
+  @RequirePermissions('audit:read')
+  async listMatterSignals(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query('reviewState') reviewState?: MatterAuditSignalReviewState,
+    @Query('matterId') matterId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.matterAuditSignalService.listSignals({
+      organizationId: user.organizationId,
+      reviewState,
+      matterId,
+      limit: limit ? Number(limit) : 100,
+    });
+  }
+
+  @Post('matter-signals/generate')
+  @RequirePermissions('audit:read')
+  async generateMatterSignals(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query('matterId') matterId?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.matterAuditSignalService.generateMissedValueSignals({
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      matterId,
+      limit: limit ? Number(limit) : 100,
+    });
+  }
+
+  @Patch('matter-signals/:signalId/review-state')
+  @RequirePermissions('audit:read')
+  async updateMatterSignalReviewState(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('signalId') signalId: string,
+    @Body() body: UpdateSignalReviewStateDto,
+  ) {
+    return this.matterAuditSignalService.updateReviewState({
+      organizationId: user.organizationId,
+      actorUserId: user.id,
+      signalId,
+      reviewState: body.reviewState,
+      reviewNotes: body.reviewNotes,
+    });
   }
 }

--- a/apps/api/src/audit/audit.module.ts
+++ b/apps/api/src/audit/audit.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { AuditController } from './audit.controller';
 import { AuditService } from './audit.service';
 import { LeadsModule } from '../leads/leads.module';
+import { MatterAuditSignalService } from './matter-audit-signal.service';
 
 @Module({
   imports: [LeadsModule],
-  providers: [AuditService],
+  providers: [AuditService, MatterAuditSignalService],
   controllers: [AuditController],
-  exports: [AuditService],
+  exports: [AuditService, MatterAuditSignalService],
 })
 export class AuditModule {}

--- a/apps/api/src/audit/dto/update-signal-review-state.dto.ts
+++ b/apps/api/src/audit/dto/update-signal-review-state.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+import { MatterAuditSignalReviewState } from '@prisma/client';
+
+export class UpdateSignalReviewStateDto {
+  @IsEnum(MatterAuditSignalReviewState)
+  reviewState!: MatterAuditSignalReviewState;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  reviewNotes?: string;
+}

--- a/apps/api/src/audit/matter-audit-signal.service.ts
+++ b/apps/api/src/audit/matter-audit-signal.service.ts
@@ -1,0 +1,167 @@
+import { Injectable } from '@nestjs/common';
+import { MatterAuditSignalReviewState, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from './audit.service';
+
+@Injectable()
+export class MatterAuditSignalService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async generateMissedValueSignals(input: {
+    organizationId: string;
+    actorUserId?: string;
+    matterId?: string;
+    limit?: number;
+  }) {
+    const logs = await this.prisma.aiExecutionLog.findMany({
+      where: {
+        organizationId: input.organizationId,
+        ...(input.matterId ? { aiJob: { matterId: input.matterId } } : {}),
+      },
+      include: {
+        aiJob: {
+          select: { id: true, matterId: true, toolName: true },
+        },
+      },
+      orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      take: input.limit ?? 100,
+    });
+
+    const createdSignals: Array<{ id: string }> = [];
+
+    for (const log of logs) {
+      const citations = this.extractCitations(log.sourceRefsJson);
+      if (citations.length === 0) {
+        continue;
+      }
+
+      const signalKey = `missed-value:${log.aiJobId}`;
+
+      const existing = await this.prisma.matterAuditSignal.findUnique({
+        where: {
+          organizationId_signalKey: {
+            organizationId: input.organizationId,
+            signalKey,
+          },
+        },
+        select: { id: true },
+      });
+
+      if (existing) {
+        continue;
+      }
+
+      const created = await this.prisma.matterAuditSignal.create({
+        data: {
+          organizationId: input.organizationId,
+          matterId: log.aiJob.matterId,
+          signalKey,
+          signalType: 'auditor.missed_value',
+          title: 'Potential missed-value finding',
+          summary: `AI tool ${log.aiJob.toolName} produced source-backed output that may need auditor follow-up.`,
+          citationsJson: citations as unknown as Prisma.InputJsonValue,
+          generatedAt: log.createdAt,
+        },
+        select: { id: true },
+      });
+
+      createdSignals.push({ id: created.id });
+      await this.audit.appendEvent({
+        organizationId: input.organizationId,
+        actorUserId: input.actorUserId,
+        action: 'matter_audit_signal.created',
+        entityType: 'MatterAuditSignal',
+        entityId: created.id,
+        metadata: {
+          signalType: 'auditor.missed_value',
+          citations,
+        },
+      });
+    }
+
+    return {
+      createdCount: createdSignals.length,
+      signalIds: createdSignals.map((signal) => signal.id),
+    };
+  }
+
+  async listSignals(input: {
+    organizationId: string;
+    reviewState?: MatterAuditSignalReviewState;
+    matterId?: string;
+    limit?: number;
+  }) {
+    return this.prisma.matterAuditSignal.findMany({
+      where: {
+        organizationId: input.organizationId,
+        ...(input.reviewState ? { reviewState: input.reviewState } : {}),
+        ...(input.matterId ? { matterId: input.matterId } : {}),
+      },
+      orderBy: [{ generatedAt: 'asc' }, { id: 'asc' }],
+      take: input.limit ?? 100,
+    });
+  }
+
+  async updateReviewState(input: {
+    organizationId: string;
+    actorUserId: string;
+    signalId: string;
+    reviewState: MatterAuditSignalReviewState;
+    reviewNotes?: string;
+  }) {
+    const existing = await this.prisma.matterAuditSignal.findFirstOrThrow({
+      where: {
+        id: input.signalId,
+        organizationId: input.organizationId,
+      },
+    });
+
+    const updated = await this.prisma.matterAuditSignal.update({
+      where: { id: existing.id },
+      data: {
+        reviewState: input.reviewState,
+        reviewNotes: input.reviewNotes,
+        reviewedByUserId: input.actorUserId,
+        reviewStateChangedAt: new Date(),
+      },
+    });
+
+    await this.audit.appendEvent({
+      organizationId: input.organizationId,
+      actorUserId: input.actorUserId,
+      action: 'matter_audit_signal.updated',
+      entityType: 'MatterAuditSignal',
+      entityId: updated.id,
+      metadata: {
+        previousReviewState: existing.reviewState,
+        reviewState: updated.reviewState,
+      },
+    });
+
+    return updated;
+  }
+
+  private extractCitations(sourceRefsJson: Prisma.JsonValue | null): string[] {
+    if (!Array.isArray(sourceRefsJson)) {
+      return [];
+    }
+
+    const citationSet = new Set<string>();
+
+    for (const entry of sourceRefsJson) {
+      if (!entry || typeof entry !== 'object') {
+        continue;
+      }
+
+      const chunkId = (entry as Record<string, unknown>).chunkId;
+      if (typeof chunkId === 'string' && chunkId.trim().length > 0) {
+        citationSet.add(chunkId.trim());
+      }
+    }
+
+    return Array.from(citationSet).sort((a, b) => a.localeCompare(b));
+  }
+}

--- a/apps/api/test/matter-audit-signal.service.spec.ts
+++ b/apps/api/test/matter-audit-signal.service.spec.ts
@@ -1,0 +1,88 @@
+import { MatterAuditSignalReviewState } from '@prisma/client';
+import { MatterAuditSignalService } from '../src/audit/matter-audit-signal.service';
+
+describe('MatterAuditSignalService', () => {
+  it('generates missed-value signals with stable, sorted citations', async () => {
+    const prisma = {
+      aiExecutionLog: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'log-1',
+            aiJobId: 'job-1',
+            createdAt: new Date('2026-02-10T10:00:00.000Z'),
+            sourceRefsJson: [{ chunkId: 'chunk-b' }, { chunkId: 'chunk-a' }, { chunkId: 'chunk-a' }],
+            aiJob: { id: 'job-1', matterId: 'matter-1', toolName: 'timeline.extract' },
+          },
+        ]),
+      },
+      matterAuditSignal: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'signal-1' }),
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new MatterAuditSignalService(prisma, audit);
+
+    const result = await service.generateMissedValueSignals({ organizationId: 'org-1', actorUserId: 'user-1' });
+
+    expect(result).toEqual({ createdCount: 1, signalIds: ['signal-1'] });
+    expect(prisma.matterAuditSignal.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ citationsJson: ['chunk-a', 'chunk-b'] }),
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'matter_audit_signal.created', entityId: 'signal-1' }),
+    );
+  });
+
+  it('lists signals in deterministic order for queue use', async () => {
+    const prisma = {
+      matterAuditSignal: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    } as any;
+
+    const service = new MatterAuditSignalService(prisma, { appendEvent: jest.fn() } as any);
+
+    await service.listSignals({ organizationId: 'org-1', reviewState: MatterAuditSignalReviewState.GENERATED });
+
+    expect(prisma.matterAuditSignal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ generatedAt: 'asc' }, { id: 'asc' }],
+      }),
+    );
+  });
+
+  it('updates review state and emits an audit event', async () => {
+    const prisma = {
+      matterAuditSignal: {
+        findFirstOrThrow: jest.fn().mockResolvedValue({ id: 'signal-1', reviewState: MatterAuditSignalReviewState.GENERATED }),
+        update: jest.fn().mockResolvedValue({ id: 'signal-1', reviewState: MatterAuditSignalReviewState.IN_REVIEW }),
+      },
+    } as any;
+
+    const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
+    const service = new MatterAuditSignalService(prisma, audit);
+
+    const updated = await service.updateReviewState({
+      organizationId: 'org-1',
+      actorUserId: 'user-1',
+      signalId: 'signal-1',
+      reviewState: MatterAuditSignalReviewState.IN_REVIEW,
+      reviewNotes: 'Needs attorney validation.',
+    });
+
+    expect(updated.reviewState).toBe(MatterAuditSignalReviewState.IN_REVIEW);
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'matter_audit_signal.updated',
+        metadata: expect.objectContaining({
+          previousReviewState: MatterAuditSignalReviewState.GENERATED,
+          reviewState: MatterAuditSignalReviewState.IN_REVIEW,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Linear Issue
- KAR-108

## Requirement ID
- REQ-EVE2-008

## Summary
- Adds matter audit signal detection model, service, and API endpoints for queue processing.
- Adds review-state update DTO/service path and deterministic signal ordering.
- Adds migration and API tests for generation/list/review transitions.

## Validation
- pnpm --filter api lint
- pnpm --filter api test -- matter-audit-signal
- pnpm --filter api test
- pnpm --filter web test test/auditor-page.spec.tsx
