### PR TITLE
[KAR-135] Tolerate fresh housekeeping artifacts in preflight

### DIFF
--- a/tools/ops/operator_preflight.mjs
+++ b/tools/ops/operator_preflight.mjs
@@ -17,6 +17,7 @@ const canonicalControlFiles = [
   'docs/WORKING_CONTRACT.md',
   'README.md',
 ];
+const housekeepingArtifactFiles = ['tools/backlog-sync/session.snapshot.json', 'docs/SESSION_HANDOFF.md'];
 const requiredTokenEnv = ['LINEAR_API_TOKEN', 'GITHUB_TOKEN', 'GITHUB_OWNER', 'GITHUB_REPO'];
 
 preloadEnvFiles(envFiles);
@@ -54,7 +55,12 @@ if (missingTokenEnv.length === 0) {
 }
 
 const failedChecks = checks.filter((check) => check.result === 'FAIL');
-const hasHardDirtyControlDrift = dirtyCanonicalFiles.length > 0;
+const onlyFreshHousekeepingArtifactsDirty =
+  dirtyCanonicalFiles.length === housekeepingArtifactFiles.length &&
+  dirtyNonCanonicalFiles.length === 0 &&
+  housekeepingArtifactFiles.every((file) => dirtyCanonicalFiles.includes(file));
+const hasFreshnessCheckFailure = failedChecks.some((check) => check.name === 'backlog:handoff:check');
+const hasHardDirtyControlDrift = dirtyCanonicalFiles.length > 0 && !(onlyFreshHousekeepingArtifactsDirty && !hasFreshnessCheckFailure);
 
 const summary = {
   startedAt,
@@ -67,6 +73,7 @@ const summary = {
   requiredEnvPresence: Object.fromEntries(requiredTokenEnv.map((name) => [name, Boolean(process.env[name])])),
   missingRequiredEnv: missingTokenEnv,
   checks,
+  housekeepingArtifactsOnly: onlyFreshHousekeepingArtifactsDirty,
   outcome: {
     pass: missingTokenEnv.length === 0 && !hasHardDirtyControlDrift && failedChecks.length === 0,
     reasons: [
@@ -186,6 +193,9 @@ function printSummary(result, pathToArtifact) {
   console.log(`- branch: ${result.branch}`);
   console.log(`- dirty files: ${result.dirtyFileCount}`);
   console.log(`- dirty canonical control files: ${result.dirtyCanonicalFiles.length}`);
+  if (result.housekeepingArtifactsOnly) {
+    console.log('- dirty canonical files are the fresh snapshot/handoff pair from housekeeping');
+  }
   console.log(`- missing required env: ${result.missingRequiredEnv.length ? result.missingRequiredEnv.join(', ') : '(none)'}`);
   for (const check of result.checks) {
     console.log(`- ${check.name}: ${check.result}`);


### PR DESCRIPTION
## Linear Issue
- Key: KAR-135
- URL: https://linear.app/karenap/issue/KAR-135/make-operator-preflight-tolerate-fresh-housekeeping-artifacts

## Requirement ID
- REQ-OPS-002

## Summary
- Make `pnpm ops:preflight` tolerate the exact fresh `session.snapshot.json` + `SESSION_HANDOFF.md` pair produced by `pnpm ops:housekeeping`.
- Keep all other dirty canonical files and failing verification checks as blocking.

## Acceptance Criteria Checklist
- [x] Acceptance criteria from Linear issue are implemented.
- [x] API/data/UI impact reviewed.
- [x] Security/privacy implications reviewed.
- [x] Verification evidence attached.

## Test Evidence
- Commands run:
  - `pnpm ops:preflight`
- Output summary:
  - Preflight passes when the only dirty files are the synchronized housekeeping artifacts and all verification checks pass.

## UI Interaction Checklist (Required for UI Changes)
- [x] Not applicable; no UI files were touched.
- [x] Keyboard navigation + focus-visible behavior verified as not applicable.
- [x] Feedback hierarchy verified as not applicable.
- [x] No console errors observed on touched routes. Not applicable; ops script change only.

## Screenshot Evidence (Required for UI Changes)
- Route(s): Not applicable.
- Before screenshot(s): Not applicable.
- After screenshot(s): Not applicable.

## Notes
- This closes the operational loop where `ops:housekeeping` immediately caused `ops:preflight` to fail on the same fresh artifacts it had just validated.
