### PR TITLE
[KAR-111] Add scheduled audit scans with idempotent notification dispatch

### DIFF
--- a/apps/api/src/communications/audit-scan-scheduler.service.ts
+++ b/apps/api/src/communications/audit-scan-scheduler.service.ts
@@ -1,0 +1,306 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { PrismaService } from '../prisma/prisma.service';
+import { QueueService } from '../queue/queue.service';
+import { MatterAuditSignalService } from '../audit/matter-audit-signal.service';
+import { AuditService } from '../audit/audit.service';
+import { MessageDispatchService } from './providers/message-dispatch.service';
+import { MembershipStatus } from '@prisma/client';
+
+const AUDIT_SCAN_QUEUE = 'audit-scan';
+const AUDIT_SCAN_JOB_NAME = 'scheduled-missed-value-scan';
+const AUDIT_SCAN_REPEAT_JOB_ID = 'audit-scan-repeat';
+
+type ScanDispatchSummary = {
+  sent: number;
+  skipped: number;
+  failures: number;
+};
+
+@Injectable()
+export class AuditScanSchedulerService implements OnModuleInit {
+  private readonly logger = new Logger(AuditScanSchedulerService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly queue: QueueService,
+    private readonly matterAuditSignals: MatterAuditSignalService,
+    private readonly audit: AuditService,
+    private readonly messageDispatch: MessageDispatchService,
+  ) {}
+
+  onModuleInit() {
+    if (!this.isSchedulerEnabled()) {
+      this.logger.log(JSON.stringify({ event: 'audit.scan.scheduler.disabled' }));
+      return;
+    }
+
+    this.queue.createWorker(AUDIT_SCAN_QUEUE, async (job: Job) => {
+      await this.runScheduledScan(this.resolveRunId(job));
+    });
+
+    const cron = process.env.AUDIT_SCAN_CRON || '*/15 * * * *';
+    void this.queue.addJob(
+      AUDIT_SCAN_QUEUE,
+      AUDIT_SCAN_JOB_NAME,
+      { trigger: 'scheduled', configuredCron: cron },
+      {
+        jobId: AUDIT_SCAN_REPEAT_JOB_ID,
+        repeat: { pattern: cron },
+        removeOnComplete: 100,
+        removeOnFail: 1000,
+      },
+    );
+  }
+
+  async runScheduledScan(runId?: string) {
+    const startedAt = new Date();
+    const correlationId = runId || `audit-scan-${startedAt.toISOString()}`;
+    const scanLimit = this.readIntEnv('AUDIT_SCAN_SIGNAL_LIMIT', 100, 1, 1000);
+
+    this.logger.log(JSON.stringify({ event: 'audit.scan.run.started', correlationId, scanLimit }));
+
+    const organizations = await this.prisma.organization.findMany({
+      select: { id: true },
+    });
+
+    let organizationsProcessed = 0;
+    let organizationsFailed = 0;
+    let createdSignals = 0;
+    let notificationsSent = 0;
+    let notificationsSkipped = 0;
+    let notificationFailures = 0;
+
+    for (const organization of organizations) {
+      try {
+        const generated = await this.matterAuditSignals.generateMissedValueSignals({
+          organizationId: organization.id,
+          limit: scanLimit,
+        });
+
+        createdSignals += generated.createdCount;
+        organizationsProcessed += 1;
+
+        const dispatch = await this.dispatchNotifications({
+          organizationId: organization.id,
+          signalIds: generated.signalIds,
+          correlationId,
+        });
+
+        notificationsSent += dispatch.sent;
+        notificationsSkipped += dispatch.skipped;
+        notificationFailures += dispatch.failures;
+
+        await this.audit.appendEvent({
+          organizationId: organization.id,
+          action: 'audit.scan.organization.completed',
+          entityType: 'AuditScanRun',
+          entityId: correlationId,
+          metadata: {
+            createdSignals: generated.createdCount,
+            notificationDispatch: dispatch,
+          },
+        });
+      } catch (error) {
+        organizationsFailed += 1;
+        this.logger.error(
+          JSON.stringify({
+            event: 'audit.scan.organization.failed',
+            correlationId,
+            organizationId: organization.id,
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+            errorMessage: error instanceof Error ? error.message : String(error),
+          }),
+        );
+
+        await this.audit.appendEvent({
+          organizationId: organization.id,
+          action: 'audit.scan.organization.failed',
+          entityType: 'AuditScanRun',
+          entityId: correlationId,
+          metadata: {
+            errorName: error instanceof Error ? error.name : 'UnknownError',
+            errorMessage: error instanceof Error ? error.message : String(error),
+          },
+        });
+      }
+    }
+
+    this.logger.log(
+      JSON.stringify({
+        event: 'audit.scan.run.completed',
+        correlationId,
+        startedAt: startedAt.toISOString(),
+        finishedAt: new Date().toISOString(),
+        organizationsProcessed,
+        organizationsFailed,
+        createdSignals,
+        notificationsSent,
+        notificationsSkipped,
+        notificationFailures,
+      }),
+    );
+
+    return {
+      correlationId,
+      organizationsProcessed,
+      organizationsFailed,
+      createdSignals,
+      notificationsSent,
+      notificationsSkipped,
+      notificationFailures,
+    };
+  }
+
+  private async dispatchNotifications(input: {
+    organizationId: string;
+    signalIds: string[];
+    correlationId: string;
+  }): Promise<ScanDispatchSummary> {
+    if (input.signalIds.length === 0) {
+      return { sent: 0, skipped: 0, failures: 0 };
+    }
+
+    const signals = await this.prisma.matterAuditSignal.findMany({
+      where: {
+        organizationId: input.organizationId,
+        id: { in: input.signalIds },
+      },
+      include: {
+        matter: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+      orderBy: [{ generatedAt: 'asc' }, { id: 'asc' }],
+    });
+
+    if (signals.length === 0) {
+      return { sent: 0, skipped: 0, failures: 0 };
+    }
+
+    const recipients = await this.prisma.membership.findMany({
+      where: {
+        organizationId: input.organizationId,
+        status: MembershipStatus.ACTIVE,
+      },
+      select: {
+        userId: true,
+        user: {
+          select: {
+            id: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    let sent = 0;
+    let skipped = 0;
+    let failures = 0;
+
+    for (const recipient of recipients) {
+      const email = recipient.user.email?.trim();
+      if (!email) {
+        continue;
+      }
+
+      for (const signal of signals) {
+        const idempotencyKey = `audit-signal:${signal.id}:recipient:${recipient.user.id}`;
+        const alreadyDispatched = await this.prisma.notification.findFirst({
+          where: {
+            organizationId: input.organizationId,
+            userId: recipient.userId,
+            type: 'audit.signal.missed_value.email',
+            payloadJson: {
+              path: ['idempotencyKey'],
+              equals: idempotencyKey,
+            },
+          },
+          select: { id: true },
+        });
+
+        if (alreadyDispatched) {
+          skipped += 1;
+          continue;
+        }
+
+        const subject = `Audit scan: ${signal.title}`;
+        const body = [
+          'A scheduled audit scan generated a new missed-value signal.',
+          '',
+          `Matter: ${signal.matter.name || signal.matter.id}`,
+          `Summary: ${signal.summary}`,
+          `Signal ID: ${signal.id}`,
+          `Correlation ID: ${input.correlationId}`,
+        ].join('\n');
+
+        try {
+          const result = await this.messageDispatch.sendEmail({
+            to: email,
+            subject,
+            body,
+            idempotencyKey,
+          });
+
+          await this.prisma.notification.create({
+            data: {
+              organizationId: input.organizationId,
+              userId: recipient.userId,
+              type: 'audit.signal.missed_value.email',
+              payloadJson: {
+                signalId: signal.id,
+                matterId: signal.matterId,
+                idempotencyKey,
+                provider: result.provider,
+                deliveryStatus: result.status,
+                providerMessageId: result.externalMessageId || result.id,
+                correlationId: input.correlationId,
+              },
+            },
+          });
+
+          sent += 1;
+        } catch (error) {
+          failures += 1;
+          await this.prisma.notification.create({
+            data: {
+              organizationId: input.organizationId,
+              userId: recipient.userId,
+              type: 'audit.signal.missed_value.dispatch_failed',
+              payloadJson: {
+                signalId: signal.id,
+                matterId: signal.matterId,
+                idempotencyKey,
+                correlationId: input.correlationId,
+                errorName: error instanceof Error ? error.name : 'UnknownError',
+                errorMessage: error instanceof Error ? error.message : String(error),
+              },
+            },
+          });
+        }
+      }
+    }
+
+    return { sent, skipped, failures };
+  }
+
+  private isSchedulerEnabled() {
+    return String(process.env.AUDIT_SCAN_SCHEDULER_ENABLED || 'false').toLowerCase() === 'true';
+  }
+
+  private resolveRunId(job: Job) {
+    const timestamp = typeof job.timestamp === 'number' ? job.timestamp : Date.now();
+    return `audit-scan-${job.id || timestamp}`;
+  }
+
+  private readIntEnv(name: string, fallback: number, min: number, max: number) {
+    const raw = process.env[name];
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.max(min, Math.min(max, parsed));
+  }
+}

--- a/apps/api/src/communications/communications.module.ts
+++ b/apps/api/src/communications/communications.module.ts
@@ -6,11 +6,19 @@ import { StubMessageProvider } from './providers/stub-message.provider';
 import { ResendEmailProvider } from './providers/resend-email.provider';
 import { TwilioSmsProvider } from './providers/twilio-sms.provider';
 import { MessageDispatchService } from './providers/message-dispatch.service';
+import { AuditScanSchedulerService } from './audit-scan-scheduler.service';
 
 @Module({
   imports: [AuditModule],
   controllers: [CommunicationsController],
-  providers: [CommunicationsService, StubMessageProvider, ResendEmailProvider, TwilioSmsProvider, MessageDispatchService],
+  providers: [
+    CommunicationsService,
+    StubMessageProvider,
+    ResendEmailProvider,
+    TwilioSmsProvider,
+    MessageDispatchService,
+    AuditScanSchedulerService,
+  ],
   exports: [MessageDispatchService],
 })
 export class CommunicationsModule {}

--- a/apps/api/src/communications/providers/message-provider.interface.ts
+++ b/apps/api/src/communications/providers/message-provider.interface.ts
@@ -2,6 +2,7 @@ export type SendMessageInput = {
   to: string;
   subject?: string;
   body: string;
+  idempotencyKey?: string;
 };
 
 export type SendMessageResult = {

--- a/apps/api/src/communications/providers/resend-email.provider.ts
+++ b/apps/api/src/communications/providers/resend-email.provider.ts
@@ -36,6 +36,7 @@ export class ResendEmailProvider implements EmailProvider {
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
+        ...(input.idempotencyKey ? { 'Idempotency-Key': input.idempotencyKey } : {}),
       },
       body: JSON.stringify({
         from,

--- a/apps/api/src/communications/providers/stub-message.provider.ts
+++ b/apps/api/src/communications/providers/stub-message.provider.ts
@@ -13,6 +13,7 @@ export class StubMessageProvider implements EmailProvider, SmsProvider {
       provider: 'stub',
       status: 'sent',
       externalMessageId: id,
+      raw: input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : undefined,
     };
   }
 
@@ -24,6 +25,7 @@ export class StubMessageProvider implements EmailProvider, SmsProvider {
       provider: 'stub',
       status: 'sent',
       externalMessageId: id,
+      raw: input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : undefined,
     };
   }
 }

--- a/apps/api/src/communications/providers/twilio-sms.provider.ts
+++ b/apps/api/src/communications/providers/twilio-sms.provider.ts
@@ -38,6 +38,7 @@ export class TwilioSmsProvider implements SmsProvider {
         To: input.to,
         From: from,
         Body: input.body,
+        ...(input.idempotencyKey ? { IdempotencyKey: input.idempotencyKey } : {}),
       }),
     });
 

--- a/apps/api/test/audit-scan-scheduler.service.spec.ts
+++ b/apps/api/test/audit-scan-scheduler.service.spec.ts
@@ -1,0 +1,139 @@
+import { MembershipStatus } from '@prisma/client';
+import { AuditScanSchedulerService } from '../src/communications/audit-scan-scheduler.service';
+
+describe('AuditScanSchedulerService', () => {
+  it('dispatches notifications for created signals and records outcomes', async () => {
+    const prisma = {
+      organization: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'org-1' }]),
+      },
+      matterAuditSignal: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'signal-1',
+            matterId: 'matter-1',
+            title: 'Potential missed-value finding',
+            summary: 'Needs review',
+            generatedAt: new Date('2026-02-10T00:00:00.000Z'),
+            matter: { id: 'matter-1', name: 'Matter A' },
+          },
+        ]),
+      },
+      membership: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            userId: 'user-1',
+            user: { id: 'user-1', email: 'attorney@example.com' },
+          },
+        ]),
+      },
+      notification: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'notification-1' }),
+      },
+    } as any;
+
+    const queue = {
+      createWorker: jest.fn(),
+      addJob: jest.fn(),
+    } as any;
+
+    const matterAuditSignals = {
+      generateMissedValueSignals: jest.fn().mockResolvedValue({ createdCount: 1, signalIds: ['signal-1'] }),
+    } as any;
+
+    const audit = {
+      appendEvent: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const messageDispatch = {
+      sendEmail: jest.fn().mockResolvedValue({
+        id: 'provider-1',
+        provider: 'stub',
+        status: 'sent',
+      }),
+    } as any;
+
+    const service = new AuditScanSchedulerService(prisma, queue, matterAuditSignals, audit, messageDispatch);
+
+    const run = await service.runScheduledScan('run-1');
+
+    expect(run).toEqual(
+      expect.objectContaining({
+        correlationId: 'run-1',
+        organizationsProcessed: 1,
+        organizationsFailed: 0,
+        createdSignals: 1,
+        notificationsSent: 1,
+        notificationsSkipped: 0,
+      }),
+    );
+    expect(prisma.membership.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: MembershipStatus.ACTIVE,
+        }),
+      }),
+    );
+    expect(messageDispatch.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'attorney@example.com',
+        idempotencyKey: 'audit-signal:signal-1:recipient:user-1',
+      }),
+    );
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'audit.scan.organization.completed',
+      }),
+    );
+  });
+
+  it('skips duplicate dispatch when idempotency key has already been recorded', async () => {
+    const prisma = {
+      organization: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'org-1' }]),
+      },
+      matterAuditSignal: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'signal-1',
+            matterId: 'matter-1',
+            title: 'Potential missed-value finding',
+            summary: 'Needs review',
+            generatedAt: new Date('2026-02-10T00:00:00.000Z'),
+            matter: { id: 'matter-1', name: 'Matter A' },
+          },
+        ]),
+      },
+      membership: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            userId: 'user-1',
+            user: { id: 'user-1', email: 'attorney@example.com' },
+          },
+        ]),
+      },
+      notification: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'notification-1' }),
+        create: jest.fn().mockResolvedValue({ id: 'notification-2' }),
+      },
+    } as any;
+
+    const matterAuditSignals = {
+      generateMissedValueSignals: jest.fn().mockResolvedValue({ createdCount: 1, signalIds: ['signal-1'] }),
+    } as any;
+
+    const service = new AuditScanSchedulerService(
+      prisma,
+      { createWorker: jest.fn(), addJob: jest.fn() } as any,
+      matterAuditSignals,
+      { appendEvent: jest.fn().mockResolvedValue(undefined) } as any,
+      { sendEmail: jest.fn() } as any,
+    );
+
+    const run = await service.runScheduledScan('run-dup');
+
+    expect(run.notificationsSent).toBe(0);
+    expect(run.notificationsSkipped).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a recurring audit scan path that generates missed-value signals and informs org users automatically. 
- Ensure notification dispatch is idempotent to prevent duplicate outbound messages for the same signal+recipient. 
- Surface run outcomes and failures for ops visibility via audit events and structured logging. 

### Description
- Added `AuditScanSchedulerService` to run a recurring `audit-scan` queue job (opt-in via `AUDIT_SCAN_SCHEDULER_ENABLED`) that scans organizations, calls `generateMissedValueSignals`, and dispatches notifications. 
- Implemented idempotency guards by generating an `idempotencyKey` per `signalId:recipient` and checking/persisting it in the `Notification.payloadJson` before/after sending to skip duplicates. 
- Extended the message provider contract (`SendMessageInput`) with optional `idempotencyKey` and flowed it through to providers: `ResendEmailProvider` (sent as `Idempotency-Key` header), `TwilioSmsProvider` (included in form payload metadata), and `StubMessageProvider` (captured in `raw`), so providers can handle dedupe where supported. 
- Recorded per-organization run outcomes as audit events (`audit.scan.organization.completed` / `audit.scan.organization.failed`) and added structured logger events around run start/finish and per-organization failures. 
- Wired the scheduler into `CommunicationsModule` and added unit tests in `apps/api/test/audit-scan-scheduler.service.spec.ts` covering successful dispatch and duplicate-skip behavior. 

### Testing
- Ran `pnpm --filter api lint` and the lint step passed with zero warnings/errors. 
- Ran `pnpm --filter api test` and the full API Jest suite passed (all tests passing, locally executed). 
- Ran `pnpm --filter api build` and the TypeScript build succeeded (`tsc -p tsconfig.build.json`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1ca3370908325aeb1e540c4101daf)