### PR TITLE
[KAR-106] Add proactive proposal lifecycle triggers and audit gates

### DIFF
--- a/apps/api/src/ai/ai.service.ts
+++ b/apps/api/src/ai/ai.service.ts
@@ -605,6 +605,7 @@ export class AiService implements OnModuleInit {
       user: input.user,
       toStatus: 'IN_REVIEW',
       action: 'ai.agent.proposal.in_review',
+      reason: 'Artifact entered attorney review',
       metadata: {
         reviewedStatus: input.status,
       },
@@ -617,6 +618,7 @@ export class AiService implements OnModuleInit {
         user: input.user,
         toStatus: 'APPROVED',
         action: 'ai.agent.proposal.approved',
+        reason: 'Attorney approved draft artifact for execution',
         metadata: {
           reviewedStatus: input.status,
         },
@@ -630,6 +632,7 @@ export class AiService implements OnModuleInit {
         user: input.user,
         toStatus: 'RETURNED',
         action: 'ai.agent.proposal.returned',
+        reason: 'Attorney returned draft artifact for edits',
         metadata: {
           reviewedStatus: input.status,
         },
@@ -762,6 +765,7 @@ export class AiService implements OnModuleInit {
       user: input.user,
       toStatus: 'EXECUTED',
       action: 'ai.agent.proposal.executed',
+      reason: 'Approved deadline selections executed as downstream records',
       metadata: {
         selectionCount: normalizedSelections.length,
         createdCount: created.length,
@@ -852,6 +856,7 @@ export class AiService implements OnModuleInit {
     user: AuthenticatedUser;
     toStatus: AgentProposalLifecycleStatus;
     action: string;
+    reason: string;
     metadata?: Record<string, unknown>;
   }): Promise<AgentRun> {
     const current = input.orchestration.proposal.status;
@@ -861,6 +866,11 @@ export class AiService implements OnModuleInit {
 
     if (!this.canTransitionProposalStatus(current, input.toStatus)) {
       throw new BadRequestException(`Invalid proposal lifecycle transition: ${current} -> ${input.toStatus}`);
+    }
+
+    const reason = String(input.reason || '').trim();
+    if (!reason) {
+      throw new BadRequestException('Proposal lifecycle transition reason is required');
     }
 
     const now = new Date().toISOString();
@@ -886,7 +896,10 @@ export class AiService implements OnModuleInit {
           kind: stepKindByStatus[input.toStatus],
           at: now,
           actorUserId: input.user.id,
-          metadata: input.metadata,
+          metadata: {
+            reason,
+            ...(input.metadata ?? {}),
+          },
         },
       ],
     };
@@ -902,6 +915,8 @@ export class AiService implements OnModuleInit {
         runId: next.id,
         fromStatus: current,
         toStatus: input.toStatus,
+        transitionedAt: now,
+        reason,
         ...(input.metadata ?? {}),
       },
     });

--- a/apps/api/src/leads/leads.controller.ts
+++ b/apps/api/src/leads/leads.controller.ts
@@ -82,6 +82,6 @@ export class LeadsController {
   @Get(':id/setup-checklist')
   @RequirePermissions('leads:read')
   setupChecklist(@CurrentUser() user: AuthenticatedUser, @Param('id') id: string) {
-    return this.leadsService.setupChecklist(user.organizationId, id);
+    return this.leadsService.setupChecklist(user.organizationId, user.id, id);
   }
 }

--- a/apps/api/src/leads/leads.service.ts
+++ b/apps/api/src/leads/leads.service.ts
@@ -11,6 +11,25 @@ import { GenerateEngagementDto } from './dto/generate-engagement.dto';
 import { SendEngagementDto } from './dto/send-engagement.dto';
 import { ConvertLeadDto } from './dto/convert-lead.dto';
 
+type ProposalLifecycleStatus = 'PROPOSED' | 'IN_REVIEW' | 'APPROVED' | 'EXECUTED' | 'RETURNED';
+
+type ProactiveLeadProposal = {
+  id: string;
+  kind: 'CLIENT_ENGAGEMENT' | 'LIFECYCLE_NEXT_ACTION';
+  status: ProposalLifecycleStatus;
+  draftOnly: true;
+  autoSend: false;
+  confidence: number;
+  reason: string;
+  rationale: string;
+  lifecycle: {
+    currentStage: LeadStage;
+    recommendedStage: LeadStage;
+  };
+  citations: Array<{ entityType: string; entityId: string; field?: string }>;
+  createdAt: string;
+};
+
 @Injectable()
 export class LeadsService {
   constructor(
@@ -272,8 +291,8 @@ export class LeadsService {
     };
   }
 
-  async setupChecklist(organizationId: string, leadId: string) {
-    await this.requireLead(organizationId, leadId);
+  async setupChecklist(organizationId: string, actorUserId: string, leadId: string) {
+    const lead = await this.requireLead(organizationId, leadId);
 
     const [intakeCount, conflict, engagementEnvelope] = await Promise.all([
       this.prisma.intakeSubmission.count({ where: { organizationId, leadId } }),
@@ -292,7 +311,7 @@ export class LeadsService {
     const engagementSent = engagementEnvelope?.status === 'SENT' || engagementEnvelope?.status === 'SIGNED';
     const engagementSigned = engagementEnvelope?.status === 'SIGNED';
 
-    return {
+    const checklist = {
       leadId,
       intakeDraftCreated: intakeCount > 0,
       conflictChecked: Boolean(conflict),
@@ -302,6 +321,171 @@ export class LeadsService {
       engagementSigned,
       convertible: engagementSigned,
     };
+
+    const proactiveProposals = this.evaluateProactiveProposals({
+      lead,
+      checklist,
+      conflictCheckId: conflict?.id,
+      engagementEnvelopeId: engagementEnvelope?.id,
+    });
+
+    await this.audit.appendEvent({
+      organizationId,
+      actorUserId,
+      action: 'lead.proactive_proposals.evaluated',
+      entityType: 'lead',
+      entityId: leadId,
+      metadata: {
+        proposalCount: proactiveProposals.length,
+        proposals: proactiveProposals.map((proposal) => ({
+          id: proposal.id,
+          kind: proposal.kind,
+          status: proposal.status,
+          reason: proposal.reason,
+          confidence: proposal.confidence,
+          rationale: proposal.rationale,
+          citations: proposal.citations,
+          draftOnly: proposal.draftOnly,
+          autoSend: proposal.autoSend,
+          createdAt: proposal.createdAt,
+        })),
+      },
+    });
+
+    return {
+      ...checklist,
+      proactiveProposals,
+    };
+  }
+
+
+  private evaluateProactiveProposals(input: {
+    lead: Awaited<ReturnType<LeadsService['requireLead']>>;
+    checklist: {
+      leadId: string;
+      intakeDraftCreated: boolean;
+      conflictChecked: boolean;
+      conflictResolved: boolean;
+      engagementGenerated: boolean;
+      engagementSent: boolean;
+      engagementSigned: boolean;
+      convertible: boolean;
+    };
+    conflictCheckId?: string;
+    engagementEnvelopeId?: string;
+  }): ProactiveLeadProposal[] {
+    const proposals: ProactiveLeadProposal[] = [];
+    const now = new Date().toISOString();
+    const currentStageRank = this.stageRank(input.lead.stage);
+
+    const pushProposal = (proposal: Omit<ProactiveLeadProposal, 'status' | 'draftOnly' | 'autoSend' | 'createdAt'>) => {
+      proposals.push({
+        ...proposal,
+        status: 'PROPOSED',
+        draftOnly: true,
+        autoSend: false,
+        createdAt: now,
+      });
+    };
+
+    if (!input.checklist.intakeDraftCreated && currentStageRank <= this.stageRank(LeadStage.NEW)) {
+      pushProposal({
+        id: `lead-${input.lead.id}-proposal-intake`,
+        kind: 'LIFECYCLE_NEXT_ACTION',
+        confidence: 0.96,
+        reason: 'Intake draft is missing for early-stage lead triage',
+        rationale: 'Create an intake draft to move lead discovery from NEW to SCREENING.',
+        lifecycle: {
+          currentStage: input.lead.stage,
+          recommendedStage: LeadStage.SCREENING,
+        },
+        citations: [{ entityType: 'lead', entityId: input.lead.id, field: 'stage' }],
+      });
+    }
+
+    if (!input.checklist.conflictChecked && currentStageRank >= this.stageRank(LeadStage.SCREENING)) {
+      pushProposal({
+        id: `lead-${input.lead.id}-proposal-conflict-check`,
+        kind: 'LIFECYCLE_NEXT_ACTION',
+        confidence: 0.93,
+        reason: 'Conflict check has not been completed',
+        rationale: 'Run conflict checks before consultation and any external engagement workflow.',
+        lifecycle: {
+          currentStage: input.lead.stage,
+          recommendedStage: LeadStage.CONFLICT_CHECK,
+        },
+        citations: [{ entityType: 'lead', entityId: input.lead.id, field: 'stage' }],
+      });
+    }
+
+    if (!input.checklist.engagementGenerated && input.checklist.conflictResolved) {
+      pushProposal({
+        id: `lead-${input.lead.id}-proposal-engagement-generate`,
+        kind: 'CLIENT_ENGAGEMENT',
+        confidence: 0.91,
+        reason: 'Conflict is resolved but engagement draft is not prepared',
+        rationale: 'Generate a draft engagement letter for attorney review; do not auto-send.',
+        lifecycle: {
+          currentStage: input.lead.stage,
+          recommendedStage: LeadStage.CONSULTATION,
+        },
+        citations: [
+          { entityType: 'lead', entityId: input.lead.id, field: 'stage' },
+          ...(input.conflictCheckId ? [{ entityType: 'conflictCheckResult', entityId: input.conflictCheckId }] : []),
+        ],
+      });
+    }
+
+    if (input.checklist.engagementGenerated && !input.checklist.engagementSent && input.checklist.conflictResolved) {
+      pushProposal({
+        id: `lead-${input.lead.id}-proposal-engagement-review-send`,
+        kind: 'CLIENT_ENGAGEMENT',
+        confidence: 0.89,
+        reason: 'Engagement draft exists but has not progressed to delivery',
+        rationale: 'Route the engagement draft through attorney review and explicit approval before send.',
+        lifecycle: {
+          currentStage: input.lead.stage,
+          recommendedStage: LeadStage.CONSULTATION,
+        },
+        citations: [
+          { entityType: 'lead', entityId: input.lead.id, field: 'stage' },
+          ...(input.engagementEnvelopeId ? [{ entityType: 'eSignEnvelope', entityId: input.engagementEnvelopeId, field: 'status' }] : []),
+        ],
+      });
+    }
+
+    if (input.checklist.engagementSigned && input.lead.stage !== LeadStage.RETAINED) {
+      pushProposal({
+        id: `lead-${input.lead.id}-proposal-convert`,
+        kind: 'LIFECYCLE_NEXT_ACTION',
+        confidence: 0.97,
+        reason: 'Signed engagement qualifies lead for matter conversion',
+        rationale: 'Convert retained lead into a matter and advance lifecycle from consultation to retained.',
+        lifecycle: {
+          currentStage: input.lead.stage,
+          recommendedStage: LeadStage.RETAINED,
+        },
+        citations: [
+          { entityType: 'lead', entityId: input.lead.id, field: 'stage' },
+          ...(input.engagementEnvelopeId ? [{ entityType: 'eSignEnvelope', entityId: input.engagementEnvelopeId, field: 'status' }] : []),
+        ],
+      });
+    }
+
+    return proposals;
+  }
+
+  private stageRank(stage: LeadStage): number {
+    const ordered: LeadStage[] = [
+      LeadStage.NEW,
+      LeadStage.SCREENING,
+      LeadStage.CONFLICT_CHECK,
+      LeadStage.CONSULTATION,
+      LeadStage.RETAINED,
+      LeadStage.REJECTED,
+    ];
+    const index = ordered.indexOf(stage);
+    return index === -1 ? 0 : index;
   }
 
   private async requireLead(organizationId: string, leadId: string) {

--- a/apps/api/src/matters/matters.service.ts
+++ b/apps/api/src/matters/matters.service.ts
@@ -5,6 +5,21 @@ import { AuditService } from '../audit/audit.service';
 import { AccessService } from '../access/access.service';
 import { AuthenticatedUser } from '../common/types';
 
+type ProposalLifecycleStatus = 'PROPOSED' | 'IN_REVIEW' | 'APPROVED' | 'EXECUTED' | 'RETURNED';
+
+type MatterProactiveProposal = {
+  id: string;
+  kind: 'CLIENT_ENGAGEMENT' | 'LIFECYCLE_NEXT_ACTION';
+  status: ProposalLifecycleStatus;
+  draftOnly: true;
+  autoSend: false;
+  confidence: number;
+  reason: string;
+  rationale: string;
+  citations: Array<{ entityType: string; entityId: string; field?: string }>;
+  createdAt: string;
+};
+
 @Injectable()
 export class MattersService {
   private static readonly INTAKE_WIZARD_DRAFT_FORM_NAME = 'Matter Intake Wizard Draft';
@@ -1062,8 +1077,88 @@ export class MattersService {
         completionPercent: Number(((completedCount / totalCount) * 100).toFixed(1)),
         missingSections,
       },
+      proactiveProposals: this.evaluateMatterProactiveProposals(matter),
     };
   }
+
+
+  private evaluateMatterProactiveProposals(matter: {
+    id: string;
+    status: MatterStatus;
+    stage: { id: string } | null;
+    tasks: Array<{ id: string; status: string; dueAt: Date | null }>;
+    communicationThreads: Array<{ messages: Array<{ id: string; occurredAt: Date }> }>;
+    aiJobs: Array<{ artifacts: Array<{ id: string; reviewedStatus: string }> }>;
+  }): MatterProactiveProposal[] {
+    const proposals: MatterProactiveProposal[] = [];
+    const now = new Date();
+    const createdAt = now.toISOString();
+
+    const push = (proposal: Omit<MatterProactiveProposal, 'status' | 'draftOnly' | 'autoSend' | 'createdAt'>) => {
+      proposals.push({
+        ...proposal,
+        status: 'PROPOSED',
+        draftOnly: true,
+        autoSend: false,
+        createdAt,
+      });
+    };
+
+    if (matter.status === MatterStatus.OPEN && !matter.stage) {
+      push({
+        id: `matter-${matter.id}-proposal-assign-stage`,
+        kind: 'LIFECYCLE_NEXT_ACTION',
+        confidence: 0.88,
+        reason: 'Open matter has no lifecycle stage assigned',
+        rationale: 'Assigning a stage enables deterministic lifecycle next-actions and governance tracking.',
+        citations: [{ entityType: 'matter', entityId: matter.id, field: 'stageId' }],
+      });
+    }
+
+    const overdueTask = matter.tasks.find((task) => task.dueAt && task.status !== 'DONE' && task.dueAt < now);
+    if (overdueTask) {
+      push({
+        id: `matter-${matter.id}-proposal-overdue-task-followup`,
+        kind: 'LIFECYCLE_NEXT_ACTION',
+        confidence: 0.9,
+        reason: 'Matter has overdue tasks pending completion',
+        rationale: 'Review overdue tasks and queue a next-action to avoid lifecycle slippage.',
+        citations: [{ entityType: 'task', entityId: overdueTask.id, field: 'dueAt' }],
+      });
+    }
+
+    const latestMessageAt = matter.communicationThreads
+      .flatMap((thread) => thread.messages)
+      .sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime())[0]?.occurredAt;
+    const inactiveDays = latestMessageAt ? (now.getTime() - latestMessageAt.getTime()) / (1000 * 60 * 60 * 24) : Number.POSITIVE_INFINITY;
+    if (matter.status === MatterStatus.OPEN && inactiveDays >= 14) {
+      push({
+        id: `matter-${matter.id}-proposal-client-status-update`,
+        kind: 'CLIENT_ENGAGEMENT',
+        confidence: 0.86,
+        reason: 'No recent client communication detected for open matter',
+        rationale: 'Prepare a draft client status update for attorney review; outbound send remains manual.',
+        citations: [{ entityType: 'matter', entityId: matter.id, field: 'communicationThreads' }],
+      });
+    }
+
+    const reviewDraftArtifact = matter.aiJobs
+      .flatMap((job) => job.artifacts)
+      .find((artifact) => artifact.reviewedStatus === 'DRAFT');
+    if (reviewDraftArtifact) {
+      push({
+        id: `matter-${matter.id}-proposal-ai-draft-review`,
+        kind: 'LIFECYCLE_NEXT_ACTION',
+        confidence: 0.87,
+        reason: 'AI artifact is still in draft review state',
+        rationale: 'Advance artifact through PROPOSED→IN REVIEW→APPROVED gates before any execution action.',
+        citations: [{ entityType: 'aiArtifact', entityId: reviewDraftArtifact.id, field: 'reviewedStatus' }],
+      });
+    }
+
+    return proposals;
+  }
+
 
   async intakeWizard(input: {
     user: AuthenticatedUser;

--- a/apps/api/test/ai-deadline-confirmation.spec.ts
+++ b/apps/api/test/ai-deadline-confirmation.spec.ts
@@ -115,6 +115,10 @@ describe('AiService deadline confirmation governance', () => {
       expect.objectContaining({
         action: 'ai.agent.proposal.executed',
         entityType: 'agentProposal',
+        metadata: expect.objectContaining({
+          reason: 'Approved deadline selections executed as downstream records',
+          transitionedAt: expect.any(String),
+        }),
       }),
     );
   });
@@ -167,6 +171,7 @@ describe('AiService deadline confirmation governance', () => {
     expect(audit.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'ai.agent.proposal.approved',
+        metadata: expect.objectContaining({ reason: 'Attorney approved draft artifact for execution' }),
       }),
     );
     expect(prisma.aiArtifact.update).toHaveBeenCalled();

--- a/apps/api/test/leads.service.spec.ts
+++ b/apps/api/test/leads.service.spec.ts
@@ -94,6 +94,50 @@ describe('LeadsService', () => {
     );
   });
 
+
+
+  it('generates deterministic proactive proposals with rationale citations', async () => {
+    const { service, prisma, audit } = buildService();
+    prisma.lead.findFirst.mockResolvedValue({ id: 'lead-1', organizationId, stage: LeadStage.CONSULTATION });
+    prisma.intakeSubmission.count.mockResolvedValue(1);
+    prisma.conflictCheckResult.findFirst.mockResolvedValue({
+      id: 'check-1',
+      resultJson: { leadId: 'lead-1', resolved: true },
+    });
+    prisma.eSignEnvelope.findFirst.mockResolvedValue({ id: 'env-1', status: 'DRAFT' });
+
+    const checklist = await service.setupChecklist(organizationId, actorUserId, 'lead-1');
+
+    expect(checklist.proactiveProposals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'lead-lead-1-proposal-engagement-review-send',
+          kind: 'CLIENT_ENGAGEMENT',
+          status: 'PROPOSED',
+          draftOnly: true,
+          autoSend: false,
+          lifecycle: {
+            currentStage: LeadStage.CONSULTATION,
+            recommendedStage: LeadStage.CONSULTATION,
+          },
+          citations: expect.arrayContaining([
+            expect.objectContaining({ entityType: 'eSignEnvelope', entityId: 'env-1' }),
+          ]),
+        }),
+      ]),
+    );
+
+    expect(audit.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'lead.proactive_proposals.evaluated',
+        actorUserId,
+        entityType: 'lead',
+        entityId: 'lead-1',
+        metadata: expect.objectContaining({ proposalCount: checklist.proactiveProposals.length }),
+      }),
+    );
+  });
+
   it('enforces tenant isolation for getById', async () => {
     const { service, prisma } = buildService();
     prisma.lead.findFirst.mockResolvedValue(null);

--- a/apps/api/test/matters.spec.ts
+++ b/apps/api/test/matters.spec.ts
@@ -1075,6 +1075,70 @@ describe('MattersService', () => {
     expect(dashboard.domainSectionCompleteness.sections.expertEngagements).toBe(true);
   });
 
+
+
+  it('dashboard returns draft-only proactive proposals for lifecycle and engagement', async () => {
+    const prisma = {
+      matter: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'matter-9',
+          matterNumber: 'M-9',
+          name: 'Matter 9',
+          practiceArea: 'Litigation',
+          status: 'OPEN',
+          stage: null,
+          participants: [],
+          docketEntries: [],
+          tasks: [
+            {
+              id: 'task-overdue-1',
+              status: 'TODO',
+              dueAt: new Date('2025-01-01T00:00:00.000Z'),
+            },
+          ],
+          calendarEvents: [],
+          communicationThreads: [],
+          documents: [],
+          invoices: [],
+          aiJobs: [{ artifacts: [{ id: 'artifact-1', reviewedStatus: 'DRAFT' }] }],
+          propertyProfile: null,
+          contractProfile: null,
+          defectIssues: [],
+          damagesItems: [],
+          lienModels: [],
+          insuranceClaims: [],
+          expertEngagements: [],
+          projectMilestones: [],
+        }),
+      },
+    } as any;
+    const service = new MattersService(
+      prisma,
+      { appendEvent: jest.fn() } as any,
+      { assertMatterAccess: jest.fn().mockResolvedValue(undefined) } as any,
+    );
+
+    const dashboard = await service.dashboard(baseUser, 'matter-9');
+
+    expect(dashboard.proactiveProposals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'matter-matter-9-proposal-assign-stage',
+          kind: 'LIFECYCLE_NEXT_ACTION',
+          status: 'PROPOSED',
+          draftOnly: true,
+          autoSend: false,
+        }),
+        expect.objectContaining({
+          id: 'matter-matter-9-proposal-client-status-update',
+          kind: 'CLIENT_ENGAGEMENT',
+          draftOnly: true,
+          autoSend: false,
+        }),
+      ]),
+    );
+  });
+
   it('saves and resumes intake drafts', async () => {
     const audit = { appendEvent: jest.fn().mockResolvedValue(undefined) } as any;
     const prisma = {


### PR DESCRIPTION
## Linear Issue
- KAR-106

## Requirement ID
- REQ-RC-012

## Summary
- Adds proactive proposal lifecycle triggers and audit gate metadata.
- Extends leads/matters proposal evaluation and transition reason capture.
- Adds/updates API tests for lifecycle trigger behavior.

## Validation
- [x] pnpm --filter api lint
- [x] pnpm --filter api test
