### PR TITLE
[KAR-117] Add unlisted implemented routes to primary navigation model

### DIFF
--- a/apps/web/app/intake/page.tsx
+++ b/apps/web/app/intake/page.tsx
@@ -38,7 +38,20 @@ export default function IntakeQueuePage() {
               <td><span className="badge status-in-review">{lead.stage}</span></td>
               <td className="mono-meta">{new Date(lead.updatedAt).toLocaleString()}</td>
               <td>
-                <Link className="button ghost" href={`/intake/${lead.id}/intake`}>Open Staged Route</Link>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+                  <Link className="button ghost" href={`/intake/${lead.id}/intake`}>
+                    Intake
+                  </Link>
+                  <Link className="button ghost" href={`/intake/${lead.id}/conflict`}>
+                    Conflict
+                  </Link>
+                  <Link className="button ghost" href={`/intake/${lead.id}/engagement`}>
+                    Engagement
+                  </Link>
+                  <Link className="button ghost" href={`/intake/${lead.id}/convert`}>
+                    Convert
+                  </Link>
+                </div>
               </td>
             </tr>
           ))}

--- a/apps/web/components/app-shell.tsx
+++ b/apps/web/components/app-shell.tsx
@@ -7,6 +7,9 @@ import { useEffect, useState, type ReactNode } from 'react';
 
 const LINKS = [
   { href: '/dashboard', label: 'Dashboard', shortCode: 'DB' },
+  { href: '/intake', label: 'Intake Queue', shortCode: 'IQ' },
+  { href: '/analyst', label: 'Analyst Dashboard', shortCode: 'AN' },
+  { href: '/auditor', label: 'Auditor Queue', shortCode: 'AQ' },
   { href: '/admin', label: 'Admin', shortCode: 'AD' },
   { href: '/contacts', label: 'Contacts', shortCode: 'CT' },
   { href: '/matters', label: 'Matters', shortCode: 'MT' },
@@ -20,6 +23,9 @@ const LINKS = [
   { href: '/portal', label: 'Client Portal', shortCode: 'PT' },
   { href: '/data-dictionary', label: 'Data Dictionary', shortCode: 'DD' },
 ];
+
+// `/shared-doc/[token]` remains intentionally out of primary navigation.
+// It is an access-token scoped context route entered from explicit share links.
 
 type ShellViewportMode = 'desktop' | 'compact' | 'tablet' | 'unsupported';
 

--- a/apps/web/test/app-shell.spec.tsx
+++ b/apps/web/test/app-shell.spec.tsx
@@ -21,9 +21,12 @@ describe('AppShell', () => {
     expect(await screen.findByRole('button', { name: 'Menu' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute('href', '#lic-main-content');
 
-    const activeLink = screen.getByRole('link', { name: /Dashboard/i });
+    const activeLink = screen.getByRole('link', { name: /^Dashboard$/i });
     expect(activeLink).toHaveAttribute('aria-current', 'page');
 
+    expect(screen.getByRole('link', { name: /Intake Queue/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Analyst Dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Auditor Queue/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Matters/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Sign Out/i })).toBeInTheDocument();
     const mainPanelContent = document.querySelector('.main-panel-content');

--- a/apps/web/test/intake-pages.spec.tsx
+++ b/apps/web/test/intake-pages.spec.tsx
@@ -50,7 +50,10 @@ describe('Intake routes', () => {
     });
 
     expect(await screen.findByText('Website Form')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Open Staged Route' })).toHaveAttribute('href', '/intake/lead-1/intake');
+    expect(screen.getByRole('link', { name: 'Intake' })).toHaveAttribute('href', '/intake/lead-1/intake');
+    expect(screen.getByRole('link', { name: 'Conflict' })).toHaveAttribute('href', '/intake/lead-1/conflict');
+    expect(screen.getByRole('link', { name: 'Engagement' })).toHaveAttribute('href', '/intake/lead-1/engagement');
+    expect(screen.getByRole('link', { name: 'Convert' })).toHaveAttribute('href', '/intake/lead-1/convert');
   });
 
   it('creates lead then redirects from /intake/new', async () => {


### PR DESCRIPTION
### Motivation
- Surface already-implemented but previously unlisted routes so operators can discover them from the primary shell navigation.
- Provide explicit, structured reachability for the intake flow subroutes so queue rows can open each intake checkpoint directly.
- Clarify handling of the tokenized `/shared-doc/[token]` route as a context-only entry point rather than a primary nav item.

### Description
- Added `/intake`, `/analyst`, and `/auditor` entries to the `AppShell` `LINKS` array so they appear in primary navigation. 
- Documented that `/shared-doc/[token]` is intentionally omitted from primary navigation and is a token-scoped context route. 
- Expanded the intake queue UI to expose direct links to intake subroutes: `/intake/[leadId]/intake`, `/intake/[leadId]/conflict`, `/intake/[leadId]/engagement`, and `/intake/[leadId]/convert`.
- Updated tests to assert the new navigation entries and the intake-row subroute links (`apps/web/test/app-shell.spec.tsx` and `apps/web/test/intake-pages.spec.tsx`).

### Testing
- Ran unit/test suite with `pnpm --filter web test`, and all web tests passed (`69` tests passed).
- Attempted production build with `pnpm --filter web build`, which failed in this environment due to external Google Fonts fetch errors from `next/font` (IBM Plex families), a network/font-fetch issue unrelated to the navigation or route changes.
- No changes were made to authentication or role rules and existing route behavior is preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1ca4119b08325b0cbb3c655613455)