### PR TITLE
[KAR-103] Implement intake queue and staged lead routes

### DIFF
--- a/apps/web/app/intake/[leadId]/conflict/page.tsx
+++ b/apps/web/app/intake/[leadId]/conflict/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import { AppShell } from '../../../../components/app-shell';
+import { PageHeader } from '../../../../components/page-header';
+import { StageNav } from '../../../../components/intake/stage-nav';
+import { resolveConflict, runConflictCheck } from '../../../../lib/intake/leads-api';
+
+export default function LeadConflictPage() {
+  const params = useParams<{ leadId: string }>();
+  const leadId = params.leadId;
+  const [queryText, setQueryText] = useState('Client name + opposing party + property address');
+  const [resolutionNotes, setResolutionNotes] = useState('No direct conflicts identified.');
+  const [status, setStatus] = useState('');
+
+  async function onRunCheck() {
+    const result = await runConflictCheck(leadId, queryText);
+    setStatus(`Conflict check ${result.id} logged at ${new Date().toLocaleString()}.`);
+  }
+
+  async function onResolve(resolved: boolean) {
+    const result = await resolveConflict(leadId, resolved, resolutionNotes);
+    setStatus(`Conflict resolution recorded (${resolved ? 'resolved' : 'blocked'}) via ${result.id}.`);
+  }
+
+  return (
+    <AppShell>
+      <PageHeader title="Conflict Check" subtitle="Run and document conflict review before engagement routing." />
+      <StageNav leadId={leadId} active="conflict" />
+      <div className="card inline-stack">
+        <div>
+          <label htmlFor="conflict-query">Conflict Query</label>
+          <textarea id="conflict-query" className="textarea" value={queryText} onChange={(e) => setQueryText(e.target.value)} />
+        </div>
+        <button className="button" type="button" onClick={onRunCheck}>Run Conflict Check</button>
+        <div>
+          <label htmlFor="resolution-notes">Resolution Notes</label>
+          <textarea id="resolution-notes" className="textarea" value={resolutionNotes} onChange={(e) => setResolutionNotes(e.target.value)} />
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button className="button secondary" type="button" onClick={() => onResolve(true)}>Mark Resolved</button>
+          <button className="button danger" type="button" onClick={() => onResolve(false)}>Mark Blocked</button>
+        </div>
+        {status ? <p className="mono-meta">{status}</p> : null}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/app/intake/[leadId]/convert/page.tsx
+++ b/apps/web/app/intake/[leadId]/convert/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { AppShell } from '../../../../components/app-shell';
+import { PageHeader } from '../../../../components/page-header';
+import { StageNav } from '../../../../components/intake/stage-nav';
+import { Checklist, convertLead, getSetupChecklist } from '../../../../lib/intake/leads-api';
+
+export default function LeadConvertPage() {
+  const params = useParams<{ leadId: string }>();
+  const leadId = params.leadId;
+  const [checklist, setChecklist] = useState<Checklist | null>(null);
+  const [name, setName] = useState('Kitchen Remodel Defect - Intake Conversion');
+  const [matterNumber, setMatterNumber] = useState('M-2026-INT-001');
+  const [practiceArea, setPracticeArea] = useState('Construction Litigation');
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    getSetupChecklist(leadId).then(setChecklist).catch(() => undefined);
+  }, [leadId]);
+
+  async function onConvert() {
+    const matter = await convertLead(leadId, { name, matterNumber, practiceArea });
+    setStatus(`Matter ${matter.id} created. Conversion logged at ${new Date().toLocaleString()}.`);
+  }
+
+  return (
+    <AppShell>
+      <PageHeader title="Lead Conversion" subtitle="Confirm setup checklist and convert lead to matter." />
+      <StageNav leadId={leadId} active="convert" />
+      <div className="card inline-stack">
+        <table className="table">
+          <thead>
+            <tr><th>Checkpoint</th><th>Status</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>Intake Draft</td><td>{checklist?.intakeDraft ? 'Complete' : 'Pending'}</td></tr>
+            <tr><td>Conflict Resolved</td><td>{checklist?.conflictResolved ? 'Complete' : 'Pending'}</td></tr>
+            <tr><td>Engagement Signed</td><td>{checklist?.engagementSigned ? 'Complete' : 'Pending'}</td></tr>
+            <tr><td>Ready To Convert</td><td>{checklist?.readyToConvert ? 'Yes' : 'No'}</td></tr>
+          </tbody>
+        </table>
+        <div>
+          <label htmlFor="matter-name">Matter Name</label>
+          <input id="matter-name" className="input" value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="matter-number">Matter Number</label>
+          <input id="matter-number" className="input" value={matterNumber} onChange={(e) => setMatterNumber(e.target.value)} />
+        </div>
+        <div>
+          <label htmlFor="practice-area">Practice Area</label>
+          <input id="practice-area" className="input" value={practiceArea} onChange={(e) => setPracticeArea(e.target.value)} />
+        </div>
+        <button className="button" type="button" onClick={onConvert}>Convert Lead</button>
+        {status ? <p className="mono-meta">{status}</p> : null}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/app/intake/[leadId]/engagement/page.tsx
+++ b/apps/web/app/intake/[leadId]/engagement/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import { AppShell } from '../../../../components/app-shell';
+import { PageHeader } from '../../../../components/page-header';
+import { StageNav } from '../../../../components/intake/stage-nav';
+import { generateEngagement, sendEngagement } from '../../../../lib/intake/leads-api';
+
+export default function LeadEngagementPage() {
+  const params = useParams<{ leadId: string }>();
+  const leadId = params.leadId;
+  const [templateId, setTemplateId] = useState('engagement-template-standard');
+  const [envelopeId, setEnvelopeId] = useState('');
+  const [status, setStatus] = useState('');
+
+  async function onGenerate() {
+    const envelope = await generateEngagement(leadId, templateId);
+    setEnvelopeId(envelope.id);
+    setStatus(`Engagement envelope ${envelope.id} generated.`);
+  }
+
+  async function onSend() {
+    if (!envelopeId) return;
+    const envelope = await sendEngagement(leadId, envelopeId);
+    setStatus(`Engagement envelope ${envelope.id} sent at ${new Date().toLocaleString()}.`);
+  }
+
+  return (
+    <AppShell>
+      <PageHeader title="Engagement Routing" subtitle="Generate and send the engagement packet after conflict resolution." />
+      <StageNav leadId={leadId} active="engagement" />
+      <div className="card inline-stack">
+        <div>
+          <label htmlFor="template-id">Template ID</label>
+          <input id="template-id" className="input" value={templateId} onChange={(e) => setTemplateId(e.target.value)} />
+        </div>
+        <button className="button" type="button" onClick={onGenerate}>Generate Envelope</button>
+        <div>
+          <label htmlFor="envelope-id">Envelope ID</label>
+          <input id="envelope-id" className="input" value={envelopeId} onChange={(e) => setEnvelopeId(e.target.value)} />
+        </div>
+        <button className="button secondary" type="button" onClick={onSend} disabled={!envelopeId}>Send Envelope</button>
+        {status ? <p className="mono-meta">{status}</p> : null}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/app/intake/[leadId]/intake/page.tsx
+++ b/apps/web/app/intake/[leadId]/intake/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import { AppShell } from '../../../../components/app-shell';
+import { PageHeader } from '../../../../components/page-header';
+import { StageNav } from '../../../../components/intake/stage-nav';
+import { createIntakeDraft } from '../../../../lib/intake/leads-api';
+import { defaultIntakeWizardForm } from '../../../../lib/intake/intake-wizard-adapter';
+
+export default function LeadIntakeDraftPage() {
+  const params = useParams<{ leadId: string }>();
+  const leadId = params.leadId;
+  const [form, setForm] = useState(defaultIntakeWizardForm);
+  const [status, setStatus] = useState('');
+
+  async function submitDraft() {
+    const result = await createIntakeDraft(leadId, form);
+    setStatus(`Intake draft ${result.id} recorded at ${new Date().toLocaleString()}.`);
+  }
+
+  return (
+    <AppShell>
+      <PageHeader title="Lead Intake Draft" subtitle="Record intake payload. Stage transitions are managed by Leads API." />
+      <StageNav leadId={leadId} active="intake" />
+      <div className="card inline-stack">
+        <table className="table">
+          <thead>
+            <tr><th>Field</th><th>Value</th></tr>
+          </thead>
+          <tbody>
+            {Object.entries(form).map(([key, value]) => (
+              <tr key={key}>
+                <td className="mono-meta">{key}</td>
+                <td>
+                  <input className="input" value={value} onChange={(e) => setForm((prev) => ({ ...prev, [key]: e.target.value }))} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button className="button" type="button" onClick={submitDraft}>Submit Intake Draft</button>
+        {status ? <p className="mono-meta">{status}</p> : null}
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/web/app/intake/new/page.tsx
+++ b/apps/web/app/intake/new/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { AppShell } from '../../../components/app-shell';
+import { PageHeader } from '../../../components/page-header';
+import { createLead } from '../../../lib/intake/leads-api';
+
+export default function IntakeNewLeadPage() {
+  const router = useRouter();
+  const [source, setSource] = useState('Website Form');
+  const [notes, setNotes] = useState('Initial queue intake created.');
+  const [status, setStatus] = useState('');
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    const lead = await createLead({ source, notes });
+    setStatus(`Lead ${lead.id} created at ${new Date(lead.createdAt).toLocaleString()}.`);
+    router.push(`/intake/${lead.id}/intake`);
+  }
+
+  return (
+    <AppShell>
+      <PageHeader title="Create Intake Lead" subtitle="Register lead metadata before staged routing." />
+      <form className="card inline-stack" onSubmit={onSubmit}>
+        <div>
+          <label htmlFor="lead-source">Lead Source</label>
+          <input id="lead-source" className="input" value={source} onChange={(e) => setSource(e.target.value)} required />
+        </div>
+        <div>
+          <label htmlFor="lead-notes">Processing Notes</label>
+          <textarea id="lead-notes" className="textarea" value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </div>
+        <button className="button" type="submit">Create Lead and Open Intake</button>
+        {status ? <p className="mono-meta">{status}</p> : null}
+      </form>
+    </AppShell>
+  );
+}

--- a/apps/web/app/intake/page.tsx
+++ b/apps/web/app/intake/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { AppShell } from '../../components/app-shell';
+import { PageHeader } from '../../components/page-header';
+import { Lead, listLeads } from '../../lib/intake/leads-api';
+
+export default function IntakeQueuePage() {
+  const [rows, setRows] = useState<Lead[]>([]);
+
+  useEffect(() => {
+    listLeads().then(setRows).catch(() => undefined);
+  }, []);
+
+  return (
+    <AppShell>
+      <PageHeader
+        title="Intake Queue"
+        subtitle="Lead staging queue. Process records in order and complete setup checkpoints."
+        right={<Link className="button" href="/intake/new">New Lead</Link>}
+      />
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Lead ID</th>
+            <th>Source</th>
+            <th>Stage</th>
+            <th>Updated</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((lead) => (
+            <tr key={lead.id}>
+              <td className="mono-meta">{lead.id}</td>
+              <td>{lead.source}</td>
+              <td><span className="badge status-in-review">{lead.stage}</span></td>
+              <td className="mono-meta">{new Date(lead.updatedAt).toLocaleString()}</td>
+              <td>
+                <Link className="button ghost" href={`/intake/${lead.id}/intake`}>Open Staged Route</Link>
+              </td>
+            </tr>
+          ))}
+          {!rows.length ? (
+            <tr>
+              <td colSpan={5} className="mono-meta">No leads in queue.</td>
+            </tr>
+          ) : null}
+        </tbody>
+      </table>
+    </AppShell>
+  );
+}

--- a/apps/web/components/intake/stage-nav.tsx
+++ b/apps/web/components/intake/stage-nav.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+const stages = [
+  { key: 'intake', label: 'Intake Draft' },
+  { key: 'conflict', label: 'Conflict Check' },
+  { key: 'engagement', label: 'Engagement' },
+  { key: 'convert', label: 'Convert' },
+] as const;
+
+export function StageNav({ leadId, active }: { leadId: string; active: (typeof stages)[number]['key'] }) {
+  return (
+    <table className="table" style={{ marginBottom: 16 }}>
+      <thead>
+        <tr>
+          <th>Stage</th>
+          <th>Route</th>
+        </tr>
+      </thead>
+      <tbody>
+        {stages.map((stage) => (
+          <tr key={stage.key}>
+            <td>
+              <span className={`badge ${stage.key === active ? 'status-in-review' : 'status-proposed'}`}>{stage.label}</span>
+            </td>
+            <td>
+              <Link href={`/intake/${leadId}/${stage.key}`} className="button ghost" style={{ minHeight: 28 }}>
+                Open {stage.label}
+              </Link>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/lib/intake/intake-wizard-adapter.ts
+++ b/apps/web/lib/intake/intake-wizard-adapter.ts
@@ -1,0 +1,76 @@
+export type IntakeWizardFormState = {
+  propertyAddress: string;
+  propertyCity: string;
+  propertyState: string;
+  parcelNumber: string;
+  contractDate: string;
+  contractPrice: string;
+  defectCategory: string;
+  defectSeverity: string;
+  defectDescription: string;
+  damageCategory: string;
+  repairEstimate: string;
+  lienClaimantName: string;
+  lienAmount: string;
+  lienStatus: string;
+  claimNumber: string;
+  policyNumber: string;
+  insurerName: string;
+  adjusterName: string;
+  expertName: string;
+  expertScope: string;
+  milestoneName: string;
+};
+
+export const defaultIntakeWizardForm: IntakeWizardFormState = {
+  propertyAddress: '1234 Orchard Lane',
+  propertyCity: 'Pasadena',
+  propertyState: 'CA',
+  parcelNumber: 'APN-1234-99',
+  contractDate: '2025-10-01',
+  contractPrice: '125000',
+  defectCategory: 'Water Intrusion',
+  defectSeverity: 'High',
+  defectDescription: 'Leak at kitchen window framing and drywall.',
+  damageCategory: 'Repair Estimate',
+  repairEstimate: '28500',
+  lienClaimantName: 'Sunset Carpentry LLC',
+  lienAmount: '14250',
+  lienStatus: 'RECORDED',
+  claimNumber: 'CLM-77821',
+  policyNumber: 'HO-445-992',
+  insurerName: 'Blue Harbor Insurance',
+  adjusterName: 'Jordan Adjuster',
+  expertName: 'Dr. Maya Expert',
+  expertScope: 'Forensic causation and repair-cost reasonableness analysis.',
+  milestoneName: 'Initial inspection complete',
+};
+
+export function buildIntakeDraftData(form: IntakeWizardFormState) {
+  return {
+    property: {
+      addressLine1: form.propertyAddress,
+      city: form.propertyCity,
+      state: form.propertyState,
+      parcelNumber: form.parcelNumber,
+    },
+    contract: {
+      contractDate: form.contractDate,
+      contractPrice: Number(form.contractPrice || 0),
+    },
+    defects: [{ category: form.defectCategory, severity: form.defectSeverity, description: form.defectDescription }],
+    damages: [{ category: form.damageCategory, repairEstimate: Number(form.repairEstimate || 0) }],
+    liens: [{ claimantName: form.lienClaimantName, amount: Number(form.lienAmount || 0), status: form.lienStatus }],
+    insuranceClaims: [
+      {
+        claimNumber: form.claimNumber,
+        policyNumber: form.policyNumber,
+        insurerName: form.insurerName,
+        adjusterName: form.adjusterName,
+        status: 'OPEN',
+      },
+    ],
+    expertEngagements: [{ expertName: form.expertName, scope: form.expertScope, status: 'ENGAGED' }],
+    milestones: form.milestoneName ? [{ name: form.milestoneName, status: 'OPEN' }] : [],
+  };
+}

--- a/apps/web/lib/intake/leads-api.ts
+++ b/apps/web/lib/intake/leads-api.ts
@@ -1,0 +1,83 @@
+import { apiFetch } from '../api';
+import { buildIntakeDraftData, IntakeWizardFormState } from './intake-wizard-adapter';
+
+export type Lead = {
+  id: string;
+  source: string;
+  stage: string;
+  notes?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type Checklist = {
+  leadId: string;
+  intakeDraft: boolean;
+  conflictResolved: boolean;
+  engagementSigned: boolean;
+  readyToConvert: boolean;
+};
+
+export function listLeads() {
+  return apiFetch<Lead[]>('/leads');
+}
+
+export function getLead(leadId: string) {
+  return apiFetch<Lead>(`/leads/${leadId}`);
+}
+
+export function createLead(payload: { source: string; notes?: string }) {
+  return apiFetch<Lead>('/leads', { method: 'POST', body: JSON.stringify(payload) });
+}
+
+export function createIntakeDraft(leadId: string, form: IntakeWizardFormState) {
+  return apiFetch<{ id: string }>(`/leads/${leadId}/intake-drafts`, {
+    method: 'POST',
+    body: JSON.stringify({
+      intakeFormDefinitionId: 'construction-intake-v1',
+      dataJson: buildIntakeDraftData(form),
+    }),
+  });
+}
+
+export function runConflictCheck(leadId: string, queryText: string) {
+  return apiFetch<{ id: string }>(`/leads/${leadId}/conflict-check`, {
+    method: 'POST',
+    body: JSON.stringify({ queryText }),
+  });
+}
+
+export function resolveConflict(leadId: string, resolved: boolean, resolutionNotes: string) {
+  return apiFetch<{ id: string }>(`/leads/${leadId}/conflict-resolution`, {
+    method: 'POST',
+    body: JSON.stringify({ resolved, resolutionNotes }),
+  });
+}
+
+export function generateEngagement(leadId: string, engagementLetterTemplateId: string) {
+  return apiFetch<{ id: string }>(`/leads/${leadId}/engagement/generate`, {
+    method: 'POST',
+    body: JSON.stringify({ engagementLetterTemplateId, provider: 'INTERNAL' }),
+  });
+}
+
+export function sendEngagement(leadId: string, envelopeId: string) {
+  return apiFetch<{ id: string }>(`/leads/${leadId}/engagement/send`, {
+    method: 'POST',
+    body: JSON.stringify({ envelopeId }),
+  });
+}
+
+export function convertLead(
+  leadId: string,
+  payload: { name: string; matterNumber: string; practiceArea: string; jurisdiction?: string; venue?: string },
+) {
+  return apiFetch<{ id: string }>(`/leads/${leadId}/convert`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export function getSetupChecklist(leadId: string) {
+  return apiFetch<Checklist>(`/leads/${leadId}/setup-checklist`);
+}

--- a/apps/web/test/intake-pages.spec.tsx
+++ b/apps/web/test/intake-pages.spec.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as nextNavigation from 'next/navigation';
+import IntakeQueuePage from '../app/intake/page';
+import IntakeNewLeadPage from '../app/intake/new/page';
+import LeadConflictPage from '../app/intake/[leadId]/conflict/page';
+
+function jsonResponse<T>(payload: T, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}
+
+describe('Intake routes', () => {
+  beforeEach(() => {
+    window.localStorage.setItem('session_token', 'test-session-token');
+  });
+
+  afterEach(() => {
+    window.localStorage.removeItem('session_token');
+    vi.restoreAllMocks();
+  });
+
+  it('renders intake queue rows from leads API', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse([
+        {
+          id: 'lead-1',
+          source: 'Website Form',
+          stage: 'NEW',
+          notes: null,
+          createdAt: '2026-02-20T01:00:00.000Z',
+          updatedAt: '2026-02-20T01:00:00.000Z',
+        },
+      ]),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<IntakeQueuePage />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/leads',
+        expect.objectContaining({ credentials: 'include' }),
+      );
+    });
+
+    expect(await screen.findByText('Website Form')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open Staged Route' })).toHaveAttribute('href', '/intake/lead-1/intake');
+  });
+
+  it('creates lead then redirects from /intake/new', async () => {
+    const push = vi.fn();
+    vi.spyOn(nextNavigation, 'useRouter').mockReturnValue({
+      push,
+      replace: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+    } as unknown as ReturnType<typeof nextNavigation.useRouter>);
+
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({
+        id: 'lead-9',
+        source: 'Website Form',
+        stage: 'NEW',
+        notes: null,
+        createdAt: '2026-02-20T01:00:00.000Z',
+        updatedAt: '2026-02-20T01:00:00.000Z',
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<IntakeNewLeadPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Lead and Open Intake' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:4000/leads',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    expect(push).toHaveBeenCalledWith('/intake/lead-9/intake');
+  });
+
+  it('runs and resolves conflict on staged conflict route', async () => {
+    vi.spyOn(nextNavigation, 'useParams').mockReturnValue({ leadId: 'lead-5' });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ id: 'cc-1' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 'cc-1' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<LeadConflictPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Conflict Check' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Resolved' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        'http://localhost:4000/leads/lead-5/conflict-check',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        'http://localhost:4000/leads/lead-5/conflict-resolution',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Linear Issue
- KAR-103

## Requirement ID
- REQ-EVE2-001

## Summary
- Adds `/intake` queue and staged lead routes (`/new`, `/[leadId]/intake`, `/conflict`, `/engagement`, `/convert`).
- Adds shared stage navigation and intake API adapters for queue + stage transitions.
- Adds route-level tests covering queue listing and staged flow rendering.

## UI Interaction Checklist
- [x] Keyboard navigation verified for queue table rows, stage links, and form controls.
- [x] Focus-visible styles are preserved via existing LIC button/link/input primitives.
- [x] No console errors observed during route navigation and staged flow interactions.

## Screenshot Evidence
- Intake queue view and staged route transitions reviewed locally while running `pnpm dev`.

## Validation
- pnpm --filter web test test/intake-pages.spec.tsx
- pnpm --filter web test
- pnpm --filter api lint
- pnpm --filter api test
